### PR TITLE
docs: 澄清网络请求默认随错误事件上报（#175）

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -403,6 +403,36 @@ export default Sentry;
 
 Both sides report to the same Sentry DSN so all errors land in a single project. For Taro, use `process.env.TARO_ENV === 'h5'` to branch similarly.
 
+### 4. Are network requests included with error events?
+
+**Yes, and it's on by default.** The SDK enables `NetworkBreadcrumbs` out of the box, which patches `wx.request` / `my.httpRequest` and records each request as a `category: xhr` breadcrumb. Those breadcrumbs ride along with the **next captured error event** (same as `@sentry/browser`), so you'll see the request trail leading up to the error in the event's **Breadcrumbs** section.
+
+- **Fields by default:** `url` / `method` / `status_code` / `duration`; failed requests are `error` level, slow ones (>3s) are `warning`.
+- **Bodies are NOT included by default.** Enable `traceNetworkBody: true` to capture request/response bodies (with built-in sensitive-field scrubbing; use `denyBodyUrls` to exclude specific URLs):
+
+  ```js
+  Sentry.init({ dsn: '...', traceNetworkBody: true });
+  ```
+
+- **No extra config for uni-app / Taro:** `uni.request` / `Taro.request` ultimately call the patched global `wx.request`, so they're captured too.
+
+If an error has no network breadcrumb, it's usually one of:
+
+1. **No request happened before the error fired** (e.g. calling `captureException` right on page load). To verify, make a request first and trigger the error in its callback:
+
+   ```js
+   wx.request({
+     url: 'https://httpbin.org/get',
+     success() {
+       Sentry.captureException(new Error('net test'));
+     },
+   });
+   ```
+
+   You should then see a `category: xhr` breadcrumb on the event.
+
+2. **`Sentry.init` ran after the request.** The patch is installed during `init`, so requests fired before `init` aren't captured. Always call `Sentry.init` before `App()` / any business request.
+
 ---
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -418,6 +418,36 @@ export default Sentry;
 
 两端上报同一个 Sentry DSN，可以在同一个 Project 里聚合查看错误。Taro 用户可以用类似的 `process.env.TARO_ENV === 'h5'` 判断分端引入。
 
+### 4. 网络请求会随错误事件一起上报吗？
+
+**会，且默认开启。** SDK 默认启用 `NetworkBreadcrumbs`，自动劫持 `wx.request` / `my.httpRequest`，把每个网络请求记成 `category: xhr` 的面包屑，随**下一个被捕获的错误事件**一起上报（与 `@sentry/browser` 默认行为一致）。在 Sentry 错误详情的 **Breadcrumbs** 区即可看到出错前的请求链路。
+
+- **默认带的字段**：`url` / `method` / `status_code` / `duration`；失败请求标 `error` 级、慢请求（>3s）标 `warning` 级。
+- **默认不带请求 / 响应体**。需要 body 时开启 `traceNetworkBody: true`（内置常见敏感字段脱敏，可用 `denyBodyUrls` 排除指定 URL）：
+
+  ```js
+  Sentry.init({ dsn: '...', traceNetworkBody: true });
+  ```
+
+- **uni-app / Taro 无需额外配置**：`uni.request` / `Taro.request` 最终都会走到被包裹的全局 `wx.request`，照常记录。
+
+如果错误里没有网络面包屑，多半是这两点之一：
+
+1. **错误触发前没发过请求**（比如一进页面就手动 `captureException`，自然没有请求面包屑）。验证方式：先发一个请求，在回调里再触发错误——
+
+   ```js
+   wx.request({
+     url: 'https://httpbin.org/get',
+     success() {
+       Sentry.captureException(new Error('net test'));
+     },
+   });
+   ```
+
+   到事件 Breadcrumbs 里应能看到 `category: xhr` 那条。
+
+2. **`Sentry.init` 晚于请求执行**：面包屑包裹在 `init` 时装上，`init` 之前发出的请求抓不到。务必让 `Sentry.init` 在 `App()` / 任何业务请求**之前**执行。
+
 ---
 
 ## 📖 文档导航

--- a/examples/uniapp/src/utils/sentry.js
+++ b/examples/uniapp/src/utils/sentry.js
@@ -29,6 +29,10 @@ Sentry.init({
   enableConsoleBreadcrumbs: true,
   enableNavigationBreadcrumbs: true,
 
+  // 网络请求面包屑默认开启（自动包裹 wx.request / uni.request，随错误事件一起上报）。
+  // 这里再开 traceNetworkBody，连请求 / 响应体也记录（内置敏感字段脱敏；可用 denyBodyUrls 排除指定 URL）。
+  traceNetworkBody: true,
+
   // 采样率：示例里全量采集，生产建议按量调低
   sampleRate: 1.0,
   tracesSampleRate: 1.0,
@@ -82,6 +86,21 @@ Sentry.setTag('miniapp.platform', 'wechat');
 // 然后到 Sentry「Issues」列表查看（与「警报规则」无关，事件照样进列表）。
 // 自建 Sentry / 真机时还需：把 Sentry 域名加入微信「request 合法域名」白名单
 // （开发者工具可临时勾选「不校验合法域名」绕过），否则请求会被拦截、事件发不出去。
+//
+// ---- 验证「网络请求是否随错误一起上报」----
+//
+// 网络面包屑默认就开，但只有在「错误触发前真的发过请求」时才会出现。
+// uni.request 最终会走到被包裹的全局 wx.request，无需额外配置。验证：
+//
+//   uni.request({
+//     url: 'https://httpbin.org/get',
+//     success() {
+//       Sentry.captureException(new Error('net test')); // 上一条请求已记成 xhr 面包屑
+//     },
+//   });
+//
+// 到事件 Breadcrumbs 区应能看到 category: xhr 那条（带 url/method/status_code/duration；
+// 开了 traceNetworkBody 还会带请求 / 响应体）。注意：Sentry.init 必须在请求之前执行。
 
 export default Sentry;
 export { Sentry };


### PR DESCRIPTION
## 背景

社区反馈「错误上报时没把网络请求一并带上」（类比 web 端默认会把 fetch/xhr 作为面包屑挂到错误事件）。在 #175 里做了源码 + 可复现模拟的排查，结论是 **SDK 行为正确、并非 bug**：

- `NetworkBreadcrumbs` **默认就启用**（`init()` 无条件挂载），把 `wx.request` / `my.httpRequest` 记成 `category: xhr` 面包屑，随下一个错误事件上报；
- **uni-app / Taro 的 `uni.request` / `Taro.request` 也被覆盖**——两者都在调用时晚绑定读全局 `wx.request`，而 SDK 的 `fill` 改的就是 `globalThis.wx.request` 本体（详见 #175 的证据链与模拟）。

缺的只是**文档**：默认带哪些字段、body 需要 `traceNetworkBody: true`、以及「没有网络面包屑」的常见原因。

## 改动

- **README.md / README.en.md** 新增 FAQ「网络请求会随错误事件一起上报吗？」：
  - 默认开启、随下一个错误事件上报、与 `@sentry/browser` 一致；
  - 默认字段 `url / method / status_code / duration`，失败标 error、慢请求（>3s）标 warning；
  - body 需 `traceNetworkBody: true`（内置脱敏 + `denyBodyUrls`）；
  - uni-app / Taro 无需额外配置；
  - 「没有网络面包屑」两个常见原因（触发前没发请求 / `init` 晚于请求）+ 验证代码。
- **examples/uniapp**：`init` 开启 `traceNetworkBody` 演示，并补「如何验证网络面包屑」说明。

## 验证

- `yarn lint` 通过（改动仅 README + 示例，不涉及 `src` / `test`）。
- 结论的源码与模拟证据见 #175。

Refs #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)