### PR TITLE
docs(readme): 优化首屏接入路径

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -14,6 +14,17 @@ A **mini program monitoring SDK** built on `@sentry/core`, providing **error mon
 
 > **What are Mini Programs?** Mini programs (小程序) are lightweight apps that run inside super-apps like WeChat, Alipay, and ByteDance/Douyin. They form a massive ecosystem in China with **hundreds of millions of daily active users**, but have no direct equivalent in the Western tech stack. Think of them as a hybrid between PWAs and native apps, but hosted within a platform's sandbox.
 
+## Quick Decision
+
+| Scenario | Recommendation |
+|---|---|
+| WeChat, Alipay, ByteDance, Baidu, QQ, DingTalk, or Kuaishou mini programs | Use `sentry-miniapp` |
+| Taro / uni-app builds targeting mini program platforms | Use `sentry-miniapp` |
+| Taro / uni-app H5 / browser builds | Use `@sentry/browser` and branch by target platform |
+| Pure Web, Node.js, React Native, or other environments | Prefer the official Sentry SDK for that platform |
+
+To integrate now, start with [Quick Start](#quick-start). For Source Map / release / CI upload, see the [Source Map Configuration Guide](./docs/SOURCEMAP_GUIDE.md).
+
 > **📰 Featured Article (Chinese)**: [《我给 Sentry 提了个 PR，后来 sentry-miniapp 进了官方文档》](https://juejin.cn/post/7636106283963760681) — How sentry-miniapp got listed in Sentry's official community-supported SDKs documentation. If you find this project useful, please consider giving it a ⭐ Star.
 
 <details>
@@ -126,6 +137,28 @@ App({
 ```
 
 Default integrations already include automatic exception capture, performance monitoring, SourceMap path normalization, network breadcrumbs, session tracking, and network status monitoring. Only pass `integrations` when you intentionally want to take over the full integration list, because it replaces the defaults.
+
+### 3. Verify Reporting
+
+Before shipping, verify two things:
+
+- Add the Sentry reporting endpoint domain to the `request` trusted domain list in your mini program admin console.
+- Trigger a test error and confirm it appears in Sentry Issues:
+
+```javascript
+Sentry.captureException(new Error('sentry-miniapp smoke test'));
+```
+
+### 4. Common Next Steps
+
+| Goal | Start Here |
+|---|---|
+| Manual reporting, user context, breadcrumbs, performance spans | [Advanced Usage](#advanced-usage) |
+| Source Map / release / CI upload | [Source Map Configuration Guide](./docs/SOURCEMAP_GUIDE.md) |
+| H5 builds in Taro / uni-app projects | [FAQ: How do I monitor the H5 build of a uni-app / Taro project?](#3-how-do-i-monitor-the-h5-build-of-a-uni-app--taro-project) |
+| WeChat mini program example | [examples/wxapp](./examples/wxapp/README.md) |
+| Multi-platform compatibility details | [Multi-Platform Compatibility Report](./docs/MultiPlatformCompatibilityReport.md) |
+| AI-assisted setup | [AI-Assisted Setup](#ai-assisted-setup) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@
 
 一个基于 `@sentry/core` 核心构建的**小程序监控 SDK**，提供**异常监控**、**性能监控**、离线缓存、分布式追踪等能力。支持微信、支付宝、字节跳动、百度、QQ、钉钉、快手等多端小程序及 Taro / uni-app 等跨端框架。
 
+## 快速判断
+
+| 场景 | 建议 |
+|---|---|
+| 微信、支付宝、字节、百度、QQ、钉钉、快手小程序 | 使用 `sentry-miniapp` |
+| Taro / uni-app 编译到小程序端 | 使用 `sentry-miniapp` |
+| Taro / uni-app 的 H5 / 浏览器端 | 使用 `@sentry/browser`，按端条件引入 |
+| 纯 Web、Node.js、React Native 等其它环境 | 优先使用 Sentry 官方 SDK |
+
+想立刻接入，从 [快速接入](#-快速接入) 开始；需要 Source Map / release / CI 上传，直接看 [Source Map 完整配置指南](./docs/SOURCEMAP_GUIDE.md)。
+
 > **📰 最新文章**：[《我给 Sentry 提了个 PR，后来 sentry-miniapp 进了官方文档》](https://juejin.cn/post/7636106283963760681) — sentry-miniapp 已被收录进 Sentry 官方文档的 community-supported SDK 列表，这篇文章记录这件事的来龙去脉。觉得有用请帮忙点个 ⭐ Star，让更多小程序团队找到它。
 
 <details>
@@ -127,6 +138,28 @@ App({
 ```
 
 默认集成已经包含自动异常捕获、性能监控、Source Map 路径归一化、网络面包屑、Session 和网络状态监控。只有在需要完全接管集成列表时才传入 `integrations`，否则会覆盖默认集成。
+
+### 3. 验证上报
+
+上线前请确认两件事：
+
+- 在小程序管理后台把 Sentry 上报域名加入 `request` 合法域名。
+- 触发一次测试错误，并在 Sentry Issues 中确认收到事件：
+
+```javascript
+Sentry.captureException(new Error('sentry-miniapp smoke test'));
+```
+
+### 4. 常用入口
+
+| 目标 | 入口 |
+|---|---|
+| 手动上报、用户信息、Breadcrumb、性能 Span | [常用进阶用法](#-常用进阶用法) |
+| Source Map / release / CI 上传 | [Source Map 完整配置指南](./docs/SOURCEMAP_GUIDE.md) |
+| Taro / uni-app 的 H5 端怎么处理 | [FAQ：uni-app / Taro 项目的 H5 端如何监控？](#3-uni-app--taro-项目的-h5-端如何监控) |
+| 微信小程序示例工程 | [examples/wxapp](./examples/wxapp/README.md) |
+| 多平台兼容性细节 | [多平台兼容性报告](./docs/MultiPlatformCompatibilityReport.md) |
+| 想让 AI 帮你接入 | [AI 辅助接入](#-ai-辅助接入) |
 
 ---
 


### PR DESCRIPTION
## 变更说明

- 在中英文 README 首屏增加轻量快速判断，帮助用户确认是否应该使用 sentry-miniapp
- 保留原有首屏文章和 What's New 节奏，不再把完整接入代码压到首屏
- 在快速接入后补充上报验证步骤和常用下一步入口，指向进阶用法、Source Map、H5/Taro/uni-app、示例工程、多端兼容性和 AI 辅助接入

## 验证

- git diff --check
- yarn run lint
- yarn run test