### PR TITLE
chore: 为 CI workflow 显式声明最小 GITHUB_TOKEN 权限

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ env:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     strategy:
       matrix:


### PR DESCRIPTION
## Summary
- 在 `.github/workflows/ci.yml` 的 `build-and-test` job 中显式声明 `permissions: contents: read`，遵循最小权限原则
- 修复 CodeQL 告警 [actions/missing-workflow-permissions #8](https://github.com/lizhiyao/sentry-miniapp/security/code-scanning/8)
- 与 `publish.yml` 已有的 job 级 `permissions` 写法保持一致

## Test plan
- [ ] CI 通过（lint / build / test 全部成功）
- [ ] CodeQL 重新扫描后告警 #8 状态变为 fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)