### PR TITLE
docs(sourcemap): 新增两层 sourcemap 离线合成脚本与实操指南

### DIFF
--- a/docs/SOURCEMAP_GUIDE.md
+++ b/docs/SOURCEMAP_GUIDE.md
@@ -526,6 +526,7 @@ SDK 会自动剥离所有 `协议://` 格式的前缀，因此 QQ、钉钉、快
 1. **不要将 `.map` 文件发布到生产环境**——Source Map 包含原始源码，泄露可能带来安全风险。上传到 Sentry 后应立即删除本地 `.map` 文件。
 2. **不要将 Auth Token 提交到代码仓库**——使用环境变量或将 `.sentryclirc` 添加到 `.gitignore`。
 3. **使用 `hidden-source-map`**——避免在产物中生成 `sourceMappingURL` 注释，防止浏览器或调试工具直接加载 `.map` 文件。
+4. **离线合成的 map 同样含源码**——`scripts/merge-sourcemap.mjs` 产出的合成 `.map` 内嵌 `sourcesContent`（即原始源码），只用于上传 Sentry，**别打进小程序包、别发布到任何公开位置**，用完即删。
 
 ---
 

--- a/docs/SOURCEMAP_GUIDE.md
+++ b/docs/SOURCEMAP_GUIDE.md
@@ -11,6 +11,7 @@
 - [第五步：CI/CD 自动化](#第五步cicd-自动化)
 - [第六步：验证 Source Map 是否生效](#第六步验证-source-map-是否生效)
 - [平台特殊说明](#平台特殊说明)
+- [跨端框架的两层 Source Map 串联](#跨端框架的两层-source-map-串联)
 - [安全注意事项](#安全注意事项)
 - [常见问题排查](#常见问题排查)
 - [完整配置示例](#完整配置示例)
@@ -31,6 +32,8 @@
 ```
 
 因此，你在上传 Source Map 时只需统一使用 `--url-prefix "app:///"` 即可，无需关心各平台差异。
+
+> ⚠️ **真机可能是另一种形态。** 上面的分页路径（如 `app:///pages/index.js`）是开发者工具 / 部分运行时的样子；**真机上微信常把逻辑层所有 JS 合并成单个 `app:///appservice.app.js`**，错误栈行列号落在这个合并大文件里，分页 Source Map 解不出。用 Taro / uni-app 等框架时几乎必然如此。**上传前请先在真机触发一个错误、看清堆栈里的文件名，再决定传哪种 map**——详见 [跨端框架的两层 Source Map 串联](#跨端框架的两层-source-map-串联)。
 
 **端到端流程：**
 
@@ -73,7 +76,7 @@ Sentry.init({
   dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0',
   release: 'my-miniapp@1.0.0',  // 必须与上传时的 release 名称一致
   environment: 'production',
-  // enableSourceMap: true,  // 默认已开启，无需显式设置
+  // enableSourceMap: true,  // 默认已开启，无需显式设置（仅控制堆栈路径归一化，与 .map 文件生成无关）
 });
 ```
 
@@ -122,7 +125,11 @@ Sentry.init({
 
 ### 关于 `enableSourceMap`
 
-SDK 默认开启路径归一化（`enableSourceMap: true`），通常无需修改。如果你因特殊原因需要禁用：
+SDK 默认开启路径归一化（`enableSourceMap: true`），通常无需修改。
+
+> ℹ️ **这个开关名容易误解：** 它**只控制错误上报时把平台虚拟路径归一化为 `app:///`**（即 `RewriteFrames`），**不负责生成 `.map` 文件**——`.map` 由你的构建工具产出。关掉它只是不再归一化堆栈路径，不会影响构建产物。
+
+如果你因特殊原因需要禁用：
 
 ```javascript
 Sentry.init({
@@ -418,12 +425,16 @@ Page({
 });
 ```
 
+> Taro / uni-app 等框架：在任意页面组件的生命周期或方法里 `throw new Error('Source Map 测试错误')` 同理，不必是 `Page({ onLoad })` 这种原生写法。
+
 ### 3. 在 Sentry 面板验证
 
 1. 登录 Sentry，进入对应项目
 2. 找到刚触发的错误事件
 3. 查看堆栈信息——如果显示的是**原始源码**而非压缩代码，说明 Source Map 配置成功
 4. 如果仍显示压缩代码，点击堆栈帧右侧的 **"Source Map Debug"** 按钮，Sentry 会告诉你匹配失败的原因
+
+> 📌 **先看堆栈帧的文件名**：若是 `app:///appservice.app.js`（真机合并大文件）而你只上传了分页 Source Map，再正确的 `release` / `--url-prefix` 也解不出——见 [跨端框架的两层 Source Map 串联](#跨端框架的两层-source-map-串联)。
 
 ---
 
@@ -441,7 +452,29 @@ Page({
 
 **路径归一化：** SDK 自动剥离 `appservice/`、`app-service/`、`WAService/` 前缀。
 
-#### ⚠️ Taro / 跨端框架：真机错误栈是 `appservice.app.js`，分页 Source Map 解不出
+#### ⚠️ 跨端框架（Taro / uni-app）：真机栈是合并的 `appservice.app.js`
+
+用 Taro / uni-app 等框架时，真机错误栈的文件名通常是合并后的 `app:///appservice.app.js`，分页 Source Map 解不出，需要单独处理（含两层 map 的离线合成脚本）——详见独立专节 [跨端框架的两层 Source Map 串联](#跨端框架的两层-source-map-串联)。
+
+### 支付宝小程序
+
+**路径归一化：** SDK 自动剥离 `https://appx/` 等 HTTP 协议前缀。
+
+### 字节跳动小程序
+
+**路径归一化：** SDK 自动剥离 `tt://` 协议前缀。
+
+### 百度小程序
+
+**路径归一化：** SDK 自动剥离 `swan://` 协议前缀。
+
+### 其他平台
+
+SDK 会自动剥离所有 `协议://` 格式的前缀，因此 QQ、钉钉、快手等平台的虚拟路径也能被正确处理。
+
+---
+
+## 跨端框架的两层 Source Map 串联
 
 如果你用 Taro / uni-app 等框架，且在**真机**上发现 Sentry 里堆栈的文件名是 `app:///appservice.app.js`（行列号动辄上万 / 几十万），而你上传的是构建产物里的**分页 Source Map**（如 `app:///pages/index/index.js.map`），那么**无论 `release`、`--url-prefix` 配置得多正确都解析不出来**。原因：
 
@@ -449,13 +482,15 @@ Page({
 - **这个文件你的构建根本不产、也没上传。** Taro `taro build --type weapp` 的产物是 `app.js` / `pages/*/index.js` / `vendors.js` 等分页文件，`appservice.app.js` 是微信侧合并出来的——Sentry 里没有这个 artifact，自然匹配不到。这不是行号偏移，而是**目标文件压根没传**。
 - **产物默认是压缩混淆的。** Taro 生产构建默认用 Terser 压缩（函数名变成 `l` / `ge` / `nn` 这种）。这与微信开发者工具里的「代码压缩」开关**无关**，关那个开关不会取消 Taro 自己的压缩。
 
+> **为什么会有「两层」map：** 框架构建（webpack / vite）先把源码压成「编译产物 JS」（产出第一层 map A：编译产物 JS → 源码）；微信上传时再 es6→es5 + 压缩，并合并成 `appservice.app.js`（产出第二层 map B：`appservice.app.js` → 编译产物 JS）。两层叠加，单独任一层的 map 都到不了源码——只传 A 对不上合并文件，只传 B 又停在编译产物 JS。
+
 **怎么办**（两种，按需要的深度选）：
 
 1. **快速定位到「分页编译后 JS」**
    - 从微信 **「We 分析 → 性能 / JS 报错 → 下载线上 Source Map」** 拿到 `appservice.app.js` 对应的 `.map`（注意：只有**体验版 / 线上版**有，`miniprogram-ci` 预览的开发版拿不到；版本要与线上一致）；
    - 以 **`app:///appservice.app.js`** 的名字上传到 Sentry（`--url-prefix "app:///"` 不变）；
-   - 想让解析结果可读，再关闭 Taro 的 JS 压缩（参考 Taro 文档对应版本的压缩 / `terser` 配置）。
-   - 结果：能定位到**分页文件 + 行列**，但停在 Taro 编译后的 JS，**不是源码 TSX**。Sentry 一次只应用一层 Source Map，不会自动再串到 Taro 的分页 map。
+   - 想让解析结果可读，再关闭框架的 JS 压缩（参考 Taro / uni-app 文档对应版本的压缩 / `terser` 配置）。
+   - 结果：能定位到**分页文件 + 行列**，但停在框架编译后的 JS，**不是源码（`.vue` / `.tsx`）**。Sentry 一次只应用一层 Source Map，不会自动再串到框架的分页 map。
 
 2. **一路解析到源码（`.vue` / `.tsx`）**
    把「微信合并 map（`appservice.app.js` → 编译产物 JS）」与「框架构建 map（编译产物 JS → 源码）」**离线合成一份** `appservice.app.js` → 源码 的 map，再以 `app:///appservice.app.js` 上传。能到源码，但需要自己合成——WeChat / Sentry / uni-app / Taro 都没有一键方案。
@@ -482,23 +517,7 @@ Page({
 
    合并算法是稳的，**难点在两份 map 的文件名能否对齐**（`B.sources` 里的名字 ↔ 构建 map 描述的文件名）。不同框架 / 打包器 / 版本命名各异，对不齐时脚本会逐条列出 `B.sources`，照提示加 `--strip <前缀>`（如 `--strip webpack://`）或对齐产物文件名即可。合成后精度取「两份 map 的较小值」，定位到行没问题。这是 best-effort 起点，其它框架的匹配策略欢迎 PR。
 
-> 这不是 SDK 的问题：`sentry-miniapp` 的堆栈解析与 `RewriteFrames` 已正确把 `appservice.app.js` 归一为 `app:///appservice.app.js`；能否解析取决于你上传的 map 是否对应这个**合并后的文件**。相关讨论见 [issue #162](https://github.com/lizhiyao/sentry-miniapp/issues/162)。
-
-### 支付宝小程序
-
-**路径归一化：** SDK 自动剥离 `https://appx/` 等 HTTP 协议前缀。
-
-### 字节跳动小程序
-
-**路径归一化：** SDK 自动剥离 `tt://` 协议前缀。
-
-### 百度小程序
-
-**路径归一化：** SDK 自动剥离 `swan://` 协议前缀。
-
-### 其他平台
-
-SDK 会自动剥离所有 `协议://` 格式的前缀，因此 QQ、钉钉、快手等平台的虚拟路径也能被正确处理。
+> 这不是 SDK 的问题：`sentry-miniapp` 的堆栈解析与 `RewriteFrames` 已正确把 `appservice.app.js` 归一为 `app:///appservice.app.js`；能否解析取决于你上传的 map 是否对应这个**合并后的文件**。相关讨论见 [issue #162](https://github.com/lizhiyao/sentry-miniapp/issues/162) 与 [#173](https://github.com/lizhiyao/sentry-miniapp/issues/173)。
 
 ---
 

--- a/docs/SOURCEMAP_GUIDE.md
+++ b/docs/SOURCEMAP_GUIDE.md
@@ -515,7 +515,7 @@ SDK 会自动剥离所有 `协议://` 格式的前缀，因此 QQ、钉钉、快
    # 4) 把 ./merged/appservice.app.js.map 以 app:///appservice.app.js 的名字上传 Sentry
    ```
 
-   合并算法是稳的，**难点在两份 map 的文件名能否对齐**（`B.sources` 里的名字 ↔ 构建 map 描述的文件名）。不同框架 / 打包器 / 版本命名各异，对不齐时脚本会逐条列出 `B.sources`，照提示加 `--strip <前缀>`（如 `--strip webpack://`）或对齐产物文件名即可。合成后精度取「两份 map 的较小值」，定位到行没问题。这是 best-effort 起点，其它框架的匹配策略欢迎 PR。
+   合并算法是稳的，**难点在两份 map 的文件名能否对齐**（`B.sources` 里的名字 ↔ 构建 map 描述的文件名）。不同框架 / 打包器 / 版本命名各异，对不齐时脚本会逐条列出 `B.sources`，照提示加 `--strip <前缀>`（如 `--strip webpack://`）或对齐产物文件名即可。脚本会优先按相对路径精确匹配（如 `pages/foo/index.js`），最后才用文件名兜底；如果多个页面都叫 `index.js`，兜底匹配会被判为歧义并跳过，避免静默套错 map。合成后精度取「两份 map 的较小值」，定位到行没问题。这是 best-effort 起点，其它框架的匹配策略欢迎 PR。
 
 > 这不是 SDK 的问题：`sentry-miniapp` 的堆栈解析与 `RewriteFrames` 已正确把 `appservice.app.js` 归一为 `app:///appservice.app.js`；能否解析取决于你上传的 map 是否对应这个**合并后的文件**。相关讨论见 [issue #162](https://github.com/lizhiyao/sentry-miniapp/issues/162) 与 [#173](https://github.com/lizhiyao/sentry-miniapp/issues/173)。
 

--- a/docs/SOURCEMAP_GUIDE.md
+++ b/docs/SOURCEMAP_GUIDE.md
@@ -457,8 +457,30 @@ Page({
    - 想让解析结果可读，再关闭 Taro 的 JS 压缩（参考 Taro 文档对应版本的压缩 / `terser` 配置）。
    - 结果：能定位到**分页文件 + 行列**，但停在 Taro 编译后的 JS，**不是源码 TSX**。Sentry 一次只应用一层 Source Map，不会自动再串到 Taro 的分页 map。
 
-2. **一路解析到源码 TSX**
-   把「微信合并 map（`appservice.app.js` → 分页 JS）」与「Taro 分页 map（分页 JS → TSX）」**离线合成一份** `appservice.app.js` → TSX 的 map，再以 `app:///appservice.app.js` 上传。能到源码，但需自己写 Source Map 合成脚本（`source-map` 库），目前 WeChat / Sentry / Taro 都没有一键方案。
+2. **一路解析到源码（`.vue` / `.tsx`）**
+   把「微信合并 map（`appservice.app.js` → 编译产物 JS）」与「框架构建 map（编译产物 JS → 源码）」**离线合成一份** `appservice.app.js` → 源码 的 map，再以 `app:///appservice.app.js` 上传。能到源码，但需要自己合成——WeChat / Sentry / uni-app / Taro 都没有一键方案。
+
+   仓库提供了一个 best-effort 合成脚本 [`scripts/merge-sourcemap.mjs`](../scripts/merge-sourcemap.mjs)，用 `source-map` 的 `applySourceMap` 把两份 map 串起来：
+
+   ```bash
+   # 1) 装依赖（只在合成时用，不是 SDK 运行时依赖）
+   npm i -D source-map
+
+   # 2) 准备两份 map：
+   #    - Map B（外层）：微信「We 分析 → 性能 / JS 报错 → 下载线上 Source Map」拿 appservice.app.js 的 .map
+   #    - Map A（内层）：框架构建里开 sourcemap（uni-app 对 mp-weixin 默认常关；
+   #      vite 设 build.sourcemap、webpack 设 devtool: 'source-map'），得到一批编译产物 JS 的 .map
+
+   # 3) 合成
+   node scripts/merge-sourcemap.mjs \
+     --wechat   ./wechat/appservice.app.js.map \
+     --build-maps ./dist/dev/mp-weixin \
+     --out      ./merged/appservice.app.js.map
+
+   # 4) 把 ./merged/appservice.app.js.map 以 app:///appservice.app.js 的名字上传 Sentry
+   ```
+
+   合并算法是稳的，**难点在两份 map 的文件名能否对齐**（`B.sources` 里的名字 ↔ 构建 map 描述的文件名）。不同框架 / 打包器 / 版本命名各异，对不齐时脚本会逐条列出 `B.sources`，照提示加 `--strip <前缀>`（如 `--strip webpack://`）或对齐产物文件名即可。合成后精度取「两份 map 的较小值」，定位到行没问题。这是 best-effort 起点，其它框架的匹配策略欢迎 PR。
 
 > 这不是 SDK 的问题：`sentry-miniapp` 的堆栈解析与 `RewriteFrames` 已正确把 `appservice.app.js` 归一为 `app:///appservice.app.js`；能否解析取决于你上传的 map 是否对应这个**合并后的文件**。相关讨论见 [issue #162](https://github.com/lizhiyao/sentry-miniapp/issues/162)。
 

--- a/scripts/merge-sourcemap.mjs
+++ b/scripts/merge-sourcemap.mjs
@@ -47,7 +47,7 @@
  * `--url-prefix "app:///"` 不变）。
  */
 
-import { readFileSync, writeFileSync, readdirSync, statSync, mkdirSync } from 'node:fs';
+import { readFileSync, writeFileSync, readdirSync, mkdirSync } from 'node:fs';
 import { basename, dirname, join, relative, resolve } from 'node:path';
 
 // ---- 极简参数解析（不引第三方）----
@@ -58,7 +58,10 @@ function parseArgs(argv) {
     if (a === '--wechat') out.wechat = argv[++i];
     else if (a === '--build-maps') out.buildMaps = argv[++i];
     else if (a === '--out') out.out = argv[++i];
-    else if (a === '--strip') out.strip.push(argv[++i]);
+    else if (a === '--strip') {
+      const v = argv[++i];
+      if (v !== undefined) out.strip.push(v); // 防止 --strip 作为末尾参数时 push 进 undefined
+    }
     else if (a === '--verbose') out.verbose = true;
     else if (a === '--help' || a === '-h') out.help = true;
   }
@@ -133,11 +136,12 @@ function collectBuildMaps(dir) {
   const found = [];
   const root = resolve(dir);
   const walk = (d) => {
-    for (const entry of readdirSync(d)) {
-      const full = join(d, entry);
-      const st = statSync(full);
-      if (st.isDirectory()) walk(full);
-      else if (entry.endsWith('.map')) found.push(full);
+    // withFileTypes 省去逐条 statSync；symlink 既不算 isDirectory 也不算 isFile，
+    // 自然跳过，顺带避免符号链接成环。
+    for (const entry of readdirSync(d, { withFileTypes: true })) {
+      const full = join(d, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.isFile() && entry.name.endsWith('.map')) found.push(full);
     }
   };
   walk(root);
@@ -153,12 +157,7 @@ function collectBuildMaps(dir) {
     } catch {
       continue; // 不是合法 JSON map，跳过
     }
-    const mapDir = dirname(relative(root, file));
-    const hit = {
-      file,
-      raw,
-      sourceMapPath: mapDir === '.' ? undefined : normalizeName(mapDir, []),
-    };
+    const hit = { file, raw };
     const keys = new Set();
     if (raw.file) keys.add(normalizeName(raw.file, []));
     keys.add(normalizeName(relative(root, file).replace(/\.map$/, ''), []));
@@ -213,9 +212,11 @@ for (const src of bSources) {
     continue;
   }
   const cA = await new SourceMapConsumer(hit.raw);
-  // sourceFile 必须严格等于 src 在 B.sources 里的原始字符串；sourceMapPath 用相对
-  // build-maps 根目录的路径，既能解析 A 里的相对源码路径，也避免把本机构建绝对路径写进 map。
-  generator.applySourceMap(cA, src, hit.sourceMapPath);
+  // sourceFile 必须严格等于 src 在 B.sources 里的原始字符串。不传 sourceMapPath：
+  // 让 A 的源码路径原样透传（多为 src/... 或 webpack:// 这类工程相对路径），既不写入
+  // 本机构建绝对路径，也不会被多套一层 map 目录前缀。源码内容靠 sourcesContent 透传，
+  // 路径仅作展示。
+  generator.applySourceMap(cA, src);
   destroyConsumer(cA);
   matched.push(src);
   if (args.verbose) console.log(`  ✓ 匹配    ${src}  ←  ${hit.file}`);
@@ -259,3 +260,4 @@ writeFileSync(outFile, generator.toString(), 'utf8');
 console.log(`\n✓ 已写出合成 map：${outFile}`);
 console.log('  接着以 `app:///appservice.app.js` 的名字上传到 Sentry（--url-prefix "app:///" 不变）。');
 console.log('  注意：合成后精度是「两份 map 的较小值」，定位到行没问题，个别列号可能略糙。');
+console.log('  ⚠ 合成 map 内嵌源码（sourcesContent），仅用于上传 Sentry，别打进小程序包或公开发布，用完即删。');

--- a/scripts/merge-sourcemap.mjs
+++ b/scripts/merge-sourcemap.mjs
@@ -47,8 +47,8 @@
  * `--url-prefix "app:///"` 不变）。
  */
 
-import { readFileSync, writeFileSync, readdirSync, statSync } from 'node:fs';
-import { basename, dirname, join, resolve } from 'node:path';
+import { readFileSync, writeFileSync, readdirSync, statSync, mkdirSync } from 'node:fs';
+import { basename, dirname, join, relative, resolve } from 'node:path';
 
 // ---- 极简参数解析（不引第三方）----
 function parseArgs(argv) {
@@ -98,17 +98,40 @@ const destroyConsumer = (c) => {
 
 // ---- 工具：把一个 source 名字归一成「裸文件名」用于匹配 ----
 function normalizeName(name, strip) {
-  let n = String(name).split('?')[0].split('#')[0]; // 去 query / hash
+  let n = String(name).split('?')[0].split('#')[0].replace(/\\/g, '/'); // 去 query / hash，统一路径分隔符
   for (const p of strip) {
-    if (n.startsWith(p)) n = n.slice(p.length);
+    const prefix = String(p).replace(/\\/g, '/');
+    if (n.startsWith(prefix)) n = n.slice(prefix.length);
   }
-  n = n.replace(/^\.?\//, ''); // 去开头的 ./ 或 /
+  while (n.startsWith('./') || n.startsWith('/')) {
+    n = n.startsWith('./') ? n.slice(2) : n.slice(1);
+  }
   return n;
+}
+
+function addBuildMapCandidate(index, key, hit) {
+  if (!key) return;
+  const existing = index.get(key);
+  if (!existing) {
+    index.set(key, [hit]);
+    return;
+  }
+  if (!existing.some((item) => item.file === hit.file)) {
+    existing.push(hit);
+  }
+}
+
+function pickBuildMapCandidate(index, key) {
+  const hits = index.get(key);
+  if (!hits) return { hit: null, ambiguous: null };
+  if (hits.length === 1) return { hit: hits[0], ambiguous: null };
+  return { hit: null, ambiguous: hits };
 }
 
 // ---- 递归收集构建 map 目录下的所有 *.map，建索引 ----
 function collectBuildMaps(dir) {
   const found = [];
+  const root = resolve(dir);
   const walk = (d) => {
     for (const entry of readdirSync(d)) {
       const full = join(d, entry);
@@ -117,10 +140,11 @@ function collectBuildMaps(dir) {
       else if (entry.endsWith('.map')) found.push(full);
     }
   };
-  walk(resolve(dir));
+  walk(root);
 
-  // 建多键索引：用「map 内部 file 字段」和「文件名去掉 .map」两种 key 都指向它，
-  // 命中率更高（不同打包器有的填 file、有的不填）。
+  // 建多键索引：用「map 内部 file 字段」「相对 build-maps 根目录的产物路径」
+  // 和「文件名去掉 .map」三种 key 都指向它。前两者保证 pages/a/index.js 与
+  // pages/b/index.js 这类同名文件能精确匹配；basename 只作为最后兜底。
   const index = new Map();
   for (const file of found) {
     let raw;
@@ -129,14 +153,21 @@ function collectBuildMaps(dir) {
     } catch {
       continue; // 不是合法 JSON map，跳过
     }
+    const mapDir = dirname(relative(root, file));
+    const hit = {
+      file,
+      raw,
+      sourceMapPath: mapDir === '.' ? undefined : normalizeName(mapDir, []),
+    };
     const keys = new Set();
     if (raw.file) keys.add(normalizeName(raw.file, []));
+    keys.add(normalizeName(relative(root, file).replace(/\.map$/, ''), []));
     keys.add(normalizeName(basename(file).replace(/\.map$/, ''), []));
     for (const k of keys) {
-      if (!index.has(k)) index.set(k, { file, raw });
+      addBuildMapCandidate(index, k, hit);
     }
   }
-  return index;
+  return { index, fileCount: found.length };
 }
 
 // ---- 主流程 ----
@@ -147,29 +178,44 @@ if (bSources.length === 0) {
   process.exit(1);
 }
 
-const buildIndex = collectBuildMaps(args.buildMaps);
+const { index: buildIndex, fileCount: buildMapCount } = collectBuildMaps(args.buildMaps);
 console.log(`· 外层 map B：${bSources.length} 个 source`);
-console.log(`· 构建 map A：索引到 ${buildIndex.size} 个候选文件\n`);
+console.log(`· 构建 map A：读取 ${buildMapCount} 个 map，索引到 ${buildIndex.size} 个匹配 key\n`);
 
 const consumerB = await new SourceMapConsumer(rawB);
 const generator = SourceMapGenerator.fromSourceMap(consumerB);
 
 const matched = [];
 const unmatched = [];
+const ambiguous = [];
 
 for (const src of bSources) {
   const key = normalizeName(src, args.strip);
   // 先精确 key，再退化为 basename 兜底
-  const hit = buildIndex.get(key) ?? buildIndex.get(normalizeName(basename(key), []));
+  let { hit, ambiguous: ambiguousHits } = pickBuildMapCandidate(buildIndex, key);
+  if (!hit && !ambiguousHits) {
+    ({ hit, ambiguous: ambiguousHits } = pickBuildMapCandidate(
+      buildIndex,
+      normalizeName(basename(key), []),
+    ));
+  }
+  if (ambiguousHits) {
+    ambiguous.push({ src, key, hits: ambiguousHits });
+    if (args.verbose) {
+      console.log(`  ✗ 歧义匹配  ${src}  (归一为 ${key})`);
+      for (const h of ambiguousHits) console.log(`      候选: ${h.file}`);
+    }
+    continue;
+  }
   if (!hit) {
     unmatched.push(src);
     if (args.verbose) console.log(`  ✗ 未匹配  ${src}  (归一为 ${key})`);
     continue;
   }
   const cA = await new SourceMapConsumer(hit.raw);
-  // sourceFile 必须严格等于 src 在 B.sources 里的原始字符串；sourceMapPath 给 A 所在目录，
-  // 好让 A 里的相对源码路径正确解析。
-  generator.applySourceMap(cA, src, dirname(hit.file));
+  // sourceFile 必须严格等于 src 在 B.sources 里的原始字符串；sourceMapPath 用相对
+  // build-maps 根目录的路径，既能解析 A 里的相对源码路径，也避免把本机构建绝对路径写进 map。
+  generator.applySourceMap(cA, src, hit.sourceMapPath);
   destroyConsumer(cA);
   matched.push(src);
   if (args.verbose) console.log(`  ✓ 匹配    ${src}  ←  ${hit.file}`);
@@ -180,10 +226,21 @@ destroyConsumer(consumerB);
 // ---- 输出 + 诚实的总结 ----
 console.log(`\n合成结果：匹配 ${matched.length} / ${bSources.length}，未匹配 ${unmatched.length}`);
 
+if (ambiguous.length > 0) {
+  console.warn(`\n⚠ 有 ${ambiguous.length} 个 source 匹配到多个同名 map，已跳过以避免误合成：`);
+  for (const item of ambiguous.slice(0, 10)) {
+    console.warn(`    ${item.src} (归一为 ${item.key})`);
+    for (const h of item.hits.slice(0, 5)) console.warn(`      - ${h.file}`);
+    if (item.hits.length > 5) console.warn(`      …（候选共 ${item.hits.length} 个）`);
+  }
+  if (ambiguous.length > 10) console.warn(`    …（共 ${ambiguous.length} 条，加 --verbose 看全部）`);
+}
+
 if (matched.length === 0) {
   console.error(
     '\n✗ 一个都没匹配上——通常是「B.sources 的名字」和「构建 map 的文件名」对不齐。\n' +
-      '  下面是 B.sources 的前若干条，照着它们的命名调 --strip 前缀，或对齐构建产物文件名：',
+      '  下面是 B.sources 的前若干条，照着它们的命名调 --strip 前缀，或对齐构建产物文件名。\n' +
+      '  如果提示“歧义匹配”，请优先让 B.sources 带上相对路径（如 pages/foo/index.js），避免只剩 index.js：',
   );
   for (const s of bSources.slice(0, 15)) console.error(`    ${s}`);
   if (bSources.length > 15) console.error(`    …（共 ${bSources.length} 条）`);
@@ -196,7 +253,9 @@ if (unmatched.length > 0) {
   if (unmatched.length > 10) console.warn(`    …（共 ${unmatched.length} 条，加 --verbose 看全部）`);
 }
 
-writeFileSync(resolve(args.out), generator.toString(), 'utf8');
-console.log(`\n✓ 已写出合成 map：${resolve(args.out)}`);
+const outFile = resolve(args.out);
+mkdirSync(dirname(outFile), { recursive: true });
+writeFileSync(outFile, generator.toString(), 'utf8');
+console.log(`\n✓ 已写出合成 map：${outFile}`);
 console.log('  接着以 `app:///appservice.app.js` 的名字上传到 Sentry（--url-prefix "app:///" 不变）。');
 console.log('  注意：合成后精度是「两份 map 的较小值」，定位到行没问题，个别列号可能略糙。');

--- a/scripts/merge-sourcemap.mjs
+++ b/scripts/merge-sourcemap.mjs
@@ -1,0 +1,202 @@
+/**
+ * 两层 Source Map 离线合成脚本（best-effort）
+ * ===========================================
+ *
+ * 解决的问题：uni-app / Taro 等框架的小程序，代码上线前会被**压缩两次**——
+ *   1. 框架构建（webpack / vite）：你的 `.vue` / `.tsx` → 编译产物 JS（这层产出 Map A）
+ *   2. 微信上传（开发者工具 / miniprogram-ci，es6→es5 + 压缩）：编译产物 JS →
+ *      合并后的单文件 `appservice.app.js`（这层产出 Map B）
+ *
+ * 真机错误栈落在「压两次后」的 `app:///appservice.app.js` 上。只传 A 翻一半卡在
+ * 编译产物 JS、只传 B 又到不了源码——必须把两份 map **串成一份**
+ * `appservice.app.js → 源码`，再以 `app:///appservice.app.js` 名字传 Sentry。
+ *
+ * 本脚本用 mozilla `source-map` 的 `applySourceMap` 做这件事：
+ *   gen = SourceMapGenerator.fromSourceMap(B)   // 起点是外层 map B
+ *   gen.applySourceMap(A_i, <B.sources[i]>)      // 把每个内层 map A 折进去
+ *   → 输出一份 appservice.app.js → 源码 的合成 map
+ *
+ * ⚠️ 这是「带刀的菜谱」，不是「带保修的厨电」：合并算法是稳的，难点全在**喂进来的
+ * 两份 map 能否对齐**（B.sources 里的文件名 ↔ 构建 map 描述的文件名）。不同框架 /
+ * 打包器 / 版本命名都可能不一样，匹配不上时本脚本会**逐条告诉你哪对不上**，你按提示
+ * 调 --strip / 文件名即可。其它框架欢迎 PR 补匹配策略。
+ *
+ * 前置准备
+ * --------
+ * 1. 装依赖（只在用本脚本时装，不进 SDK 运行时）：
+ *      npm i -D source-map
+ * 2. 拿 Map B（外层，微信合并+压缩）：微信「We 分析 → 性能 / JS 报错 → 下载线上
+ *    Source Map」，得到 `appservice.app.js` 对应的 `.map`。注意：只有体验版 / 线上版
+ *    有，miniprogram-ci 预览的开发版拿不到；版本要与线上一致。
+ * 3. 拿 Map A（内层，框架构建）：在框架构建里**开 sourcemap**（uni-app 对 mp-weixin
+ *    默认常是关的；vite 设 `build.sourcemap: true`，webpack 设 `devtool: 'source-map'`），
+ *    得到一批编译产物 JS 的 `.map`，放在同一个目录下。
+ *
+ * 用法
+ * ----
+ *   node scripts/merge-sourcemap.mjs \
+ *     --wechat ./wechat/appservice.app.js.map \
+ *     --build-maps ./dist/dev/mp-weixin \
+ *     --out ./merged/appservice.app.js.map
+ *
+ * 可选：
+ *   --strip <prefix>   从 B.sources 名字里剥掉的前缀（可多次），常见如 webpack:// app:///
+ *   --verbose          打印每条 source 的匹配明细
+ *
+ * 产出的 `--out` 即可上传 Sentry（名字保持 `appservice.app.js` 对应关系，
+ * `--url-prefix "app:///"` 不变）。
+ */
+
+import { readFileSync, writeFileSync, readdirSync, statSync } from 'node:fs';
+import { basename, dirname, join, resolve } from 'node:path';
+
+// ---- 极简参数解析（不引第三方）----
+function parseArgs(argv) {
+  const out = { strip: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--wechat') out.wechat = argv[++i];
+    else if (a === '--build-maps') out.buildMaps = argv[++i];
+    else if (a === '--out') out.out = argv[++i];
+    else if (a === '--strip') out.strip.push(argv[++i]);
+    else if (a === '--verbose') out.verbose = true;
+    else if (a === '--help' || a === '-h') out.help = true;
+  }
+  return out;
+}
+
+const USAGE = `用法：
+  node scripts/merge-sourcemap.mjs --wechat <B.map> --build-maps <构建 map 目录> --out <合成.map> [--strip <前缀>]... [--verbose]
+
+  --wechat       微信线上 Source Map（外层 Map B：appservice.app.js → 编译产物 JS）
+  --build-maps   框架构建 Source Map 所在目录（内层 Map A：编译产物 JS → 源码），会递归查找 *.map
+  --out          合成后输出的 .map 路径
+  --strip        从 B.sources 名字里剥掉的前缀，可重复（如 --strip webpack:// --strip app:///）
+  --verbose      打印每条 source 的匹配明细
+`;
+
+const args = parseArgs(process.argv.slice(2));
+if (args.help || !args.wechat || !args.buildMaps || !args.out) {
+  console.log(USAGE);
+  process.exit(args.help ? 0 : 1);
+}
+
+// ---- 加载 source-map（缺了给清楚的安装提示，不把它塞进 SDK 依赖）----
+let SourceMapConsumer, SourceMapGenerator;
+try {
+  const sm = await import('source-map');
+  ({ SourceMapConsumer, SourceMapGenerator } = sm.default ?? sm);
+} catch {
+  console.error('✗ 缺少依赖 source-map，请先安装：\n    npm i -D source-map\n  （它只在用本脚本合成时需要，不是 SDK 运行时依赖）');
+  process.exit(1);
+}
+
+// 0.6.x 的 consumer 没有 destroy()，0.7+ 才有；两个版本都兼容。
+const destroyConsumer = (c) => {
+  if (c && typeof c.destroy === 'function') c.destroy();
+};
+
+// ---- 工具：把一个 source 名字归一成「裸文件名」用于匹配 ----
+function normalizeName(name, strip) {
+  let n = String(name).split('?')[0].split('#')[0]; // 去 query / hash
+  for (const p of strip) {
+    if (n.startsWith(p)) n = n.slice(p.length);
+  }
+  n = n.replace(/^\.?\//, ''); // 去开头的 ./ 或 /
+  return n;
+}
+
+// ---- 递归收集构建 map 目录下的所有 *.map，建索引 ----
+function collectBuildMaps(dir) {
+  const found = [];
+  const walk = (d) => {
+    for (const entry of readdirSync(d)) {
+      const full = join(d, entry);
+      const st = statSync(full);
+      if (st.isDirectory()) walk(full);
+      else if (entry.endsWith('.map')) found.push(full);
+    }
+  };
+  walk(resolve(dir));
+
+  // 建多键索引：用「map 内部 file 字段」和「文件名去掉 .map」两种 key 都指向它，
+  // 命中率更高（不同打包器有的填 file、有的不填）。
+  const index = new Map();
+  for (const file of found) {
+    let raw;
+    try {
+      raw = JSON.parse(readFileSync(file, 'utf8'));
+    } catch {
+      continue; // 不是合法 JSON map，跳过
+    }
+    const keys = new Set();
+    if (raw.file) keys.add(normalizeName(raw.file, []));
+    keys.add(normalizeName(basename(file).replace(/\.map$/, ''), []));
+    for (const k of keys) {
+      if (!index.has(k)) index.set(k, { file, raw });
+    }
+  }
+  return index;
+}
+
+// ---- 主流程 ----
+const rawB = JSON.parse(readFileSync(resolve(args.wechat), 'utf8'));
+const bSources = Array.isArray(rawB.sources) ? rawB.sources : [];
+if (bSources.length === 0) {
+  console.error('✗ 外层 map 没有 sources 字段，无法合成。确认 --wechat 传的是微信线上 appservice.app.js 的 map。');
+  process.exit(1);
+}
+
+const buildIndex = collectBuildMaps(args.buildMaps);
+console.log(`· 外层 map B：${bSources.length} 个 source`);
+console.log(`· 构建 map A：索引到 ${buildIndex.size} 个候选文件\n`);
+
+const consumerB = await new SourceMapConsumer(rawB);
+const generator = SourceMapGenerator.fromSourceMap(consumerB);
+
+const matched = [];
+const unmatched = [];
+
+for (const src of bSources) {
+  const key = normalizeName(src, args.strip);
+  // 先精确 key，再退化为 basename 兜底
+  const hit = buildIndex.get(key) ?? buildIndex.get(normalizeName(basename(key), []));
+  if (!hit) {
+    unmatched.push(src);
+    if (args.verbose) console.log(`  ✗ 未匹配  ${src}  (归一为 ${key})`);
+    continue;
+  }
+  const cA = await new SourceMapConsumer(hit.raw);
+  // sourceFile 必须严格等于 src 在 B.sources 里的原始字符串；sourceMapPath 给 A 所在目录，
+  // 好让 A 里的相对源码路径正确解析。
+  generator.applySourceMap(cA, src, dirname(hit.file));
+  destroyConsumer(cA);
+  matched.push(src);
+  if (args.verbose) console.log(`  ✓ 匹配    ${src}  ←  ${hit.file}`);
+}
+
+destroyConsumer(consumerB);
+
+// ---- 输出 + 诚实的总结 ----
+console.log(`\n合成结果：匹配 ${matched.length} / ${bSources.length}，未匹配 ${unmatched.length}`);
+
+if (matched.length === 0) {
+  console.error(
+    '\n✗ 一个都没匹配上——通常是「B.sources 的名字」和「构建 map 的文件名」对不齐。\n' +
+      '  下面是 B.sources 的前若干条，照着它们的命名调 --strip 前缀，或对齐构建产物文件名：',
+  );
+  for (const s of bSources.slice(0, 15)) console.error(`    ${s}`);
+  if (bSources.length > 15) console.error(`    …（共 ${bSources.length} 条）`);
+  process.exit(1);
+}
+
+if (unmatched.length > 0) {
+  console.warn(`\n⚠ 有 ${unmatched.length} 个 source 没匹配上，这些位置会停在「编译产物 JS」、解不到源码：`);
+  for (const s of unmatched.slice(0, 10)) console.warn(`    ${s}`);
+  if (unmatched.length > 10) console.warn(`    …（共 ${unmatched.length} 条，加 --verbose 看全部）`);
+}
+
+writeFileSync(resolve(args.out), generator.toString(), 'utf8');
+console.log(`\n✓ 已写出合成 map：${resolve(args.out)}`);
+console.log('  接着以 `app:///appservice.app.js` 的名字上传到 Sentry（--url-prefix "app:///" 不变）。');
+console.log('  注意：合成后精度是「两份 map 的较小值」，定位到行没问题，个别列号可能略糙。');


### PR DESCRIPTION
## 背景

uni-app / Taro 等框架的小程序，代码上线前会被**压缩两次**：

1. **框架构建**（webpack / vite）：`.vue` / `.tsx` → 编译产物 JS（产出 **Map A**）
2. **微信上传**（开发者工具 / miniprogram-ci，es6→es5 + 压缩）：编译产物 JS → 合并后的单文件 `appservice.app.js`（产出 **Map B**）

真机错误栈落在压两次后的 `app:///appservice.app.js` 上。只传 A 翻一半卡在编译产物 JS、只传 B 又到不了源码——必须把两份 map **串成一份** `appservice.app.js → 源码`，再以 `app:///appservice.app.js` 上传 Sentry。社区反复问到这个串联怎么做（#162、#173），而 WeChat / Sentry / uni-app / Taro 都没有一键方案。

## 改动

- **新增 `scripts/merge-sourcemap.mjs`**（best-effort）：用 mozilla `source-map` 的 `applySourceMap` 把 Map A 折进 Map B，产出 `appservice.app.js → 源码` 的合成 map。
  - **不进 SDK 运行时依赖**：`source-map` 只在用本脚本时装（`npm i -D source-map`），缺失时给清晰安装提示；
  - **兼容 `source-map` 0.6.x / 0.7+**（`destroy()` 守卫）；
  - **诚实的失败反馈**：文件名对不齐时逐条列出 `B.sources`，提示用 `--strip <前缀>` 调整或对齐产物文件名；一个都没匹配上时 dump 出 sources 帮你排查；
  - 递归扫描构建 map 目录、按 `file` 字段与文件名双键索引提高命中率。
- **`docs/SOURCEMAP_GUIDE.md`「一路解析到源码」一节**：补上脚本用法与前置准备（开框架 sourcemap、从微信 We 分析拿线上 map），并说明 best-effort 边界。

## 定位说明

这**不是 SDK 的新能力**，而是一个构建期辅助脚本 + 文档。SDK 运行时已把 `appservice.app.js` 正确归一为 `app:///appservice.app.js`；能否解析取决于上传的 map 是否对应这个合并文件。合并算法是稳的，难点在两份 map 的文件名能否对齐（因框架 / 打包器 / 版本而异），故标为 best-effort 起点，其它框架的匹配策略欢迎 PR。

## 验证

- `yarn lint` 通过（改动只涉及 `scripts/` + `docs/`，不碰 `src` / `test`）。
- **端到端验证**：用合成的两层 fixture（Map A：`compiled.js → app.vue:42`；Map B：`appservice.app.js → compiled.js`）跑脚本，合成 map 能把 `appservice.app.js (1:100)` 正确解析到 `app.vue:42`、并带回原函数名 `handleTap`。

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)