### PR TITLE
chore(deps): 修复 brace-expansion 安全告警

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3172,20 +3172,20 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "brace-expansion@npm:2.0.2"
+  version: 2.1.2
+  resolution: "brace-expansion@npm:2.1.2"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10c0/6d117a4c793488af86b83172deb6af143e94c17bc53b0b3cec259733923b4ca84679d506ac261f4ba3c7ed37c46018e2ff442f9ce453af8643ecd64f4a54e6cf
+  checksum: 10c0/5442ecab84045d21826268bc56c81a6ef4215327ee1f5ee153f67928e93f7a915d130ecec9966623143277fa3cce036ebb50020024bcc4d78853cdd6af9a19f8
   languageName: node
   linkType: hard
 
 "brace-expansion@npm:^5.0.2":
-  version: 5.0.4
-  resolution: "brace-expansion@npm:5.0.4"
+  version: 5.0.8
+  resolution: "brace-expansion@npm:5.0.8"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/359cbcfa80b2eb914ca1f3440e92313fbfe7919ee6b274c35db55bec555aded69dac5ee78f102cec90c35f98c20fa43d10936d0cd9978158823c249257e1643a
+  checksum: 10c0/73304caafd00fdc5b0168e693ac15bf25b6357dec76d1195fcd628fe2cf99c46f9c889a7ecfa3cfe236dbd2d5ce3e27a6ccc4370b46d475d0d19081e11f86019
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 变更

- 将 yarn.lock 中的 `brace-expansion@^2.0.2` 从 2.0.2 升级到 2.1.2。
- 将 yarn.lock 中的 `brace-expansion@^5.0.2` 从 5.0.4 升级到 5.0.8。

## 背景

GitHub Dependabot 当前仍有 2 个 `brace-expansion` 高危告警：

- Alert #153：`>= 2.0.0, < 2.1.2`，patched version 为 2.1.2。
- Alert #151：`>= 3.0.0, < 5.0.7`，patched version 为 5.0.7；本次升级到 npm latest 5.0.8。

这两个版本均来自 `minimatch` 的间接依赖，只需要更新 lockfile，不涉及 `package.json`、源码、构建产物或 SDK 对外 API。

## 验证

- `yarn install --immutable`
- `yarn run lint`
- `yarn run typecheck`
- `yarn run test`
