### PR TITLE
docs: uni-app（Vue）组件错误上报指引；澄清 Taro 框架

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -433,6 +433,54 @@ If an error has no network breadcrumb, it's usually one of:
 
 2. **`Sentry.init` ran after the request.** The patch is installed during `init`, so requests fired before `init` aren't captured. Always call `Sentry.init` before `App()` / any business request.
 
+### 5. Errors in uni-app (Vue) components aren't reported / reporting rate is very low?
+
+With **uni-app** (Vue under the hood) you may hit "`sampleRate` is 1 but only an occasional error shows up". The reason: **Vue catches errors thrown inside components (render / lifecycle / watchers / methods invoked from `@click`) with its own error handler — by default it only logs to console and does NOT bubble them to `wx.onError`**, so the SDK never sees them. Only errors that escape Vue (e.g. `setTimeout` callbacks, unhandled promises, hard crashes) get through, which is why reporting looks sporadic.
+
+Wire Vue's `errorHandler` to Sentry so component errors are reported:
+
+**uni-app Vue3 (`main.js` / `main.ts`, the current default):**
+
+```js
+import Sentry from '@/utils/sentry'; // your sentry-miniapp init wrapper
+import { createSSRApp } from 'vue';
+import App from './App.vue';
+
+export function createApp() {
+  const app = createSSRApp(App);
+  app.config.errorHandler = (err, instance, info) => {
+    Sentry.captureException(err, { extra: { lifecycleHook: info } });
+    console.error(err);
+  };
+  return { app };
+}
+```
+
+**Vue2 (older uni-app):**
+
+```js
+Vue.config.errorHandler = (err, vm, info) => {
+  Sentry.captureException(err);
+  console.error(err);
+};
+```
+
+> **Taro is not Vue.** Taro defaults to **React** (and also supports Vue). With **Vue**, wire `errorHandler` the same way; with **React**, React does not silently swallow component errors like Vue (an uncaught render error propagates upward), but you can add an **Error Boundary** to forward render errors to Sentry with richer context:
+>
+> ```jsx
+> class SentryBoundary extends React.Component {
+>   componentDidCatch(error, info) {
+>     Sentry.captureException(error, { extra: info });
+>   }
+>   render() {
+>     return this.props.children;
+>   }
+> }
+> // Wrap your root: <SentryBoundary><App /></SentryBoundary>
+> ```
+
+This also improves delivery: once `errorHandler` / the boundary catches the error the app keeps running, so the in-flight report request completes (a hard crash would otherwise kill it).
+
 ---
 
 ## Documentation

--- a/README.md
+++ b/README.md
@@ -448,6 +448,54 @@ export default Sentry;
 
 2. **`Sentry.init` 晚于请求执行**：面包屑包裹在 `init` 时装上，`init` 之前发出的请求抓不到。务必让 `Sentry.init` 在 `App()` / 任何业务请求**之前**执行。
 
+### 5. uni-app（Vue）组件内的错误没上报 / 上报率很低？
+
+如果你用 **uni-app**（底层是 Vue），可能遇到「`sampleRate` 设成 1，却只偶尔上报一条」的情况。原因：**Vue 会用自己的错误处理接住组件内（render / 生命周期 / watch / 模板 `@click` 调用的方法）抛出的错误，默认只打印 console，不会再冒泡到 `wx.onError`**，于是 SDK 捕获不到。能上来的只剩「逃逸出 Vue」的那部分（`setTimeout` 回调、未处理 promise、硬崩溃），所以看起来只偶尔上报。
+
+把 Vue 的 `errorHandler` 接到 Sentry，组件内错误就会上报：
+
+**uni-app Vue3（`main.js` / `main.ts`，现在默认）：**
+
+```js
+import Sentry from '@/utils/sentry'; // 你封装的 sentry-miniapp 初始化
+import { createSSRApp } from 'vue';
+import App from './App.vue';
+
+export function createApp() {
+  const app = createSSRApp(App);
+  app.config.errorHandler = (err, instance, info) => {
+    Sentry.captureException(err, { extra: { lifecycleHook: info } });
+    console.error(err);
+  };
+  return { app };
+}
+```
+
+**Vue2（uni-app 旧版）：**
+
+```js
+Vue.config.errorHandler = (err, vm, info) => {
+  Sentry.captureException(err);
+  console.error(err);
+};
+```
+
+> **Taro 不是 Vue。** Taro 默认用 **React**（也支持 Vue）。用 **Vue** 时同理接 `errorHandler`；用 **React** 时，React 不会像 Vue 那样静默吞掉组件错误（未捕获的渲染错误会向上抛），但你可以加一个**错误边界（Error Boundary）**把渲染错误更完整地转给 Sentry：
+>
+> ```jsx
+> class SentryBoundary extends React.Component {
+>   componentDidCatch(error, info) {
+>     Sentry.captureException(error, { extra: info });
+>   }
+>   render() {
+>     return this.props.children;
+>   }
+> }
+> // 用它包住根组件：<SentryBoundary><App /></SentryBoundary>
+> ```
+
+接上之后还顺带提升送达率——`errorHandler` / 错误边界接住后应用不崩，上报请求能正常发完（硬崩溃会把还在飞的上报请求一起带走）。
+
 ---
 
 ## 📖 文档导航

--- a/examples/uniapp/src/main.js
+++ b/examples/uniapp/src/main.js
@@ -3,10 +3,21 @@ import App from './App.vue';
 
 // 在创建应用实例前导入 Sentry 封装，确保 Sentry.init 尽早执行、
 // 能捕获到应用启动阶段的异常。集成细节见 ./utils/sentry.js。
-import './utils/sentry';
+import Sentry from './utils/sentry';
 
 export function createApp() {
   const app = createSSRApp(App);
+
+  // 关键：uni-app 底层是 Vue，组件内（render / 生命周期 / watch / 模板 @click 调用的方法）
+  // 抛出的错误会被 Vue 自己的错误处理接住、只打印 console，不会冒泡到 wx.onError，
+  // SDK 默认捕获不到——这是「sampleRate 设了 1 却只偶尔上报一条」的常见根因。
+  // 把 Vue 的 errorHandler 接到 Sentry，组件内错误才会上报。
+  // Vue2（uni-app 旧版）改用 Vue.config.errorHandler，写法见 README「常见问题」。
+  app.config.errorHandler = (err, instance, info) => {
+    Sentry.captureException(err, { extra: { lifecycleHook: info } });
+    console.error(err); // 保留本地打印，方便开发期排查
+  };
+
   return {
     app,
   };


### PR DESCRIPTION
## 背景

**uni-app 底层是 Vue。** 组件内（render / 生命周期 / watch / 模板 `@click` 调用的方法）抛出的错误会被 Vue 自己的 `errorHandler` 接住，默认只打印 console、不冒泡到 `wx.onError`，于是 SDK 默认捕获不到。能上来的只剩逃逸出 Vue 的那部分（`setTimeout`、未处理 promise、硬崩溃），表现就是「`sampleRate` 设了 1 却只偶尔上报一条」——这正是 #18 / #168 社区反馈的根因。

此前已诊断过，但修法一直留在讨论里没落地；连我们自己的 uni-app 示例都没接 `errorHandler`，组件里抛错也不会上报。

> 注：**Taro 不是 Vue**，默认用 React（也支持 Vue）。本 PR 文档已据此区分：Taro + Vue 同理接 `errorHandler`；Taro + React 用 Error Boundary（`componentDidCatch`）转给 Sentry。

## 改动

- **`examples/uniapp/src/main.js`**：`createApp` 里接 `app.config.errorHandler → Sentry.captureException`（带 `lifecycleHook` 上下文），并把 `import './utils/sentry'` 改为 `import Sentry from './utils/sentry'` 以拿到默认导出（仍保留 init 的副作用）。
- **README.md / README.en.md** 新增 FAQ「uni-app（Vue）组件内的错误没上报 / 上报率很低？」：
  - 讲清 Vue 吞错机制；
  - 给出 Vue3（`app.config.errorHandler`）与 Vue2（`Vue.config.errorHandler`）两种接法；
  - 澄清 **Taro 默认是 React（非 Vue）**：用 Vue 时同理，用 React 时用 Error Boundary；
  - 说明顺带提升送达率（接住后应用不崩，上报请求能发完）。

## 验证

- `yarn lint` 通过（改动仅示例 + README，不涉及 `src` / `test`）。
- 示例 `main.js` 改动后 `createApp` 仍正常导出，且组件内错误会经 `errorHandler` 上报。

Refs #18, #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)