### PR TITLE
feat: H5/浏览器环境下输出引导提示，建议改用 @sentry/browser

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -313,6 +313,41 @@ If errors are not being reported, check:
 
 **Not currently.** Sentry's official Replay feature relies on standard browser DOM (via rrweb recording). Mini programs use a dual-thread architecture without standard DOM access. We recommend using **Breadcrumbs** combined with **custom logging** to reconstruct user action sequences.
 
+### 3. How do I monitor the H5 build of a uni-app / Taro project?
+
+`sentry-miniapp` **only adapts mini program platforms** and does not implement browser-native signals (`window.onerror`, `fetch` / `XHR` interception, `PerformanceObserver`, etc.). For the H5 build, use Sentry's official [`@sentry/browser`](https://docs.sentry.io/platforms/javascript/) directly — full feature coverage, maintained upstream.
+
+> When this SDK is initialized in a browser environment, it logs a warning suggesting you switch to `@sentry/browser`.
+
+Recommended pattern: split SDKs by platform via **uni-app conditional compilation**:
+
+```ts
+// utils/sentry.ts
+let Sentry: any;
+
+// #ifdef H5
+Sentry = require('@sentry/browser');
+Sentry.init({
+  dsn: 'YOUR_DSN',
+  environment: 'production',
+  tracesSampleRate: 0.2,
+});
+// #endif
+
+// #ifdef MP-WEIXIN || MP-ALIPAY || MP-BAIDU || MP-TOUTIAO || MP-QQ || MP-KUAISHOU || MP-DINGTALK
+Sentry = require('sentry-miniapp');
+Sentry.init({
+  dsn: 'YOUR_DSN',
+  environment: 'production',
+  tracesSampleRate: 0.2,
+});
+// #endif
+
+export default Sentry;
+```
+
+Both sides report to the same Sentry DSN so all errors land in a single project. For Taro, use `process.env.TARO_ENV === 'h5'` to branch similarly.
+
 ---
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -328,6 +328,41 @@ App({
 目前 **不支持** `Sentry.replayIntegration()`。
 Sentry 官方的 Replay 功能强依赖于浏览器标准 DOM 环境（通过 rrweb 录制）。小程序采用双线程架构且没有开放标准 DOM 接口，无法直接复用。建议通过完善**Breadcrumbs（面包屑路径）**结合**自定义日志**来还原用户操作现场。
 
+### 3. uni-app / Taro 项目的 H5 端如何监控？
+
+`sentry-miniapp` **仅适配各小程序平台**，不内置浏览器原生信号（`window.onerror`、`fetch` / `XHR` 拦截、`PerformanceObserver` 等）。H5 端请直接使用 Sentry 官方的 [`@sentry/browser`](https://docs.sentry.io/platforms/javascript/)，能力完整、长期由官方维护。
+
+> SDK 在 H5 环境下被错误初始化时，会输出引导提示，提醒切换到 `@sentry/browser`。
+
+推荐通过 **uni-app 条件编译**按端引入：
+
+```ts
+// utils/sentry.ts
+let Sentry: any;
+
+// #ifdef H5
+Sentry = require('@sentry/browser');
+Sentry.init({
+  dsn: 'YOUR_DSN',
+  environment: 'production',
+  tracesSampleRate: 0.2,
+});
+// #endif
+
+// #ifdef MP-WEIXIN || MP-ALIPAY || MP-BAIDU || MP-TOUTIAO || MP-QQ || MP-KUAISHOU || MP-DINGTALK
+Sentry = require('sentry-miniapp');
+Sentry.init({
+  dsn: 'YOUR_DSN',
+  environment: 'production',
+  tracesSampleRate: 0.2,
+});
+// #endif
+
+export default Sentry;
+```
+
+两端上报同一个 Sentry DSN，可以在同一个 Project 里聚合查看错误。Taro 用户可以用类似的 `process.env.TARO_ENV === 'h5'` 判断分端引入。
+
 ---
 
 ## 📖 文档导航

--- a/src/crossPlatform.ts
+++ b/src/crossPlatform.ts
@@ -98,6 +98,19 @@ export interface SystemInfo {
 }
 
 /**
+ * 判断当前运行时是否为标准浏览器环境（含 uni-app H5、Taro H5、纯 Web 等）。
+ * 仅在所有小程序全局对象都未命中时作为兜底分支调用。
+ */
+const isBrowserRuntime = (): boolean => {
+  return (
+    typeof window !== 'undefined' &&
+    window !== null &&
+    typeof document !== 'undefined' &&
+    document !== null
+  );
+};
+
+/**
  * 获取跨平台的 SDK
  */
 const getSDK = (): SDK => {
@@ -134,7 +147,17 @@ const getSDK = (): SDK => {
     // tslint:disable-next-line: no-unsafe-any
     currentSdk = ks;
   } else {
-    console.warn('[sentry-miniapp] 未检测到已支持的小程序平台，SDK 将以降级模式运行');
+    if (isBrowserRuntime()) {
+      console.warn(
+        '[sentry-miniapp] 检测到当前运行在浏览器/H5 环境（如 uni-app H5、Taro H5）。\n' +
+          '本 SDK 仅适配各小程序平台，不支持浏览器原生信号（window.onerror、fetch/XHR 拦截、PerformanceObserver 等）。\n' +
+          '建议改用 Sentry 官方浏览器 SDK：@sentry/browser。\n' +
+          '若使用 uni-app/Taro，可结合条件编译按端引入：H5 用 @sentry/browser，小程序端用 sentry-miniapp。\n' +
+          '详情参考：https://docs.sentry.io/platforms/javascript/',
+      );
+    } else {
+      console.warn('[sentry-miniapp] 未检测到已支持的小程序平台，SDK 将以降级模式运行');
+    }
     // 返回带有空操作方法的默认 SDK，而非抛出异常
     return currentSdk;
   }

--- a/test/crossPlatform.test.ts
+++ b/test/crossPlatform.test.ts
@@ -137,6 +137,38 @@ describe('CrossPlatform', () => {
       );
       consoleSpy.mockRestore();
     });
+
+    it('should suggest @sentry/browser when running in a browser/H5 environment', async () => {
+      const originalWindow = (global as any).window;
+      const originalDocument = (global as any).document;
+      (global as any).window = {};
+      (global as any).document = {};
+
+      const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        const { getSDK } = await import('../src/crossPlatform');
+        const result = getSDK();
+        expect(result).toBeDefined();
+        expect(typeof result.request).toBe('function');
+        expect(consoleSpy).toHaveBeenCalledTimes(1);
+        const message = (consoleSpy.mock.calls[0] as unknown[])[0] as string;
+        expect(message).toContain('浏览器/H5 环境');
+        expect(message).toContain('@sentry/browser');
+        expect(message).not.toContain('未检测到已支持的小程序平台');
+      } finally {
+        consoleSpy.mockRestore();
+        if (originalWindow === undefined) {
+          delete (global as any).window;
+        } else {
+          (global as any).window = originalWindow;
+        }
+        if (originalDocument === undefined) {
+          delete (global as any).document;
+        } else {
+          (global as any).document = originalDocument;
+        }
+      }
+    });
   });
 
   describe('getSystemInfo', () => {


### PR DESCRIPTION
## Summary

- 在 `crossPlatform.ts` 的 fallback 分支识别浏览器/H5 运行时（`window` + `document`），输出多行引导提示，建议改用 `@sentry/browser`，并附 uni-app/Taro 条件编译思路与官方文档链接；非浏览器的未知环境保持原"降级模式运行"提示。
- 中英 README 的 FAQ 区域新增"H5 端如何监控 / How to monitor the H5 build"章节，给出按端引入 SDK 的条件编译示例。
- 新增测试覆盖浏览器分支：当 `window` 与 `document` 均存在时，warn 内容包含 `浏览器/H5 环境` 与 `@sentry/browser`，且不再回退到通用未知环境提示。

closes #135

## Test plan

- [x] `yarn lint`
- [x] `yarn test`（26 suites / 450 tests 全绿，含新增 case）
- [ ] reviewer 在 uni-app H5 调试模式下手动确认控制台提示文案

🤖 Generated with [Claude Code](https://claude.com/claude-code)