### PR TITLE
fix(website): 文档站版权年份 2020 → 2019

### DIFF
--- a/website/.vitepress/config.mts
+++ b/website/.vitepress/config.mts
@@ -72,7 +72,7 @@ export default defineConfig({
 
     footer: {
       message: '基于 @sentry/core 的跨端小程序 SDK · MIT Licensed',
-      copyright: `Copyright © 2020-present <a href="${GITHUB}">sentry-miniapp</a>`,
+      copyright: `Copyright © 2019-present <a href="${GITHUB}">sentry-miniapp</a>`,
     },
   },
 });


### PR DESCRIPTION
文档站 footer 写的是 `© 2020-present`,但项目**首次 commit 为 2019-08-07**、`LICENSE` 也是 `Copyright (c) 2019, lizhiyao`。年份不准确,改为 `2019-present` 与之对齐。

纯文案一行改动,`docs:build` 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)