### PR TITLE
docs(examples): 新增 Taro 4(React) 集成示例

### DIFF
--- a/examples/taro/.gitignore
+++ b/examples/taro/.gitignore
@@ -1,0 +1,12 @@
+# Taro 示例的本地依赖与构建产物，不进仓库
+node_modules/
+dist/
+.temp/
+.swc/
+.DS_Store
+*.log
+
+# 示例锁文件不入库：避免重型工具链的传递依赖持续触发 Dependabot 告警
+# （示例工程非发布产物，fresh npm install 即可，无需锁版本）
+package-lock.json
+yarn.lock

--- a/examples/taro/README.md
+++ b/examples/taro/README.md
@@ -1,0 +1,78 @@
+# sentry-miniapp · Taro(React) 集成示例
+
+基于 **Taro 4（React + TypeScript，webpack5）** 的 `sentry-miniapp` 集成示例，演示在微信小程序端如何初始化 SDK、上报异常、追踪性能、采集网络面包屑，并用 **React 错误边界** 捕获组件渲染错误。
+
+> 本示例只演示**小程序端**（`weapp`）。Taro 默认用 React；若你的 Taro 工程用 Vue，集成方式与 [`examples/uniapp`](../uniapp) 一致（`app.config.errorHandler`）。要同时监控 H5 端，请参考仓库根 `README.md` 的「uni-app / Taro」一节，用 `process.env.TARO_ENV === 'h5'` 按端引入 `@sentry/browser`。
+
+## 演示内容
+
+| 页面 | 演示能力 |
+|------|----------|
+| **概览** (`pages/index`) | SDK 初始化、页面生命周期面包屑、`Taro.request` 走包裹后的 `wx.request` 产生 `xhr` 网络面包屑 |
+| **实验室** (`pages/test`) | `captureException`（同步）、未处理 Promise 异常、`captureMessage`、以及**组件渲染错误 → React 错误边界 → 上报** |
+
+集成核心都在 [`src/utils/sentry.ts`](./src/utils/sentry.ts)；错误边界在 [`src/components/SentryBoundary.tsx`](./src/components/SentryBoundary.tsx)，于 [`src/app.tsx`](./src/app.tsx) 包住整个应用。
+
+## 重点：Taro(React) 的组件错误用「错误边界」上报
+
+Taro 默认是 **React**，不是 Vue。React 不像 Vue 那样静默吞掉组件错误（未捕获的渲染错误会向上抛），但**用错误边界（Error Boundary）能把渲染错误更完整地上报**（带 `componentStack`）、并避免整页白屏：
+
+```tsx
+class SentryBoundary extends Component {
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+  componentDidCatch(error, info) {
+    Sentry.captureException(error, { extra: { componentStack: info.componentStack } });
+  }
+  render() {
+    return this.state.hasError ? <View>页面出错了，已上报</View> : this.props.children;
+  }
+}
+// 用它包住根组件：<SentryBoundary>{children}</SentryBoundary>
+```
+
+> 错误边界只能捕获**渲染期**错误；事件回调 / `setTimeout` / 异步里的错误捕获不到——那些直接 `try/catch` 后 `Sentry.captureException`，或交给 SDK 的全局 / TryCatch 集成。这与 uni-app(Vue) 的 `app.config.errorHandler` 是同一思路的两个框架版本（见仓库根 README「常见问题」第 5 条）。
+
+## 运行
+
+```bash
+# 在本目录下
+npm install
+
+# 编译微信小程序（产出到 dist/，--watch 持续编译）
+npm run dev:weapp
+# 或一次性构建
+npm run build:weapp
+```
+
+然后用**微信开发者工具**导入本目录（`project.config.json` 的 `miniprogramRoot` 指向 `dist/`），即可预览。点按钮后到 Sentry「Issues」/「Performance」查看事件与面包屑。
+
+> `project.config.json` 里 `es6` / `minified` 设为 `false`：交给 Taro 编译，避免微信开发者工具二次压缩导致 Source Map 错位（见仓库 `docs/SOURCEMAP_GUIDE.md`）。
+
+## DSN 配置
+
+`src/utils/sentry.ts` 里的 `DSN` 与 `examples/wxapp`、`examples/uniapp` **共用同一个演示 Sentry 项目**，开箱即可上报。换成你自己项目的 DSN 即可在你的后台观察数据。
+
+> 三个示例共用同一项目，后台事件会混在一起。本示例给所有事件打了 `app.framework: taro-react` 标签，需要区分时在 Sentry 后台按 `app.framework:taro-react` 过滤即可。
+
+微信开发者工具中还需把 Sentry 上报域名加入小程序后台「合法域名」（开发期可临时勾选「不校验合法域名」）。
+
+## Source Map（真机）
+
+Taro 真机错误栈是微信合并后的 `appservice.app.js`，**分页 Source Map 解不出**，需要两层 map 串联。详见仓库 [`docs/SOURCEMAP_GUIDE.md`](../../docs/SOURCEMAP_GUIDE.md) 的「跨端框架的两层 Source Map 串联」一节与 [`scripts/merge-sourcemap.mjs`](../../scripts/merge-sourcemap.mjs)。
+
+## 用本地源码而非已发布版
+
+示例默认依赖已发布的 `sentry-miniapp`（`package.json` 中 `"sentry-miniapp": "^1.11.0"`）。
+若想验证仓库当前源码，先在仓库根执行 `yarn build`，再把本目录依赖改为：
+
+```jsonc
+"sentry-miniapp": "file:../.."
+```
+
+重新 `npm install` 即可。
+
+## 说明
+
+本示例工程作为参考工程独立维护，不接入仓库 CI；`node_modules/`、`dist/`、锁文件等已在 `.gitignore` 中忽略，`fresh npm install` 即可运行。

--- a/examples/taro/babel.config.js
+++ b/examples/taro/babel.config.js
@@ -1,0 +1,14 @@
+// Taro(React) 标准 Babel 配置。
+// babel-preset-taro 更多选项和默认值：https://docs.taro.zone/docs/babel-config
+module.exports = {
+  presets: [
+    [
+      'taro',
+      {
+        framework: 'react',
+        ts: true,
+        compiler: 'webpack5',
+      },
+    ],
+  ],
+};

--- a/examples/taro/config/dev.ts
+++ b/examples/taro/config/dev.ts
@@ -1,0 +1,10 @@
+import type { UserConfigExport } from '@tarojs/cli';
+
+export default {
+  logger: {
+    quiet: false,
+    stats: true,
+  },
+  mini: {},
+  h5: {},
+} satisfies UserConfigExport<'webpack5'>;

--- a/examples/taro/config/index.ts
+++ b/examples/taro/config/index.ts
@@ -1,0 +1,87 @@
+import { defineConfig, type UserConfigExport } from '@tarojs/cli';
+import TsconfigPathsPlugin from 'tsconfig-paths-webpack-plugin';
+import devConfig from './dev';
+import prodConfig from './prod';
+
+// https://taro-docs.jd.com/docs/next/config#defineconfig-辅助函数
+export default defineConfig<'webpack5'>(async (merge) => {
+  const baseConfig: UserConfigExport<'webpack5'> = {
+    projectName: 'sentry-miniapp-taro-example',
+    date: '2026-6-11',
+    designWidth: 750,
+    deviceRatio: {
+      640: 2.34 / 2,
+      750: 1,
+      375: 2,
+      828: 1.81 / 2,
+    },
+    sourceRoot: 'src',
+    outputRoot: 'dist',
+    plugins: ['@tarojs/plugin-generator'],
+    defineConstants: {},
+    copy: {
+      patterns: [],
+      options: {},
+    },
+    framework: 'react',
+    compiler: 'webpack5',
+    cache: {
+      enable: false,
+    },
+    mini: {
+      postcss: {
+        pxtransform: {
+          enable: true,
+          config: {},
+        },
+        cssModules: {
+          enable: false,
+          config: {
+            namingPattern: 'module',
+            generateScopedName: '[name]__[local]___[hash:base64:5]',
+          },
+        },
+      },
+      webpackChain(chain) {
+        chain.resolve.plugin('tsconfig-paths').use(TsconfigPathsPlugin);
+      },
+      // 想上传 Source Map 到 Sentry 时，参考仓库 docs/SOURCEMAP_GUIDE.md：
+      // Taro 真机错误栈是合并后的 appservice.app.js，需要两层 map 串联，
+      // 详见该文档「跨端框架的两层 Source Map 串联」一节与 scripts/merge-sourcemap.mjs。
+    },
+    h5: {
+      publicPath: '/',
+      staticDirectory: 'static',
+      output: {
+        filename: 'js/[name].[hash:8].js',
+        chunkFilename: 'js/[name].[chunkhash:8].js',
+      },
+      miniCssExtractPluginOption: {
+        ignoreOrder: true,
+        filename: 'css/[name].[hash].css',
+        chunkFilename: 'css/[name].[chunkhash].css',
+      },
+      postcss: {
+        autoprefixer: {
+          enable: true,
+          config: {},
+        },
+        cssModules: {
+          enable: false,
+          config: {
+            namingPattern: 'module',
+            generateScopedName: '[name]__[local]___[hash:base64:5]',
+          },
+        },
+      },
+      webpackChain(chain) {
+        chain.resolve.plugin('tsconfig-paths').use(TsconfigPathsPlugin);
+      },
+    },
+  };
+
+  if (process.env.NODE_ENV === 'development') {
+    return merge({}, baseConfig, devConfig);
+  }
+  return merge({}, baseConfig, prodConfig);
+});

--- a/examples/taro/config/prod.ts
+++ b/examples/taro/config/prod.ts
@@ -1,0 +1,6 @@
+import type { UserConfigExport } from '@tarojs/cli';
+
+export default {
+  mini: {},
+  h5: {},
+} satisfies UserConfigExport<'webpack5'>;

--- a/examples/taro/package.json
+++ b/examples/taro/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "sentry-miniapp-taro-example",
+  "version": "1.0.0",
+  "private": true,
+  "description": "sentry-miniapp 在 Taro(React + TypeScript) 中的集成示例（微信小程序端）",
+  "templateInfo": {
+    "name": "default",
+    "typescript": true,
+    "css": "sass",
+    "framework": "react"
+  },
+  "scripts": {
+    "build:weapp": "taro build --type weapp",
+    "dev:weapp": "npm run build:weapp -- --watch"
+  },
+  "browserslist": [
+    "defaults and fully supports es6-module",
+    "maintained node versions"
+  ],
+  "author": "",
+  "dependencies": {
+    "@babel/runtime": "^7.24.4",
+    "@tarojs/components": "4.2.0",
+    "@tarojs/helper": "4.2.0",
+    "@tarojs/plugin-framework-react": "4.2.0",
+    "@tarojs/plugin-platform-weapp": "4.2.0",
+    "@tarojs/react": "4.2.0",
+    "@tarojs/runtime": "4.2.0",
+    "@tarojs/shared": "4.2.0",
+    "@tarojs/taro": "4.2.0",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
+    "sentry-miniapp": "^1.11.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.24.4",
+    "@babel/plugin-transform-class-properties": "7.25.9",
+    "@babel/preset-react": "^7.24.1",
+    "@pmmmwh/react-refresh-webpack-plugin": "^0.5.5",
+    "@tarojs/cli": "4.2.0",
+    "@tarojs/plugin-generator": "4.2.0",
+    "@tarojs/taro-loader": "4.2.0",
+    "@tarojs/webpack5-runner": "4.2.0",
+    "@types/node": "^18",
+    "@types/react": "^18.0.0",
+    "@types/webpack-env": "^1.13.6",
+    "babel-preset-taro": "4.2.0",
+    "postcss": "^8.5.6",
+    "react-refresh": "^0.14.0",
+    "sass": "^1.75.0",
+    "tsconfig-paths-webpack-plugin": "^4.1.0",
+    "typescript": "^5.4.5",
+    "webpack": "5.91.0"
+  }
+}

--- a/examples/taro/project.config.json
+++ b/examples/taro/project.config.json
@@ -1,0 +1,19 @@
+{
+  "miniprogramRoot": "dist/",
+  "projectname": "sentry-miniapp-taro-example",
+  "description": "sentry-miniapp 在 Taro(React) 中的集成示例",
+  "appid": "touristappid",
+  "setting": {
+    "urlCheck": false,
+    "es6": false,
+    "enhance": false,
+    "postcss": false,
+    "minified": false,
+    "babelSetting": {
+      "ignore": [],
+      "disablePlugins": [],
+      "outputPath": ""
+    }
+  },
+  "compileType": "miniprogram"
+}

--- a/examples/taro/src/app.config.ts
+++ b/examples/taro/src/app.config.ts
@@ -1,0 +1,9 @@
+export default defineAppConfig({
+  pages: ['pages/index/index', 'pages/test/test'],
+  window: {
+    backgroundTextStyle: 'light',
+    navigationBarBackgroundColor: '#ffffff',
+    navigationBarTitleText: 'sentry-miniapp · Taro',
+    navigationBarTextStyle: 'black',
+  },
+});

--- a/examples/taro/src/app.scss
+++ b/examples/taro/src/app.scss
@@ -1,0 +1,4 @@
+page {
+  background: #f5f6f7;
+  font-family: -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Helvetica, sans-serif;
+}

--- a/examples/taro/src/app.tsx
+++ b/examples/taro/src/app.tsx
@@ -1,0 +1,21 @@
+import { PropsWithChildren } from 'react';
+import { useLaunch } from '@tarojs/taro';
+import Sentry from './utils/sentry'; // 引入即执行 Sentry.init（尽早初始化，先于业务请求）
+import SentryBoundary from './components/SentryBoundary';
+import './app.scss';
+
+function App({ children }: PropsWithChildren) {
+  useLaunch(() => {
+    Sentry.addBreadcrumb({
+      category: 'app.lifecycle',
+      message: 'App onLaunch',
+      level: 'info',
+    });
+  });
+
+  // 用错误边界包住整个应用：React 组件渲染 / 生命周期里抛出的错误会被捕获并上报。
+  // 这是 Taro(React) 对应 uni-app(Vue) errorHandler 的做法（见仓库 README「常见问题」）。
+  return <SentryBoundary>{children}</SentryBoundary>;
+}
+
+export default App;

--- a/examples/taro/src/components/SentryBoundary.tsx
+++ b/examples/taro/src/components/SentryBoundary.tsx
@@ -1,0 +1,47 @@
+import { Component, ErrorInfo, ReactNode } from 'react';
+import { View, Text } from '@tarojs/components';
+import Sentry from '../utils/sentry';
+
+interface Props {
+  children: ReactNode;
+}
+interface State {
+  hasError: boolean;
+}
+
+/**
+ * React 错误边界：捕获子树「渲染 / 生命周期」里抛出的错误，转交 Sentry 上报，并给用户兜底 UI。
+ *
+ * 为什么需要它：Taro 默认用 React。React 不像 Vue 那样静默吞掉组件错误（未捕获的渲染错误会
+ * 向上抛），但用错误边界能把渲染错误更完整地上报（带 componentStack），并避免整页白屏。
+ * 这是 Taro(React) 对应 uni-app(Vue) `app.config.errorHandler` 的做法（见仓库 README「常见问题」）。
+ *
+ * 注意：错误边界只能捕获「渲染期」错误，捕获不到事件回调 / setTimeout / 异步里的错误——
+ * 那些请直接 try/catch 后 `Sentry.captureException`，或交给 SDK 的全局 / TryCatch 集成。
+ */
+export default class SentryBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    Sentry.captureException(error, {
+      extra: { componentStack: info.componentStack },
+    });
+    // 保留本地打印，方便开发期排查
+    console.error(error);
+  }
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      return (
+        <View style={{ padding: '40rpx', color: '#c0392b' }}>
+          <Text>页面渲染出错，已上报 Sentry。</Text>
+        </View>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/examples/taro/src/pages/index/index.config.ts
+++ b/examples/taro/src/pages/index/index.config.ts
@@ -1,0 +1,3 @@
+export default definePageConfig({
+  navigationBarTitleText: '概览',
+});

--- a/examples/taro/src/pages/index/index.tsx
+++ b/examples/taro/src/pages/index/index.tsx
@@ -1,0 +1,43 @@
+import { View, Text, Button } from '@tarojs/components';
+import Taro, { useLoad } from '@tarojs/taro';
+import Sentry from '../../utils/sentry';
+
+export default function Index() {
+  useLoad(() => {
+    Sentry.addBreadcrumb({
+      category: 'page.lifecycle',
+      message: 'index onLoad',
+      level: 'info',
+    });
+  });
+
+  // Taro.request 最终走被包裹的全局 wx.request，会记成 xhr 面包屑（随下一个错误事件上报）。
+  const sendRequest = () => {
+    Taro.request({
+      url: 'https://httpbin.org/get',
+      success: () => {
+        Sentry.captureMessage('网络请求成功——到 Sentry 事件的 Breadcrumbs 看 xhr 那条', 'info');
+        Taro.showToast({ title: '已上报，看后台', icon: 'none' });
+      },
+      fail: () => {
+        Taro.showToast({ title: '请求失败（也会记面包屑）', icon: 'none' });
+      },
+    });
+  };
+
+  return (
+    <View style={{ padding: '32rpx' }}>
+      <Text style={{ fontSize: '32rpx', fontWeight: 'bold' }}>sentry-miniapp · Taro(React) 集成示例</Text>
+      <View style={{ marginTop: '16rpx', color: '#666' }}>
+        <Text>SDK 已在 src/utils/sentry.ts 初始化，下面的操作都会在 Sentry 后台留下事件 / 面包屑。</Text>
+      </View>
+
+      <Button style={{ marginTop: '32rpx' }} onClick={sendRequest}>
+        发一个网络请求（演示 xhr 面包屑）
+      </Button>
+      <Button style={{ marginTop: '16rpx' }} onClick={() => Taro.navigateTo({ url: '/pages/test/test' })}>
+        去「实验室」试各种上报
+      </Button>
+    </View>
+  );
+}

--- a/examples/taro/src/pages/test/test.config.ts
+++ b/examples/taro/src/pages/test/test.config.ts
@@ -1,0 +1,3 @@
+export default definePageConfig({
+  navigationBarTitleText: '实验室',
+});

--- a/examples/taro/src/pages/test/test.tsx
+++ b/examples/taro/src/pages/test/test.tsx
@@ -1,0 +1,61 @@
+import { useState } from 'react';
+import { View, Text, Button } from '@tarojs/components';
+import Taro from '@tarojs/taro';
+import Sentry from '../../utils/sentry';
+import SentryBoundary from '../../components/SentryBoundary';
+
+// 一个在「渲染时」抛错的组件，用来演示 SentryBoundary 捕获组件错误并上报。
+function Boom() {
+  throw new Error('Taro 组件渲染错误（应被 SentryBoundary 捕获并上报）');
+  // eslint-disable-next-line no-unreachable
+  return null;
+}
+
+export default function Test() {
+  const [boom, setBoom] = useState(false);
+
+  const captureSync = () => {
+    Sentry.captureException(new Error('手动 captureException（同步）'));
+    Taro.showToast({ title: '已上报 exception', icon: 'none' });
+  };
+
+  const unhandledRejection = () => {
+    // 未处理的 Promise 异常：由 SDK 的全局 onUnhandledRejection 捕获
+    Promise.reject(new Error('未处理的 Promise 异常'));
+    Taro.showToast({ title: '已触发未处理 rejection', icon: 'none' });
+  };
+
+  const captureMsg = () => {
+    Sentry.captureMessage('captureMessage 测试（error 级）', 'error');
+    Taro.showToast({ title: '已上报 message', icon: 'none' });
+  };
+
+  return (
+    <View style={{ padding: '32rpx' }}>
+      <Text style={{ fontSize: '30rpx', fontWeight: 'bold' }}>实验室：各种上报方式</Text>
+
+      <Button style={{ marginTop: '24rpx' }} onClick={captureSync}>
+        captureException（同步异常）
+      </Button>
+      <Button style={{ marginTop: '16rpx' }} onClick={unhandledRejection}>
+        未处理 Promise 异常
+      </Button>
+      <Button style={{ marginTop: '16rpx' }} onClick={captureMsg}>
+        captureMessage
+      </Button>
+      <Button style={{ marginTop: '16rpx' }} type="warn" onClick={() => setBoom(true)}>
+        触发组件渲染错误（走 Error Boundary）
+      </Button>
+
+      <View style={{ marginTop: '24rpx', color: '#888', fontSize: '24rpx' }}>
+        <Text>
+          最后一个按钮：点了之后下方的 Boom 在渲染时抛错 → 被这里的 SentryBoundary 捕获并
+          captureException，仅该区域显示兜底 UI、整页仍可用。这演示了「组件渲染错误」如何上报。
+        </Text>
+      </View>
+
+      {/* 局部错误边界：只兜住 Boom 这块，便于演示而不影响整页 */}
+      <SentryBoundary>{boom ? <Boom /> : null}</SentryBoundary>
+    </View>
+  );
+}

--- a/examples/taro/src/utils/sentry.ts
+++ b/examples/taro/src/utils/sentry.ts
@@ -1,0 +1,61 @@
+/**
+ * Sentry 集成封装（Taro + React，微信小程序端）
+ *
+ * 本示例只演示小程序端集成，直接引入 sentry-miniapp。
+ * 若 Taro 工程还要监控 H5 端，请按仓库根 README 的「uni-app / Taro」一节，
+ * 用 `process.env.TARO_ENV === 'h5'` 判断分端引入 `@sentry/browser`。
+ */
+import * as Sentry from 'sentry-miniapp';
+
+// 与 examples/wxapp、examples/uniapp 共用同一个演示 Sentry 项目 DSN，开箱即可上报。
+// 换成你自己项目的 DSN 后，即可在你的后台观察数据。
+const DSN = 'https://47703e01ba4344b8b252c15e8fd980fd@o113510.ingest.us.sentry.io/1528228';
+
+Sentry.init({
+  dsn: DSN,
+  environment: 'production',
+  debug: false,
+
+  // 小程序平台标识
+  platform: 'wechat',
+  enableSystemInfo: true,
+  enableUserInteractionBreadcrumbs: true,
+  enableConsoleBreadcrumbs: true,
+  enableNavigationBreadcrumbs: true,
+
+  // 采样率：示例里全量采集，生产建议按量调低
+  sampleRate: 1.0,
+  tracesSampleRate: 1.0,
+
+  // 网络请求面包屑默认开启（自动包裹 wx.request；Taro.request 最终也走它）。
+  // 这里再开 traceNetworkBody，连请求 / 响应体也记录（内置敏感字段脱敏；可用 denyBodyUrls 排除指定 URL）。
+  traceNetworkBody: true,
+
+  // 事件体积保护：限制面包屑数量、裁剪过大的上下文，避免请求体过大被拒
+  beforeSend(event) {
+    if (event.breadcrumbs && event.breadcrumbs.length > 20) {
+      event.breadcrumbs = event.breadcrumbs.slice(-20);
+    }
+    const contexts = event.contexts;
+    const size = JSON.stringify(event).length;
+    if (size > 200000 && contexts) {
+      Object.keys(contexts).forEach((key) => {
+        if (!['device', 'app', 'os', 'miniapp', 'trace'].includes(key)) {
+          delete contexts[key];
+        }
+      });
+    }
+    return event;
+  },
+});
+
+// 默认集成已包含：自动异常捕获、性能监控、Source Map 路径归一化、网络面包屑、
+// Session 与网络状态监控。无需手动传 integrations；只有完全接管集成列表时才传（会覆盖默认）。
+
+// 全局用户与标签（演示用，生产请按真实登录态设置）
+Sentry.setUser({ id: 'taro-demo-user', username: 'taro_demo' });
+Sentry.setTag('app.framework', 'taro-react');
+Sentry.setTag('miniapp.platform', 'wechat');
+
+export default Sentry;
+export { Sentry };

--- a/examples/taro/tsconfig.json
+++ b/examples/taro/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "commonjs",
+    "removeComments": false,
+    "preserveConstEnums": true,
+    "moduleResolution": "node",
+    "experimentalDecorators": true,
+    "noImplicitAny": false,
+    "allowSyntheticDefaultImports": true,
+    "outDir": "lib",
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "strictNullChecks": true,
+    "sourceMap": true,
+    "rootDir": ".",
+    "jsx": "react-jsx",
+    "allowJs": true,
+    "resolveJsonModule": true,
+    "typeRoots": ["node_modules/@types"],
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["./src", "./types", "./config"],
+  "compileOnSave": false
+}

--- a/examples/taro/types/global.d.ts
+++ b/examples/taro/types/global.d.ts
@@ -1,0 +1,23 @@
+/// <reference types="@tarojs/taro" />
+
+declare module '*.png';
+declare module '*.gif';
+declare module '*.jpg';
+declare module '*.jpeg';
+declare module '*.svg';
+declare module '*.css';
+declare module '*.less';
+declare module '*.scss';
+declare module '*.sass';
+declare module '*.styl';
+
+declare namespace NodeJS {
+  interface ProcessEnv {
+    /** NODE 内置环境变量, 会影响到最终构建生成产物 */
+    NODE_ENV: 'development' | 'production';
+    /** 当前构建的平台 */
+    TARO_ENV: 'weapp' | 'swan' | 'alipay' | 'h5' | 'rn' | 'tt' | 'qq' | 'jd' | 'harmony' | 'jdrn';
+    /** 当前构建的小程序 appid */
+    TARO_APP_ID: string;
+  }
+}


### PR DESCRIPTION
## 背景

`examples/` 下原有 `wxapp`（原生）、`uniapp`（Vue3），缺 **Taro**。本 PR 补一个 **Taro 4（React + TypeScript，webpack5，微信小程序端）** 的集成示例，并落地此前写进 README FAQ 的 Taro+React 指引（用 **React 错误边界** 上报组件错误）。

> **为什么是 Taro 4**：npm 上周下载量 Taro 4.x 占 ~64%、3.x ~30%，4.x 是当前主流（4.0 已发布约 2 年）。Taro 默认用 React（也支持 Vue）；Taro+Vue 的接法与 `examples/uniapp` 一致。

## 演示内容

| 页面 | 能力 |
|------|------|
| 概览 `pages/index` | SDK 初始化、页面生命周期面包屑、`Taro.request` → 包裹后的 `wx.request` 产生 `xhr` 面包屑 |
| 实验室 `pages/test` | `captureException`、未处理 Promise、`captureMessage`、**组件渲染错误 → React 错误边界 → 上报** |

核心：`src/components/SentryBoundary.tsx`（`componentDidCatch → captureException`）在 `src/app.tsx` 包住整个应用——对应 uni-app(Vue) 的 `errorHandler`（README「常见问题」第 5 条）。

## 约定

- 工程结构照 **Taro 4 官方默认模板**：`config/*.ts` 用 `defineConfig`、global 声明放 `types/`、`babel.config.js` 带 `compiler: 'webpack5'`、`tsconfig.json` 含 `paths` / `strictNullChecks` / `noUnused*`。
- 镜像 `uniapp` 示例：`src/utils/sentry.ts` 共用演示 DSN、`traceNetworkBody: true`、`app.framework: taro-react` 标签。
- `project.config.json` 关 `es6` / `minified`（交给 Taro 编译，避免二次压缩错位 Source Map）。
- 不提交 `node_modules` / `dist` / 锁文件（`.gitignore`），`fresh npm install` 即可。

## 验证

- 依赖版本均**从 npm 核实**：Taro `4.2.0`（latest），周边包（`@tarojs/taro-loader`、`plugin-generator`、`tsconfig-paths-webpack-plugin` 等）均存在。
- **`tsc --noEmit` 通过**：在真实 `@tarojs/taro@4.2.0` + `react@18` + `sentry-miniapp` 类型下，源码类型全部通过（exit 0）。
- 受限于环境未跑完整 `taro build`（重型工具链 + 需微信开发者工具）；config 按官方模板编写。

🤖 Generated with [Claude Code](https://claude.com/claude-code)