### PR TITLE
docs: 更新 README 顶部最新文章卡片

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -14,7 +14,7 @@ A **mini program monitoring SDK** built on `@sentry/core`, providing **error mon
 
 > **What are Mini Programs?** Mini programs (小程序) are lightweight apps that run inside super-apps like WeChat, Alipay, and ByteDance/Douyin. They form a massive ecosystem in China with **hundreds of millions of daily active users**, but have no direct equivalent in the Western tech stack. Think of them as a hybrid between PWAs and native apps, but hosted within a platform's sandbox.
 
-> **📰 Featured Article (Chinese)**: [《我把 Sentry 接进了 7 端小程序：从异常捕获、Breadcrumb 到 Source Map 定位》](https://juejin.cn/post/7621871037853843465) — multi-platform integration, Breadcrumb context, offline buffering, and Source Map workflow walked through end-to-end. If you find this project useful, please consider giving it a ⭐ Star.
+> **📰 Featured Article (Chinese)**: [《我给 Sentry 提了个 PR，后来 sentry-miniapp 进了官方文档》](https://juejin.cn/post/7636106283963760681) — How sentry-miniapp got listed in Sentry's official community-supported SDKs documentation. If you find this project useful, please consider giving it a ⭐ Star.
 
 <details>
 <summary><b>🆕 What's New: v1.3 → v1.8 (click to expand)</b></summary>

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 一个基于 `@sentry/core` 核心构建的**小程序监控 SDK**，提供**异常监控**、**性能监控**、离线缓存、分布式追踪等能力。支持微信、支付宝、字节跳动、百度、QQ、钉钉、快手等多端小程序及 Taro / uni-app 等跨端框架。
 
-> **📰 最新文章**：[《我把 Sentry 接进了 7 端小程序：从异常捕获、Breadcrumb 到 Source Map 定位》](https://juejin.cn/post/7621871037853843465) — 多端统一接入、Breadcrumb 上下文、弱网兜底、Source Map 实战，一篇串完整套方案。觉得有用请帮忙点个 ⭐ Star，让更多小程序团队找到它。
+> **📰 最新文章**：[《我给 Sentry 提了个 PR，后来 sentry-miniapp 进了官方文档》](https://juejin.cn/post/7636106283963760681) — sentry-miniapp 已被收录进 Sentry 官方文档的 community-supported SDK 列表，这篇文章记录这件事的来龙去脉。觉得有用请帮忙点个 ⭐ Star，让更多小程序团队找到它。
 
 <details>
 <summary><b>🆕 v1.3 → v1.8 What's New（点击展开）</b></summary>


### PR DESCRIPTION
## Summary

把 README 顶部的「📰 最新文章」卡片从第一篇文章（接入实战）切换到刚发布的里程碑文章。

## Changes

| 文件 | 旧 | 新 |
|---|---|---|
| `README.md` | 《我把 Sentry 接进了 7 端小程序…》(7621871037853843465) | 《我给 Sentry 提了个 PR，后来 sentry-miniapp 进了官方文档》([7636106283963760681](https://juejin.cn/post/7636106283963760681)) |
| `README.en.md` | 同上 | 同上 |

只保留一条卡片，保持顶部简洁。被顶替的旧文章在文章正文中（"上一篇"链接）仍可见。

🤖 Generated with [Claude Code](https://claude.ai/code)