### PR TITLE
chore(lint): eslint 覆盖扩到 test/，清理 require 导入与未用变量

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "docs:dev": "vitepress dev website",
     "docs:build": "vitepress build website",
     "docs:preview": "vitepress preview website",
-    "lint": "eslint src --ext .ts",
+    "lint": "eslint src test --ext .ts",
     "typecheck": "tsc --noEmit",
     "test": "jest",
     "prepublishOnly": "npm run build",

--- a/test/error-handling.test.ts
+++ b/test/error-handling.test.ts
@@ -268,7 +268,7 @@ describe('Error Handling', () => {
       const executeWithFallback = () => {
         try {
           return primaryOperation();
-        } catch (error) {
+        } catch {
           captureMessage('Primary operation failed, using fallback', 'warning');
           return fallbackOperation();
         }
@@ -297,7 +297,7 @@ describe('Error Handling', () => {
       const executeWithDegradation = () => {
         try {
           return advancedFeature();
-        } catch (error) {
+        } catch {
           captureMessage('Advanced feature failed, degrading to basic', 'info');
           return basicFeature();
         }

--- a/test/minigame-framerate.realcore.test.ts
+++ b/test/minigame-framerate.realcore.test.ts
@@ -20,7 +20,7 @@ describe('MinigameFrameRateIntegration（真 @sentry/core 集成）', () => {
     clock = t;
     const cb = rafCallback;
     rafCallback = null;
-    cb && cb();
+    if (cb) cb();
   }
 
   beforeEach(() => {

--- a/test/minigame-framerate.test.ts
+++ b/test/minigame-framerate.test.ts
@@ -254,7 +254,7 @@ describe('MinigameFrameRateIntegration', () => {
     const rafCalls = (g.requestAnimationFrame as jest.Mock).mock.calls.length;
     // 调用已捕获的 loop：因 _running=false，应立即返回且不再注册新帧
     clock = 10;
-    rafCallback && rafCallback();
+    if (rafCallback) rafCallback();
     expect((g.requestAnimationFrame as jest.Mock).mock.calls.length).toBe(rafCalls);
   });
 

--- a/test/performance.test.ts
+++ b/test/performance.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import { addBreadcrumb, getCurrentScope } from '@sentry/core';
 import { PerformanceIntegration } from '../src/integrations/performance';
-import { getPerformanceManager, getSystemInfo } from '../src/crossPlatform';
+import { getPerformanceManager, getSystemInfo, sdk } from '../src/crossPlatform';
 import type {
   PerformanceEntry,
   PerformanceManager,
@@ -675,7 +675,6 @@ describe('PerformanceIntegration', () => {
     });
 
     it('should collect memory when enableMemory is true and API available', () => {
-      const { sdk } = require('../src/crossPlatform');
       const mockMemory = { jsHeapSizeUsed: 1024000, jsHeapSizeLimit: 10240000 };
       (sdk as jest.Mock).mockReturnValue({
         getPerformance: jest.fn(() => ({ memory: mockMemory })),
@@ -705,7 +704,6 @@ describe('PerformanceIntegration', () => {
     });
 
     it('should handle missing memory API gracefully', () => {
-      const { sdk } = require('../src/crossPlatform');
       (sdk as jest.Mock).mockReturnValue({
         getPerformance: jest.fn(() => ({})), // No memory property
         reportPerformance: jest.fn(),
@@ -1004,7 +1002,6 @@ describe('PerformanceIntegration', () => {
 
   describe('reportToNativeAPI', () => {
     it('should report to native API when reportPerformance is available', () => {
-      const { sdk } = require('../src/crossPlatform');
       const mockReportPerformance = jest.fn();
       (sdk as jest.Mock).mockReturnValue({
         getPerformance: jest.fn(),

--- a/test/system.test.ts
+++ b/test/system.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import { getCurrentScope } from '@sentry/core';
 import { System } from '../src/integrations/system';
+import { getSystemInfo } from '../src/crossPlatform';
 
 // Mock @sentry/core
 jest.mock('@sentry/core', () => ({
@@ -208,7 +209,6 @@ describe('System', () => {
 
   describe('error handling', () => {
     it('should handle getSystemInfo returning null', () => {
-      const { getSystemInfo } = require('../src/crossPlatform');
       (getSystemInfo as jest.Mock).mockReturnValueOnce(null);
 
       const integration = new System();
@@ -216,7 +216,6 @@ describe('System', () => {
     });
 
     it('should handle system without OS separator', () => {
-      const { getSystemInfo } = require('../src/crossPlatform');
       (getSystemInfo as jest.Mock).mockReturnValueOnce({
         ...mockSystemInfo,
         system: 'Android',

--- a/test/transport.test.ts
+++ b/test/transport.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import { createMiniappTransport } from '../src/transports/xhr';
 import { Envelope } from '@sentry/core';
-import { _sdk } from '../src/crossPlatform';
+import { resetPlatformCache } from '../src/crossPlatform';
 
 describe('Transport', () => {
   beforeEach(() => {
@@ -94,7 +94,7 @@ describe('Transport', () => {
       (global as any).wx = { request: mockRequest };
 
       // Reset the SDK cache to pick up the new mock
-      (_sdk as any) = null;
+      resetPlatformCache();
 
       const transport = createMiniappTransport({
         url: 'https://sentry.io/api/123/store/',
@@ -123,7 +123,7 @@ describe('Transport', () => {
       (global as any).wx = { request: mockRequest };
 
       // Reset the SDK cache to pick up the new mock
-      (_sdk as any) = null;
+      resetPlatformCache();
 
       const transport = createMiniappTransport({
         url: 'https://sentry.io/api/123/store/',
@@ -238,7 +238,7 @@ describe('Transport', () => {
     beforeEach(() => {
       jest.clearAllMocks();
       // Clear the memoized SDK cache so each test picks up the new global
-      (_sdk as any) = null;
+      resetPlatformCache();
       delete (global as any).wx;
       delete (global as any).my;
       delete (global as any).dd;

--- a/test/version.test.ts
+++ b/test/version.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from '@jest/globals';
 import { SDK_VERSION, SDK_NAME } from '../src/version';
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const pkg = require('../package.json');
+import pkg from '../package.json';
 
 describe('Version', () => {
   describe('SDK_VERSION', () => {


### PR DESCRIPTION
Closes #201

架构 review 卫生项的最后一个延迟项(#198 推迟)。把 ESLint 从 `src` 扩到 `test/`,并清掉因此暴露的既存问题。

## 改了什么

**lint 覆盖面**
- `package.json`:`eslint src` → `eslint src test --ext .ts`。CI 经 `yarn run lint` 自动同步覆盖 `test/`,无需改 workflow。

**清理(共 11 处:8 error + 3 warning)**
- `require()` 风格导入 → ESM `import`:
  - `version.test.ts`:`require('../package.json')` → `import pkg from`(`resolveJsonModule` 已开)。
  - `system.test.ts`(×2)/`performance.test.ts`(×3):`const {x} = require('../src/crossPlatform')` 在测试体内。该模块已 `jest.mock`(hoist),顶层 `import` 拿到的是**同一个 mock**,故上提为顶层 import、删除 in-body require,行为不变。
- `transport.test.ts`:`(_sdk as any) = null`(只写不读、被 ESLint 判未使用)→ 公开 API `resetPlatformCache()`,消除对内部 `_sdk` 的写依赖,语义一致(清缓存以拾取新 mock)。
- `error-handling.test.ts`(×2):未使用的 `catch (error)` → 可选 catch 绑定 `catch {}`。
- `minigame-framerate*.test.ts`(×2):`x && x()` 短路语句(`no-unused-expressions`)→ `if (x) x()`。

## 不动的

纯测试 + lint 脚本改动,**无 `src/` 改动、无构建产物变化**。

## 验证

`yarn lint`(含 `test/`)**零报错零警告** · **510 测试全绿** · 无 `src`/`dist` 变更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)