### PR TITLE
chore(deps): 固定 Yarn 4 版本并补齐 berry 配置

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,9 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
 
+    - name: Enable Corepack
+      run: corepack enable
+
     - name: Install dependencies
       run: yarn cache clean && yarn install --update-checksums
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       run: corepack enable
 
     - name: Install dependencies
-      run: yarn cache clean && yarn install --update-checksums
+      run: yarn install --immutable
 
     - name: Run Lint
       run: yarn run lint

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
       run: corepack enable
 
     - name: Install dependencies
-      run: yarn cache clean && yarn install --update-checksums
+      run: yarn install --immutable
 
     - name: Run Lint
       run: yarn run lint

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,9 @@ jobs:
         node-version: '22.x'
         registry-url: 'https://registry.npmjs.org'
 
+    - name: Enable Corepack
+      run: corepack enable
+
     - name: Install dependencies
       run: yarn cache clean && yarn install --update-checksums
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,15 @@
 node_modules/
 packages/*/package-lock.json
 
+# yarn 4 (corepack 固定版本，仅忽略本地产物；如需 patches/releases 再放开)
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions
+.pnp.*
+
 # build and test
 dist/
 esm/

--- a/.yarnrc
+++ b/.yarnrc
@@ -1,1 +1,0 @@
-registry "https://registry.npmjs.org/"

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,8 @@
+# Yarn 4 配置（Yarn 2+ 读取本文件，旧版 classic .yarnrc 已废弃）
+# Yarn 版本通过 package.json 的 packageManager 字段固定，配合 corepack 使用。
+
+# 保持 node_modules 安装布局，避免 PnP 对小程序构建 / Vite 链路的兼容风险
+nodeLinker: node-modules
+
+# 统一使用 npm 官方源（与 lint-staged 中的 yarn.lock registry 校验保持一致）
+npmRegistryServer: "https://registry.npmjs.org"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,8 @@ cp -r .claude/skills/sentry-miniapp-sdk ~/.codex/agents/skills/sentry-miniapp-sd
 
 ## 常用命令
 
+> 环境要求：Node ≥ 20、Yarn 4（由 `package.json` 的 `packageManager` 固定）。首次先跑 `corepack enable`，让仓库内的 `yarn` 自动对齐到固定版本。
+
 - `yarn install` - 安装依赖
 - `yarn run lint` - 代码检查
 - `yarn run test` - 运行单元测试

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ Quick start:
 ```bash
 git clone https://github.com/<your-username>/sentry-miniapp.git
 cd sentry-miniapp
+corepack enable   # 启用后 yarn 自动对齐到 package.json 固定的 Yarn 4 版本
 yarn install
 yarn dev
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,6 +4,15 @@
 
 ## 🚀 快速开始
 
+### 0. 环境要求
+
+- **Node.js** ≥ 20
+- **Yarn 4**：项目通过 `package.json` 的 `packageManager` 字段固定 Yarn 版本，推荐用 [Corepack](https://nodejs.org/api/corepack.html) 自动对齐，无需全局手动安装：
+
+  ```bash
+  corepack enable   # 启用后，仓库内执行 yarn 会自动使用固定的 Yarn 4 版本
+  ```
+
 ### 1. 安装依赖
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "author": "dancerlzy@gmail.com",
   "license": "MIT",
+  "packageManager": "yarn@4.16.0",
   "engines": {
     "node": ">=20"
   },


### PR DESCRIPTION
## 背景

master 当前的 `yarn.lock` 已是 **Yarn 4 berry 格式**（`__metadata: version`），但：

- `package.json` 没有 `packageManager` 字段 → Yarn 版本未固定
- 仍保留 classic 格式的 `.yarnrc`（Yarn 4 已不读它，是死文件）
- CI 用的 `yarn install --update-checksums` 其实是 **Yarn 1 classic 专属标志**

也就是说项目此前 CI 实际是用 **classic Yarn 1** 在跑（忽略了 berry 锁文件，靠 runner 默认 yarn 蒙混过关），处于「半迁移、未固定」的脆弱状态。本 PR 把它扶正,强制走固定的 Yarn 4，消除「本机能跑、CI 不一定」的问题。

## 改动

| 文件 | 改动 |
|---|---|
| `package.json` | 新增 `"packageManager": "yarn@4.16.0"`，配合 corepack 固定版本 |
| `.yarnrc.yml` | **新增**正式配置：`nodeLinker: node-modules` + 官方源 |
| `.yarnrc` | **删除**（classic 格式，Yarn 4 不读，仅剩死配置） |
| `.github/workflows/ci.yml`、`publish.yml` | ① 安装前 `corepack enable`；② `yarn install --update-checksums`（classic 标志，Yarn 4 报错）→ `yarn install --immutable`（Yarn 4 标准，锁文件漂移即 fail） |
| `.gitignore` | 忽略 `.yarn/*` 本地产物（保留 patches/releases 等可选放开项） |
| `AGENTS.md`、`DEVELOPMENT.md` | 补充 Node ≥ 20 与 Yarn 4 + corepack 环境说明 |

## 设计取舍

- **保持 `node-modules` linker，不启用 PnP**：PnP 对小程序构建 / Vite 链路兼容风险大，收益不明显。
- **不提交 `.yarn/releases` 二进制**：依赖 corepack + `packageManager` 固定版本，仓库更干净。
- **CI 改用 `--immutable`**：从锁文件还原依赖、漂移即失败，正好契合「固定版本、保证可复现」的目标。
- 锁文件无需变动：master 已是 berry 格式，`yarn install` 后 `yarn.lock` 零变化。

## 验证

- ✅ `corepack enable` 后 `yarn --version` → `4.16.0`
- ✅ `yarn install --immutable` — 通过，`yarn.lock` 无变化
- ✅ `yarn run lint` — 通过
- ✅ `yarn run test` — 450 单测全过
- ✅ `yarn run build` — 构建通过，examples 产物无 diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)