### PR TITLE
docs(website): 新增 Taro / uni-app 框架接入指南

### DIFF
--- a/website/.vitepress/config.mts
+++ b/website/.vitepress/config.mts
@@ -34,6 +34,13 @@ export default defineConfig({
           ],
         },
         {
+          text: '框架接入',
+          items: [
+            { text: 'Taro（React）', link: '/guide/taro' },
+            { text: 'uni-app（Vue）', link: '/guide/uniapp' },
+          ],
+        },
+        {
           text: '进阶',
           items: [
             { text: '常见问题 (FAQ)', link: '/guide/faq' },

--- a/website/guide/getting-started.md
+++ b/website/guide/getting-started.md
@@ -56,11 +56,12 @@ Sentry.captureException(new Error('sentry test'));
 
 - **合法域名**：自托管 Sentry / 真机预览时，需把 Sentry 上报域名加入小程序后台「request 合法域名」白名单（开发者工具可临时勾选「不校验合法域名」绕过）。
 - **真机 vs 开发者工具**：微信开发者工具某些环境下的报错不会触发底层 `wx.onError`，建议在真机预览下测试。
-- **uni-app / Taro 框架**：组件内的错误可能被框架接住、不冒泡到 `wx.onError`，需接框架的错误处理。详见 [常见问题](/guide/faq#组件内错误)。
+- **uni-app / Taro 框架**：组件内的错误可能被框架接住、不冒泡到 `wx.onError`，需接框架的错误处理。详见 [Taro 接入指南](/guide/taro)、[uni-app 接入指南](/guide/uniapp) 或 [常见问题](/guide/faq#组件内错误)。
 
 ## 下一步
 
 - [支持平台与能力矩阵](/guide/platforms)
+- [Taro 接入指南](/guide/taro) · [uni-app 接入指南](/guide/uniapp)
 - [常见问题 (FAQ)](/guide/faq)
 - [Source Map 配置](/guide/sourcemap)
 - [示例工程](/guide/examples)

--- a/website/guide/taro.md
+++ b/website/guide/taro.md
@@ -1,0 +1,123 @@
+# Taro 接入指南
+
+Taro 默认使用 **React**（也可通过 `framework` 配置切换到 Vue3 / Vue）。本页以最常见的 **Taro 4 + React + TypeScript、编译到微信小程序**为例，给出从安装到组件错误上报的完整接入。可运行示例见 [`examples/taro`](https://github.com/lizhiyao/sentry-miniapp/tree/master/examples/taro)。
+
+## 为什么不能直接用 `@sentry/browser`
+
+很多人第一反应是装官方的 `@sentry/browser` 或 `@sentry/react`，但**在小程序端跑不起来**：
+
+- 小程序没有浏览器的 `window` / `fetch` / `XMLHttpRequest`，官方 Web SDK 的传输层和全局错误钩子都依赖这些；
+- 小程序是双线程架构、网络只能走 `wx.request`，需要专门的 transport 与平台适配。
+
+`sentry-miniapp` 正是补齐这一层：自定义 transport（走 `wx.request`）、小程序全局异常捕获、Source Map 路径归一化、网络面包屑等。**Taro 小程序端用 `sentry-miniapp`，H5 端才用 `@sentry/browser`**（见下文「分端接入」）。
+
+## 1. 安装
+
+```bash
+npm install sentry-miniapp --save
+```
+
+## 2. 初始化封装
+
+新建 `src/utils/sentry.ts`，集中放初始化（DSN、采样、标签）：
+
+```ts
+import * as Sentry from 'sentry-miniapp';
+
+Sentry.init({
+  dsn: 'https://your-dsn@o0.ingest.sentry.io/0',
+  release: 'my-taro-app@1.0.0', // 与上传 Source Map 时的 release 完全一致
+  environment: 'production',
+
+  platform: 'wechat',
+  sampleRate: 1.0, // error 采样率
+  tracesSampleRate: 1.0, // 性能采样率；开启后 API 请求会作为 http.client span 上报
+
+  // 网络面包屑默认开启（自动包裹 wx.request；Taro.request 最终也走它，无需额外配置）。
+  // 开 traceNetworkBody 连请求 / 响应体也记录（内置脱敏）。
+  traceNetworkBody: false,
+});
+
+Sentry.setTag('app.framework', 'taro-react');
+
+export default Sentry;
+```
+
+默认集成已含：自动异常捕获、性能监控、Source Map 路径归一化、网络面包屑、Session 与网络状态监控。**通常无需手动传 `integrations`**——只有完全接管集成列表时才传（会覆盖默认）。
+
+## 3. 尽早初始化
+
+在 `src/app.tsx` 顶部引入封装（引入即执行 `init`），确保先于业务请求、能捕获启动阶段异常：
+
+```tsx
+import Sentry from './utils/sentry'; // 引入即执行 Sentry.init
+import SentryBoundary from './components/SentryBoundary';
+
+function App({ children }) {
+  return <SentryBoundary>{children}</SentryBoundary>;
+}
+
+export default App;
+```
+
+## 4. 组件错误：用 React 错误边界
+
+React 不像 Vue 那样静默吞掉组件错误，但**渲染期错误若不接住会整页白屏**。用错误边界把渲染错误更完整地上报（带 `componentStack`）并兜底 UI。新建 `src/components/SentryBoundary.tsx`：
+
+```tsx
+import { Component, ErrorInfo, ReactNode } from 'react';
+import { View, Text } from '@tarojs/components';
+import Sentry from '../utils/sentry';
+
+export default class SentryBoundary extends Component<{ children: ReactNode }, { hasError: boolean }> {
+  state = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    Sentry.captureException(error, { extra: { componentStack: info.componentStack } });
+    console.error(error);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <View style={{ padding: '40rpx', color: '#c0392b' }}>
+          <Text>页面渲染出错，已上报 Sentry。</Text>
+        </View>
+      );
+    }
+    return this.props.children;
+  }
+}
+```
+
+::: warning 错误边界只接「渲染期」错误
+事件回调 / `setTimeout` / 异步里的错误，错误边界捕获不到——那些请直接 `try/catch` 后 `Sentry.captureException`，或交给 SDK 的全局 / TryCatch 集成。
+:::
+
+> 这是 Taro(React) 对应 uni-app(Vue) `errorHandler` 的做法。对比见 [常见问题 · 组件内错误](/guide/faq#组件内错误)。
+
+## 5. 分端接入（同时要 H5）
+
+若 Taro 工程还编译 H5，用 `process.env.TARO_ENV` 分端引入——小程序用 `sentry-miniapp`，H5 用功能完整、官方维护的 `@sentry/browser`：
+
+```ts
+let Sentry;
+if (process.env.TARO_ENV === 'h5') {
+  Sentry = require('@sentry/browser'); // H5 端
+} else {
+  Sentry = require('sentry-miniapp'); // 小程序端
+}
+```
+
+## 6. 其它
+
+- **网络**：`Taro.request` 最终走被包裹的全局 `wx.request`，请求会自动记成 `xhr` 面包屑、随错误事件上报，无需额外配置。
+- **Source Map**：Taro 经过编译，错误栈是编译后代码，需上传 Source Map 才能还原。配置见 [Source Map 配置](/guide/sourcemap)。
+
+## 下一步
+
+- [示例工程](/guide/examples) · [常见问题](/guide/faq) · [支持平台与能力](/guide/platforms)

--- a/website/guide/taro.md
+++ b/website/guide/taro.md
@@ -50,10 +50,11 @@ export default Sentry;
 在 `src/app.tsx` 顶部引入封装（引入即执行 `init`），确保先于业务请求、能捕获启动阶段异常：
 
 ```tsx
+import type { PropsWithChildren } from 'react';
 import Sentry from './utils/sentry'; // 引入即执行 Sentry.init
 import SentryBoundary from './components/SentryBoundary';
 
-function App({ children }) {
+function App({ children }: PropsWithChildren) {
   return <SentryBoundary>{children}</SentryBoundary>;
 }
 
@@ -65,7 +66,7 @@ export default App;
 React 不像 Vue 那样静默吞掉组件错误，但**渲染期错误若不接住会整页白屏**。用错误边界把渲染错误更完整地上报（带 `componentStack`）并兜底 UI。新建 `src/components/SentryBoundary.tsx`：
 
 ```tsx
-import { Component, ErrorInfo, ReactNode } from 'react';
+import { Component, type ErrorInfo, type ReactNode } from 'react';
 import { View, Text } from '@tarojs/components';
 import Sentry from '../utils/sentry';
 
@@ -103,6 +104,10 @@ export default class SentryBoundary extends Component<{ children: ReactNode }, {
 ## 5. 分端接入（同时要 H5）
 
 若 Taro 工程还编译 H5，用 `process.env.TARO_ENV` 分端引入——小程序用 `sentry-miniapp`，H5 用功能完整、官方维护的 `@sentry/browser`：
+
+```bash
+npm install sentry-miniapp @sentry/browser --save
+```
 
 ```ts
 let Sentry;

--- a/website/guide/uniapp.md
+++ b/website/guide/uniapp.md
@@ -81,13 +81,22 @@ Vue.config.errorHandler = (err, vm, info) => {
 
 uni-app 用**条件编译**按端引入——小程序用 `sentry-miniapp`，H5 用官方 `@sentry/browser`：
 
+```bash
+npm install sentry-miniapp @sentry/browser --save
+```
+
 ```js
+let Sentry;
+
 // #ifdef H5
-import * as Sentry from '@sentry/browser';
+Sentry = require('@sentry/browser');
 // #endif
+
 // #ifdef MP-WEIXIN || MP-ALIPAY || MP-BAIDU || MP-TOUTIAO || MP-QQ || MP-KUAISHOU || MP-DINGTALK
-import * as Sentry from 'sentry-miniapp';
+Sentry = require('sentry-miniapp');
 // #endif
+
+export default Sentry;
 ```
 
 ## 5. 其它

--- a/website/guide/uniapp.md
+++ b/website/guide/uniapp.md
@@ -1,0 +1,101 @@
+# uni-app 接入指南
+
+uni-app 底层是 **Vue**。本页以 **uni-app（Vue3 + Vite）编译到微信小程序**为例，给出完整接入，并重点讲清一个最容易踩的坑：**Vue 会吞掉组件内错误**。可运行示例见 [`examples/uniapp`](https://github.com/lizhiyao/sentry-miniapp/tree/master/examples/uniapp)。
+
+## 为什么不能直接用 `@sentry/browser`
+
+小程序没有浏览器的 `window` / `fetch` / `XMLHttpRequest`，网络只能走 `wx.request`，官方 Web SDK 的传输层与全局错误钩子都用不了。`sentry-miniapp` 补齐了这层（自定义 transport、小程序全局异常捕获、Source Map 归一化、网络面包屑）。**uni-app 小程序端用 `sentry-miniapp`，H5 端才用 `@sentry/browser`**（见「分端接入」）。
+
+## 1. 安装
+
+```bash
+npm install sentry-miniapp --save
+```
+
+## 2. 初始化封装
+
+新建 `src/utils/sentry.js`：
+
+```js
+import * as Sentry from 'sentry-miniapp';
+
+Sentry.init({
+  dsn: 'https://your-dsn@o0.ingest.sentry.io/0',
+  release: 'my-uniapp@1.0.0', // 与上传 Source Map 时的 release 完全一致
+  environment: 'production',
+
+  platform: 'wechat',
+  sampleRate: 1.0, // error 采样率
+  tracesSampleRate: 1.0, // 性能采样率；开启后 API 请求会作为 http.client span 上报
+
+  // 网络面包屑默认开启（自动包裹全局 wx.request；uni.request 最终也走它，无需额外配置）。
+  traceNetworkBody: false,
+});
+
+Sentry.setTag('app.framework', 'uni-app');
+
+export default Sentry;
+```
+
+## 3. main.js 尽早初始化 + 接 Vue errorHandler（关键）
+
+::: danger 最常见的「明明设了 sampleRate: 1 却只偶尔上报一条」根因
+uni-app 底层是 Vue。**组件内**（`render` / 生命周期 / `watch` / 模板 `@click` 调用的方法）抛出的错误，会被 **Vue 自己的错误处理接住、只打印 console，不会冒泡到 `wx.onError`**，SDK 默认捕获不到。必须把 Vue 的 `errorHandler` 接到 Sentry，组件内错误才会上报。
+:::
+
+`src/main.js`（Vue3）：
+
+```js
+import { createSSRApp } from 'vue';
+import App from './App.vue';
+import Sentry from './utils/sentry'; // 引入即执行 Sentry.init（先于业务、能捕获启动异常）
+
+export function createApp() {
+  const app = createSSRApp(App);
+
+  // 关键：把 Vue 组件内错误转交 Sentry
+  app.config.errorHandler = (err, instance, info) => {
+    Sentry.captureException(err, { extra: { lifecycleHook: info } });
+    console.error(err); // 保留本地打印，方便开发期排查
+  };
+
+  return { app };
+}
+```
+
+**Vue2（uni-app 旧版）** 改用 `Vue.config.errorHandler`：
+
+```js
+import Vue from 'vue';
+import Sentry from './utils/sentry';
+
+Vue.config.errorHandler = (err, vm, info) => {
+  Sentry.captureException(err, { extra: { lifecycleHook: info } });
+  console.error(err);
+};
+```
+
+> 这是 uni-app(Vue) 对应 Taro(React) 错误边界的做法。对比见 [常见问题 · 组件内错误](/guide/faq#组件内错误)。
+
+## 4. 分端接入（同时要 H5）
+
+uni-app 用**条件编译**按端引入——小程序用 `sentry-miniapp`，H5 用官方 `@sentry/browser`：
+
+```js
+// #ifdef H5
+import * as Sentry from '@sentry/browser';
+// #endif
+// #ifdef MP-WEIXIN || MP-ALIPAY || MP-BAIDU || MP-TOUTIAO || MP-QQ || MP-KUAISHOU || MP-DINGTALK
+import * as Sentry from 'sentry-miniapp';
+// #endif
+```
+
+## 5. 其它
+
+- **网络**：`uni.request` 最终走被包裹的全局 `wx.request`，请求会自动记成 `xhr` 面包屑、随错误事件上报，无需额外配置。
+- **Source Map**：uni-app 经过编译，错误栈是编译后代码，需上传 Source Map 才能还原。配置见 [Source Map 配置](/guide/sourcemap)。
+- **验证**：`addBreadcrumb` 不会单独上报，需主动 `Sentry.captureException(new Error('test'))` 才能在 Issues 看到。详见 [快速接入](/guide/getting-started)。
+
+## 下一步
+
+- [示例工程](/guide/examples) · [常见问题](/guide/faq) · [支持平台与能力](/guide/platforms)


### PR DESCRIPTION
## 背景

承接「Taro Sentry 接入」「uni-app 错误监控」这类搜索，降低两大跨端框架用户的接入门槛——SDK 本就兼容 Taro/uni-app，但缺少各自的专页指南。

## 改动

- 新增 `website/guide/taro.md`（Taro 4 + React）：为什么不能直接用 `@sentry/browser`、初始化封装、React 错误边界上报组件错误、H5 分端接入、网络与 Source Map 提示。
- 新增 `website/guide/uniapp.md`（uni-app Vue3）：同上，重点讲清 **Vue 会吞掉组件内错误**的坑、`app.config.errorHandler`（Vue3）/ `Vue.config.errorHandler`（Vue2）、条件编译分端。
- 侧边栏新增「框架接入」分组；快速接入页交叉链接到两份指南。

## 说明

- 内容基于现有可运行示例 `examples/taro`、`examples/uniapp`，代码与示例一致。
- 纯文档站改动，不涉及 SDK 源码 / 产物。`yarn docs:build` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)