### PR TITLE
docs: 让 README 顶部 badge 可点击跳转

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,11 +1,11 @@
 # Sentry Miniapp SDK — Mini Program Monitoring SDK
 
-![npm version](https://img.shields.io/npm/v/sentry-miniapp)
-![npm downloads/month](https://img.shields.io/npm/dm/sentry-miniapp)
-![github forks](https://img.shields.io/github/forks/lizhiyao/sentry-miniapp?style=social)
-![github stars](https://img.shields.io/github/stars/lizhiyao/sentry-miniapp?style=social)
+[![npm version](https://img.shields.io/npm/v/sentry-miniapp)](https://www.npmjs.com/package/sentry-miniapp)
+[![npm downloads/month](https://img.shields.io/npm/dm/sentry-miniapp)](https://www.npmjs.com/package/sentry-miniapp)
+[![github forks](https://img.shields.io/github/forks/lizhiyao/sentry-miniapp?style=social)](https://github.com/lizhiyao/sentry-miniapp/network/members)
+[![github stars](https://img.shields.io/github/stars/lizhiyao/sentry-miniapp?style=social)](https://github.com/lizhiyao/sentry-miniapp/stargazers)
 ![test coverage](https://img.shields.io/badge/test%20coverage-100%25-brightgreen.svg)
-![license](https://img.shields.io/github/license/lizhiyao/sentry-miniapp)
+[![license](https://img.shields.io/github/license/lizhiyao/sentry-miniapp)](./LICENSE)
 
 [简体中文](./README.md) | English
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Sentry Miniapp SDK — 小程序监控 SDK
 
-![npm version](https://img.shields.io/npm/v/sentry-miniapp)
-![npm download](https://img.shields.io/npm/dm/sentry-miniapp)
-![github forks](https://img.shields.io/github/forks/lizhiyao/sentry-miniapp?style=social)
-![github stars](https://img.shields.io/github/stars/lizhiyao/sentry-miniapp?style=social)
+[![npm version](https://img.shields.io/npm/v/sentry-miniapp)](https://www.npmjs.com/package/sentry-miniapp)
+[![npm download](https://img.shields.io/npm/dm/sentry-miniapp)](https://www.npmjs.com/package/sentry-miniapp)
+[![github forks](https://img.shields.io/github/forks/lizhiyao/sentry-miniapp?style=social)](https://github.com/lizhiyao/sentry-miniapp/network/members)
+[![github stars](https://img.shields.io/github/stars/lizhiyao/sentry-miniapp?style=social)](https://github.com/lizhiyao/sentry-miniapp/stargazers)
 ![test coverage](https://img.shields.io/badge/test%20coverage-100%25-brightgreen.svg)
-![license](https://img.shields.io/github/license/lizhiyao/sentry-miniapp)
+[![license](https://img.shields.io/github/license/lizhiyao/sentry-miniapp)](./LICENSE)
 
 简体中文 | [English](./README.en.md)
 


### PR DESCRIPTION
## Summary
之前 README 顶部的 npm / forks / stars / license badge 是纯图片（`![]()`），点击没有跳转。这个 PR 用 `[![]()](url)` 给它们包一层链接：

- **npm version / downloads** → npm 包页面 `https://www.npmjs.com/package/sentry-miniapp`
- **forks** → `…/network/members`
- **stars** → `…/stargazers`
- **license** → 仓库 LICENSE 文件

`test coverage` 是静态徽章，没有合适的跳转目标，保持原样。

中英文 README 同步修改。

## Test plan
- [ ] 本地 GitHub 渲染 README，点击 badge 验证跳转
- [ ] 中英文 README 都已修改

🤖 Generated with [Claude Code](https://claude.com/claude-code)