### PR TITLE
docs(examples): uni-app 示例补充「如何验证上报」说明

### DIFF
--- a/examples/uniapp/src/utils/sentry.js
+++ b/examples/uniapp/src/utils/sentry.js
@@ -68,5 +68,20 @@ Sentry.setUser({ id: 'uniapp-demo-user', username: 'uniapp_demo' });
 Sentry.setTag('app.framework', 'uni-app');
 Sentry.setTag('miniapp.platform', 'wechat');
 
+// ---- 如何验证上报是否打通（自测用，验证完可删）----
+//
+// ⚠️ addBreadcrumb（面包屑）不会单独上报！它只是被缓存，等「下一次事件」发生时随事件一起发送。
+// 只调用 addBreadcrumb 而不捕获事件，后台会一直没有数据——这不是 SDK 没生效。
+//
+// 要验证上报链路，必须主动捕获一个「事件」：
+//
+//   import Sentry from '@/utils/sentry';
+//   Sentry.captureException(new Error('sentry test'));   // error 级，最直观
+//   // 或 Sentry.captureMessage('sentry test', 'error'); // 注意别用默认的 info 级，可能被列表筛选挡掉
+//
+// 然后到 Sentry「Issues」列表查看（与「警报规则」无关，事件照样进列表）。
+// 自建 Sentry / 真机时还需：把 Sentry 域名加入微信「request 合法域名」白名单
+// （开发者工具可临时勾选「不校验合法域名」绕过），否则请求会被拦截、事件发不出去。
+
 export default Sentry;
 export { Sentry };


### PR DESCRIPTION
## 背景

见 #168。uni-app 用户拷贝 `examples/uniapp/src/utils/sentry.js` 后，用 `Sentry.addBreadcrumb` 来验证上报，但**面包屑不会单独上报**（只在下一次事件发生时随事件一起发），于是后台一直没数据，误以为 SDK 未生效。该示例此前只有 `init` + `setUser/setTag`，没有「如何验证」的指引。

## 改动

在示例末尾补一段自测说明（注释，不执行）：

- `addBreadcrumb` 不触发上报，需用 `captureException` / `captureMessage` 主动捕获事件；
- `captureMessage` 别用默认 `info` 级，可能被 Issues 列表筛选挡掉；
- 事件进 Issues 列表与「警报规则」无关；
- 自建 Sentry / 真机需把 Sentry 域名加入微信「request 合法域名」白名单（开发者工具可勾「不校验合法域名」绕过）。

纯示例注释，无代码 / 行为变更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)