### PR TITLE
docs: 精简 README 核心特性说明

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -19,20 +19,7 @@ A **mini program monitoring SDK** built on `@sentry/core`, providing **error mon
 
 > **📰 Featured Article (Chinese)**: [《我给 Sentry 提了个 PR，后来 sentry-miniapp 进了官方文档》](https://juejin.cn/post/7636106283963760681) — How sentry-miniapp got listed in Sentry's official community-supported SDKs documentation. If you find this project useful, please consider giving it a ⭐ Star.
 
-<details>
-<summary><b>🆕 Current Highlights: v1.11 → v1.16 (click to expand)</b></summary>
-
-| Version | Highlights |
-|---|---|
-| **v1.16.0** | Source Map Debug ID support for mini-game globals outside `globalThis`; public `stackParser` option for private runtimes or special stack formats |
-| **v1.15.0** | `Sentry.logger.*` support for sending business logs as standalone Sentry Logs |
-| **v1.14.0** | Optional W3C `traceparent` propagation; improved mini-game / Cocos Source Map compatibility |
-| **v1.13.0** | `requireConsent` / `setConsent` privacy gate: collect into local buffers before consent, flush after consent |
-| **v1.11.x** | Mini-game performance data as independent transactions; docs site, Taro / uni-app examples, and two-layer Source Map merge script |
-
-See [CHANGELOG.md](./CHANGELOG.md) for full details.
-
-</details>
+See [CHANGELOG.md](./CHANGELOG.md) for version history.
 
 ---
 
@@ -43,7 +30,7 @@ See [CHANGELOG.md](./CHANGELOG.md) for full details.
 - **🎮 Mini Game Support**: Auto-detects mini-game environments — error / network / device monitoring out of the box, plus mini-game-specific **cold-start first-frame timing** and **frame-rate / jank monitoring**.
 - **🎯 Automatic Exception Capture**: No business code intrusion. Hooks into lifecycle error listeners (`onError`, `onUnhandledRejection`, `onPageNotFound`, `onMemoryWarning`).
 - **🍞 Rich Context Breadcrumbs**: Auto-records device info, user tap/touch, network requests (XHR), and page lifecycle.
-- **🗺️ Built-in SourceMap Path Normalization**: Unifies virtual stack paths across platforms; works with sentry-cli for seamless resolution.
+- **🗺️ Source Map & Stack Trace Resolution**: Unifies virtual stack paths across platforms, supports Debug ID injection, and allows custom `stackParser` logic for private runtimes or special stack formats.
 - **📡 Offline Caching for Weak Networks**: Caches events to local storage on failure, silently retries when connectivity returns.
 - **⚡ Deep Performance Monitoring**: Navigation timing (FCP/LCP), render performance, resource loading, and custom marks.
 - **🔗 Distributed Tracing**: Injects `sentry-trace` / `baggage` headers, can optionally add W3C `traceparent`, and reports API timing as `http.client` spans, connecting mini program and backend call chains.

--- a/README.en.md
+++ b/README.en.md
@@ -25,19 +25,14 @@ See [CHANGELOG.md](./CHANGELOG.md) for version history.
 
 ## ✨ Core Features
 
-- **🚀 Modern Architecture**: Built on the latest Sentry JavaScript V10 SDK core modules.
-- **📱 True Multi-Platform Support**: Built-in API abstraction engine — one codebase supports **WeChat, Alipay, ByteDance, Baidu, QQ, DingTalk, and Kuaishou** mini programs.
-- **🎮 Mini Game Support**: Auto-detects mini-game environments — error / network / device monitoring out of the box, plus mini-game-specific **cold-start first-frame timing** and **frame-rate / jank monitoring**.
-- **🎯 Automatic Exception Capture**: No business code intrusion. Hooks into lifecycle error listeners (`onError`, `onUnhandledRejection`, `onPageNotFound`, `onMemoryWarning`).
-- **🍞 Rich Context Breadcrumbs**: Auto-records device info, user tap/touch, network requests (XHR), and page lifecycle.
+- **🚀 Modern SDK Core**: Built on the latest Sentry JavaScript V10 SDK core modules.
+- **📱 Multi-Platform & Framework Support**: One API for WeChat, Alipay, ByteDance, Baidu, QQ, DingTalk, Kuaishou, plus Taro / uni-app mini program builds.
+- **🎯 Automatic Capture & Context**: Captures global errors, Promise rejections, page errors, and memory warnings; records device, interaction, network, and page lifecycle breadcrumbs.
+- **⚡ Performance, Tracing & Logs**: Tracks navigation / rendering / resource / custom spans; reports API requests as `http.client` spans; supports standalone `Sentry.logger.*` logs.
 - **🗺️ Source Map & Stack Trace Resolution**: Unifies virtual stack paths across platforms, supports Debug ID injection, and allows custom `stackParser` logic for private runtimes or special stack formats.
-- **📡 Offline Caching for Weak Networks**: Caches events to local storage on failure, silently retries when connectivity returns.
-- **⚡ Deep Performance Monitoring**: Navigation timing (FCP/LCP), render performance, resource loading, and custom marks.
-- **🔗 Distributed Tracing**: Injects `sentry-trace` / `baggage` headers, can optionally add W3C `traceparent`, and reports API timing as `http.client` spans, connecting mini program and backend call chains.
-- **🪵 Sentry Logs**: Send business logs through `Sentry.logger.*` as standalone log envelopes, separate from console breadcrumbs attached to events.
-- **🔒 Privacy Consent Gate**: `requireConsent` buffers collected events locally before user consent, then flushes them after `setConsent(true)`.
-- **📊 Session Health** & **📶 Network Status Monitoring**: Session lifecycle management + real-time network change tracking (WiFi/4G/offline).
-- **🛡️ Smart Deduplication & Filtering**: Built-in dedup and sample rate controls to prevent log storms.
+- **📡 Reliable Delivery & Consent Gate**: Caches failed sends locally and retries on reconnect; `requireConsent` buffers locally before user consent and sends nothing outbound.
+- **🎮 Mini Game Capabilities**: Auto-detects WeChat / Douyin mini games and adds cold-start first-frame timing plus FPS / jank monitoring.
+- **🛡️ Noise Reduction & Filtering**: Built-in deduplication, sample rates, and before-send hooks to prevent log storms.
 
 ---
 
@@ -81,9 +76,11 @@ Sentry.init({
 App({ onLaunch() {} });
 ```
 
-Do not put `Sentry.init` inside `App.onLaunch`: by then `App()` has already been registered, so the SDK cannot wrap that first `onLaunch` call. App lifecycle breadcrumbs, the first session start, and cold-start timing which depends on the `onLaunch` start point may be missing. If you only need later errors, network breadcrumbs, and manual capture, initializing in `onLaunch` still works, but startup instrumentation is degraded.
+Integration notes:
 
-Default integrations already include **exception capture, performance monitoring, Source Map path normalization, network breadcrumbs, session and network status monitoring** — you usually don't pass `integrations` (doing so replaces the defaults). Full options (offline cache, trace propagation, breadcrumb toggles) are on the [docs site · Configuration](https://sentry-miniapp.pages.dev/guide/configuration).
+- `Sentry.init` must run before `App()`; putting it in `App.onLaunch` degrades startup instrumentation.
+- Default integrations already include exception capture, performance monitoring, Source Map path normalization, network breadcrumbs, session, and network status monitoring. You usually don't need to pass `integrations`.
+- Full options are on the [docs site · Configuration](https://sentry-miniapp.pages.dev/guide/configuration).
 
 **Verify it works** — capture an event and check the Sentry "Issues" list:
 
@@ -115,52 +112,27 @@ Sentry.logger.info('User completed payment', { orderId: 'order_123' });
 // Custom span
 await Sentry.startSpan({ name: 'fetch-user', op: 'http.client' }, async () => { /* ... */ });
 
+// User feedback: mini programs have no DOM, so submit from your own native form
+Sentry.captureFeedback({ message: 'The page is frozen', name: 'John Doe', email: 'john@example.com' });
+
 // Privacy consent: after init({ requireConsent: true }), flush buffered events once granted
 Sentry.setConsent(true);
 ```
 
-For per-page / per-scenario sampling use the `tracesSampler` callback (it overrides `tracesSampleRate`); see the [docs site · Configuration](https://sentry-miniapp.pages.dev/guide/configuration).
-
-For privacy-compliance flows, initialize with `requireConsent: true`: before consent the SDK keeps collecting but sends no network requests, storing events locally. Call `Sentry.setConsent(true)` after the user agrees, or `Sentry.setConsent(false)` if consent is revoked.
+Advanced options such as sampling, Logs, privacy consent, and `traceparent` propagation live on the [docs site · Configuration](https://sentry-miniapp.pages.dev/guide/configuration).
 
 ---
 
-## 🗺️ Source Map
+## 🧭 Production Setup Pointers
 
-The SDK normalizes platform virtual stack paths to the `app:///` prefix by default (`enableSourceMap: true`). Upload with sentry-cli:
+The README keeps only the decision-level summary. Production details live in the docs:
 
-```bash
-sentry-cli releases files "my-miniapp@1.0.0" upload-sourcemaps ./dist \
-  --url-prefix "app:///" --ext js --ext map
-```
-
-Private runtimes or special stack formats can pass a custom `stackParser`; by default the SDK uses the built-in `miniappStackParser`.
-
-> Full end-to-end setup (build tools, CI/CD, two-layer map merging for cross-platform frameworks, verification) is in the **[Source Map Configuration Guide](./docs/SOURCEMAP_GUIDE.md)**.
-
----
-
-## 🎮 Mini Game Support
-
-`sentry-miniapp` also works in WeChat / Douyin **mini games**: auto-detects the environment, error / network / device monitoring out of the box, plus **cold-start first-frame timing** and **frame-rate / jank monitoring**. Initialization is identical to mini programs; with `tracesSampleRate` enabled, performance data is reported as independent transactions on the Performance page.
-
-> Capability matrix and performance-reporting details: [docs site · Platforms & Capabilities](https://sentry-miniapp.pages.dev/guide/platforms).
-
-## 📦 Bundle Size Optimization
-
-The SDK is ~100KB. If main-package size matters, use platform "subpackage async" / "dynamic loading" to move the SDK into a subpackage and reduce main-package overhead; platforms with cross-subpackage async loading can reach zero main-package overhead.
-
-> WeChat subpackage async loading and cross-platform verification guidance: [docs site · Bundle Size](https://sentry-miniapp.pages.dev/guide/bundle-size).
-
----
-
-## 💬 User Feedback
-
-Mini programs have no DOM, so `showReportDialog()` is deprecated. Build a native form to collect feedback, then submit via `Sentry.captureFeedback()`:
-
-```javascript
-Sentry.captureFeedback({ message: 'The page is frozen', name: 'John Doe', email: 'john@example.com' });
-```
+| Scenario | README Summary | Details |
+|----------|----------------|---------|
+| Source Map | `release` must match the upload; the SDK normalizes stacks to `app:///`; special stacks can use `stackParser` | [Source Map Configuration Guide](./docs/SOURCEMAP_GUIDE.md) |
+| Taro / uni-app | Use `sentry-miniapp` in mini program builds; use official `@sentry/browser` for H5 builds | [Taro](https://sentry-miniapp.pages.dev/guide/taro) / [uni-app](https://sentry-miniapp.pages.dev/guide/uniapp) |
+| Mini games | Initialization is the same; mini-game runtimes enable dedicated lifecycle and frame-rate integrations | [Platforms & Capabilities](https://sentry-miniapp.pages.dev/guide/platforms) |
+| Bundle size | If main-package size matters, use subpackage async loading / dynamic loading | [Bundle Size](https://sentry-miniapp.pages.dev/guide/bundle-size) |
 
 ---
 

--- a/README.en.md
+++ b/README.en.md
@@ -19,7 +19,7 @@ A **mini program monitoring SDK** built on `@sentry/core`, providing **error mon
 
 > **📰 Featured Article (Chinese)**: [《我给 Sentry 提了个 PR，后来 sentry-miniapp 进了官方文档》](https://juejin.cn/post/7636106283963760681) — How sentry-miniapp got listed in Sentry's official community-supported SDKs documentation. If you find this project useful, please consider giving it a ⭐ Star.
 
-See [CHANGELOG.md](./CHANGELOG.md) for version history.
+See [CHANGELOG.md](https://github.com/lizhiyao/sentry-miniapp/blob/master/CHANGELOG.md) for version history.
 
 ---
 
@@ -129,7 +129,7 @@ The README keeps only the decision-level summary. Production details live in the
 
 | Scenario | README Summary | Details |
 |----------|----------------|---------|
-| Source Map | `release` must match the upload; the SDK normalizes stacks to `app:///`; special stacks can use `stackParser` | [Source Map Configuration Guide](./docs/SOURCEMAP_GUIDE.md) |
+| Source Map | `release` must match the upload; the SDK normalizes stacks to `app:///`; special stacks can use `stackParser` | [Source Map Configuration Guide](https://sentry-miniapp.pages.dev/guide/sourcemap) |
 | Taro / uni-app | Use `sentry-miniapp` in mini program builds; use official `@sentry/browser` for H5 builds | [Taro](https://sentry-miniapp.pages.dev/guide/taro) / [uni-app](https://sentry-miniapp.pages.dev/guide/uniapp) |
 | Mini games | Initialization is the same; mini-game runtimes enable dedicated lifecycle and frame-rate integrations | [Platforms & Capabilities](https://sentry-miniapp.pages.dev/guide/platforms) |
 | Bundle size | If main-package size matters, use subpackage async loading / dynamic loading | [Bundle Size](https://sentry-miniapp.pages.dev/guide/bundle-size) |
@@ -154,10 +154,10 @@ The README keeps only the decision-level summary. Production details live in the
 |----------|-------------|
 | [Documentation site](https://sentry-miniapp.pages.dev/) | Getting started / capability matrix / FAQ / Source Map / examples (recommended, with search) |
 | [Taro guide](https://sentry-miniapp.pages.dev/guide/taro) · [uni-app guide](https://sentry-miniapp.pages.dev/guide/uniapp) | Cross-platform framework setup & component error handling |
-| [Source Map Configuration Guide](./docs/SOURCEMAP_GUIDE.md) | End-to-end setup, build tools, CI/CD, verification |
-| [Multi-Platform Compatibility Report](./docs/MultiPlatformCompatibilityReport.md) | Platform API differences |
-| [Examples](./examples/) | wxapp (native) / taro (React) / uniapp (Vue) runnable examples |
-| [Development Guide](./DEVELOPMENT.md) · [Contributing Guide](./CONTRIBUTING.md) | Local dev, debugging & contributing |
+| [Source Map Configuration Guide](https://sentry-miniapp.pages.dev/guide/sourcemap) | End-to-end setup, build tools, CI/CD, verification |
+| [Multi-Platform Compatibility Report](https://github.com/lizhiyao/sentry-miniapp/blob/master/docs/MultiPlatformCompatibilityReport.md) | Platform API differences |
+| [Examples](https://sentry-miniapp.pages.dev/guide/examples) | wxapp (native) / taro (React) / uniapp (Vue) runnable examples |
+| [Development Guide](https://github.com/lizhiyao/sentry-miniapp/blob/master/DEVELOPMENT.md) · [Contributing Guide](https://github.com/lizhiyao/sentry-miniapp/blob/master/CONTRIBUTING.md) | Local dev, debugging & contributing |
 
 ---
 
@@ -165,7 +165,7 @@ The README keeps only the decision-level summary. Production details live in the
 
 Have questions or want to discuss mini program monitoring? Due to WeChat group QR code expiration (7-day limit), please add the author on WeChat (**note: sentry-miniapp**) to be invited to the group:
 
-<img src="docs/qrcode/zhiyao.jpeg" alt="Author WeChat QR Code" width="200" style="border-radius: 8px; box-shadow: 0 4px 8px rgba(0,0,0,0.1);" />
+<img src="https://raw.githubusercontent.com/lizhiyao/sentry-miniapp/master/docs/qrcode/zhiyao.jpeg" alt="Author WeChat QR Code" width="200" style="border-radius: 8px; box-shadow: 0 4px 8px rgba(0,0,0,0.1);" />
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -23,19 +23,14 @@
 
 ## ✨ 核心特性
 
-- **🚀 现代架构**：基于 Sentry JavaScript V10 SDK 核心模块构建。
-- **📱 真正的多端支持**：内置 API 抹平引擎，一套代码兼容**微信、支付宝、字节、百度、QQ、钉钉、快手**等主流小程序平台。
-- **🎮 小游戏支持**：自动识别小游戏环境，异常 / 网络 / 设备监控开箱即用，并提供小游戏专属的**冷启动首帧耗时**与**帧率 / 卡顿监控**。
-- **🎯 全自动异常捕获**：无需侵入业务代码，自动监听并上报生命周期异常（`onError`、`onUnhandledRejection`、`onPageNotFound`、`onMemoryWarning`）。
-- **🍞 丰富的上下文面包屑**：自动记录设备信息、用户点击 / 触摸、网络请求（XHR）以及页面生命周期。
+- **🚀 现代 SDK 内核**：基于 Sentry JavaScript V10 SDK 核心模块构建。
+- **📱 多端与跨端框架**：一套 API 兼容微信、支付宝、字节、百度、QQ、钉钉、快手，并支持 Taro / uni-app 小程序端。
+- **🎯 自动异常与上下文**：自动捕获全局异常、Promise rejection、页面异常、内存告警，并记录设备、交互、网络和页面生命周期面包屑。
+- **⚡ 性能、追踪与日志**：采集导航 / 渲染 / 资源 / 自定义 span；API 请求可作为 `http.client` span 串联后端；支持 `Sentry.logger.*` 独立日志。
 - **🗺️ Source Map 与堆栈还原**：自动统一多端虚拟堆栈路径，兼容 Debug ID 注入，并可通过 `stackParser` 适配私有引擎或特殊堆栈格式。
-- **📡 弱网离线缓存**：断网或发送失败时自动缓存事件到本地 Storage，网络恢复后静默重试，确保数据不丢失。
-- **⚡ 深度性能监控**：采集导航性能（FCP/LCP）、渲染性能、资源加载耗时及自定义性能标记。
-- **🔗 分布式追踪**：自动注入 `sentry-trace` / `baggage` 头，可选追加 W3C `traceparent`，并将 API 请求耗时上报为 `http.client` span，串联小程序与后端调用链。
-- **🪵 Sentry Logs**：通过 `Sentry.logger.*` 将业务日志作为独立 log envelope 上报，区别于随事件发送的 console 面包屑。
-- **🔒 隐私合规门禁**：`requireConsent` 支持用户同意前只采集入本地缓冲、同意后再补发，适配国内小程序隐私流程。
-- **📊 Session 健康监控** 与 **📶 网络状态监控**：会话生命周期管理 + 实时网络变化追踪（WiFi/4G/离线）。
-- **🛡️ 智能降噪**：内置错误去重与采样率控制，避免日志风暴。
+- **📡 可靠上报与合规门禁**：断网 / 发送失败自动缓存，恢复后重试；`requireConsent` 支持用户同意前只入缓冲、不发网络。
+- **🎮 小游戏能力**：自动识别微信 / 抖音小游戏，提供冷启动首帧耗时、FPS / jank 监控。
+- **🛡️ 降噪与过滤**：内置错误去重、采样率控制和发送前过滤钩子，避免日志风暴。
 
 ---
 
@@ -79,9 +74,11 @@ Sentry.init({
 App({ onLaunch() {} });
 ```
 
-不要把 `Sentry.init` 放进 `App.onLaunch` 里：那时 `App()` 已经完成注册，SDK 无法再提前包装本次 `onLaunch`，因此 App 生命周期面包屑、Session 首次启动以及依赖 `onLaunch` 起点的冷启动耗时可能拿不到。若只关心后续异常、网络面包屑和手动上报，放在 `onLaunch` 内仍可工作，但启动阶段能力会降级。
+接入时注意：
 
-默认集成已含**异常捕获、性能监控、Source Map 路径归一化、网络面包屑、Session 与网络状态监控**，通常无需手动传 `integrations`（传入会覆盖默认）。完整配置项（离线缓存、追踪头注入、面包屑开关等）见[文档站 · 配置项参考](https://sentry-miniapp.pages.dev/guide/configuration)。
+- `Sentry.init` 必须在 `App()` 之前执行，放进 `App.onLaunch` 会丢失部分启动阶段能力。
+- 默认集成已包含异常捕获、性能监控、Source Map 路径归一化、网络面包屑、Session 与网络状态监控，通常无需手动传 `integrations`。
+- 完整配置项见[文档站 · 配置项参考](https://sentry-miniapp.pages.dev/guide/configuration)。
 
 **验证是否打通**——主动捕获一个事件，到 Sentry「Issues」列表查看：
 
@@ -113,52 +110,27 @@ Sentry.logger.info('用户完成支付', { orderId: 'order_123' });
 // 自定义测速
 await Sentry.startSpan({ name: 'fetch-user', op: 'http.client' }, async () => { /* ... */ });
 
+// 用户反馈：小程序无 DOM，请自行实现原生表单后提交
+Sentry.captureFeedback({ message: '页面卡住了', name: '张三', email: 'zhangsan@example.com' });
+
 // 隐私合规：init({ requireConsent: true }) 后，用户同意隐私协议再补发缓冲
 Sentry.setConsent(true);
 ```
 
-需要按页面 / 场景精细采样时用 `tracesSampler` 回调（设置后 `tracesSampleRate` 被忽略），写法见[文档站 · 配置项参考](https://sentry-miniapp.pages.dev/guide/configuration)。
-
-国内小程序 / 小游戏合规场景可在初始化时设置 `requireConsent: true`：同意前 SDK 照常采集但不发网络，事件先入本地缓冲；用户同意后调用 `Sentry.setConsent(true)` 补发，撤回同意时调用 `Sentry.setConsent(false)` 重新闸断。
+采样、Logs、隐私同意、`traceparent` 等高级配置见[文档站 · 配置项参考](https://sentry-miniapp.pages.dev/guide/configuration)。
 
 ---
 
-## 🗺️ Source Map
+## 🧭 生产配置入口
 
-SDK 默认开启多端堆栈路径归一化（`enableSourceMap: true`），自动将各平台虚拟路径转为统一 `app:///` 前缀，配合 sentry-cli 上传即可解析：
+README 只保留结论，生产接入细节统一看官网：
 
-```bash
-sentry-cli releases files "my-miniapp@1.0.0" upload-sourcemaps ./dist \
-  --url-prefix "app:///" --ext js --ext map
-```
-
-私有引擎或特殊堆栈格式可通过 `stackParser` 传入自定义堆栈解析器；不传时默认使用内置 `miniappStackParser`。
-
-> 端到端配置（各构建工具、CI/CD、跨端框架两层 map 串联、验证排查）见 **[Source Map 完整配置指南](./docs/SOURCEMAP_GUIDE.md)**。
-
----
-
-## 🎮 小游戏支持
-
-`sentry-miniapp` 同样适用于微信 / 抖音等**小游戏**：自动识别环境，异常 / 网络 / 设备监控开箱即用，并额外提供**冷启动首帧耗时**与**帧率 / 卡顿监控**。初始化与小程序完全一致，开启 `tracesSampleRate` 后性能数据会作为独立 transaction 进 Performance 页。
-
-> 能力矩阵与性能上报细节见[文档站 · 支持平台与能力](https://sentry-miniapp.pages.dev/guide/platforms)。
-
-## 📦 主包体积优化
-
-SDK 原始体积约 100KB。很在意主包体积时，可用平台「分包异步化」/「动态加载」把 SDK 移到分包，显著降低主包占用；微信等支持跨分包异步加载的场景有机会做到主包 0KB 占用。
-
-> 微信分包异步化做法与其他平台 / 框架的核查建议见[文档站 · 主包体积优化](https://sentry-miniapp.pages.dev/guide/bundle-size)。
-
----
-
-## 💬 用户反馈
-
-小程序无 DOM，`showReportDialog()` 已废弃。请自行实现原生表单收集反馈，再调 `Sentry.captureFeedback()` 提交：
-
-```javascript
-Sentry.captureFeedback({ message: '页面卡住了', name: '张三', email: 'zhangsan@example.com' });
-```
+| 场景 | README 结论 | 详细文档 |
+|------|-------------|----------|
+| Source Map | `release` 需与上传时一致；SDK 默认归一化为 `app:///`，特殊堆栈可配 `stackParser` | [Source Map 完整配置指南](./docs/SOURCEMAP_GUIDE.md) |
+| Taro / uni-app | 小程序端直接用 `sentry-miniapp`；H5 端用官方 `@sentry/browser` | [Taro](https://sentry-miniapp.pages.dev/guide/taro) / [uni-app](https://sentry-miniapp.pages.dev/guide/uniapp) |
+| 小游戏 | 初始化方式与小程序一致，小游戏环境会启用专属生命周期与帧率能力 | [支持平台与能力](https://sentry-miniapp.pages.dev/guide/platforms) |
+| 主包体积 | 关心主包体积时，用分包异步化 / 动态加载降低主包占用 | [主包体积优化](https://sentry-miniapp.pages.dev/guide/bundle-size) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 > **📰 最新文章**：[《我给 Sentry 提了个 PR，后来 sentry-miniapp 进了官方文档》](https://juejin.cn/post/7636106283963760681) — sentry-miniapp 已被收录进 Sentry 官方文档的 community-supported SDK 列表。觉得有用请帮忙点个 ⭐ Star，让更多小程序团队找到它。
 
-完整版本历史见 [CHANGELOG.md](./CHANGELOG.md)。
+完整版本历史见 [CHANGELOG.md](https://github.com/lizhiyao/sentry-miniapp/blob/master/CHANGELOG.md)。
 
 ---
 
@@ -127,7 +127,7 @@ README 只保留结论，生产接入细节统一看官网：
 
 | 场景 | README 结论 | 详细文档 |
 |------|-------------|----------|
-| Source Map | `release` 需与上传时一致；SDK 默认归一化为 `app:///`，特殊堆栈可配 `stackParser` | [Source Map 完整配置指南](./docs/SOURCEMAP_GUIDE.md) |
+| Source Map | `release` 需与上传时一致；SDK 默认归一化为 `app:///`，特殊堆栈可配 `stackParser` | [Source Map 完整配置指南](https://sentry-miniapp.pages.dev/guide/sourcemap) |
 | Taro / uni-app | 小程序端直接用 `sentry-miniapp`；H5 端用官方 `@sentry/browser` | [Taro](https://sentry-miniapp.pages.dev/guide/taro) / [uni-app](https://sentry-miniapp.pages.dev/guide/uniapp) |
 | 小游戏 | 初始化方式与小程序一致，小游戏环境会启用专属生命周期与帧率能力 | [支持平台与能力](https://sentry-miniapp.pages.dev/guide/platforms) |
 | 主包体积 | 关心主包体积时，用分包异步化 / 动态加载降低主包占用 | [主包体积优化](https://sentry-miniapp.pages.dev/guide/bundle-size) |
@@ -152,10 +152,10 @@ README 只保留结论，生产接入细节统一看官网：
 |------|------|
 | [文档站](https://sentry-miniapp.pages.dev/) | 快速接入 / 能力矩阵 / FAQ / Source Map / 示例（推荐，带搜索） |
 | [Taro 接入指南](https://sentry-miniapp.pages.dev/guide/taro) · [uni-app 接入指南](https://sentry-miniapp.pages.dev/guide/uniapp) | 跨端框架接入与组件错误处理 |
-| [Source Map 完整配置指南](./docs/SOURCEMAP_GUIDE.md) | 端到端配置、各构建工具、CI/CD、验证排查 |
-| [多端兼容性报告](./docs/MultiPlatformCompatibilityReport.md) | 各小程序平台 API 差异说明 |
-| [示例项目](./examples/) | wxapp（原生）/ taro（React）/ uniapp（Vue）三套可运行示例 |
-| [开发指南](./DEVELOPMENT.md) · [贡献指南](./CONTRIBUTING.md) | 本地开发、调试与贡献 |
+| [Source Map 完整配置指南](https://sentry-miniapp.pages.dev/guide/sourcemap) | 端到端配置、各构建工具、CI/CD、验证排查 |
+| [多端兼容性报告](https://github.com/lizhiyao/sentry-miniapp/blob/master/docs/MultiPlatformCompatibilityReport.md) | 各小程序平台 API 差异说明 |
+| [示例项目](https://sentry-miniapp.pages.dev/guide/examples) | wxapp（原生）/ taro（React）/ uniapp（Vue）三套可运行示例 |
+| [开发指南](https://github.com/lizhiyao/sentry-miniapp/blob/master/DEVELOPMENT.md) · [贡献指南](https://github.com/lizhiyao/sentry-miniapp/blob/master/CONTRIBUTING.md) | 本地开发、调试与贡献 |
 
 ---
 
@@ -163,7 +163,7 @@ README 只保留结论，生产接入细节统一看官网：
 
 遇到问题？想探讨小程序监控方案？由于微信群二维码有 7 天时效，请添加作者微信（**备注 sentry-miniapp**），由作者邀请入群：
 
-<img src="docs/qrcode/zhiyao.jpeg" alt="作者微信二维码" width="200" style="border-radius: 8px; box-shadow: 0 4px 8px rgba(0,0,0,0.1);" />
+<img src="https://raw.githubusercontent.com/lizhiyao/sentry-miniapp/master/docs/qrcode/zhiyao.jpeg" alt="作者微信二维码" width="200" style="border-radius: 8px; box-shadow: 0 4px 8px rgba(0,0,0,0.1);" />
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -17,20 +17,7 @@
 
 > **📰 最新文章**：[《我给 Sentry 提了个 PR，后来 sentry-miniapp 进了官方文档》](https://juejin.cn/post/7636106283963760681) — sentry-miniapp 已被收录进 Sentry 官方文档的 community-supported SDK 列表。觉得有用请帮忙点个 ⭐ Star，让更多小程序团队找到它。
 
-<details>
-<summary><b>🆕 当前版本亮点（v1.11 → v1.16，点击展开）</b></summary>
-
-| 版本 | 亮点 |
-|---|---|
-| **v1.16.0** | Source Map Debug ID 兼容小游戏非 `globalThis` 注入；开放 `stackParser` 高级配置，适配私有引擎或特殊堆栈格式 |
-| **v1.15.0** | 支持 `Sentry.logger.*`，可将业务日志作为 Sentry Logs 独立上报 |
-| **v1.14.0** | 分布式追踪可选追加 W3C `traceparent`；优化小游戏 / Cocos Source Map 兼容 |
-| **v1.13.0** | 新增 `requireConsent` / `setConsent` 隐私合规门禁，同意前只采集入缓冲、不发网络 |
-| **v1.11.x** | 小游戏性能数据独立上报为 transaction；上线文档站、Taro / uni-app 示例与两层 Source Map 合成脚本 |
-
-完整变更见 [CHANGELOG.md](./CHANGELOG.md)。
-
-</details>
+完整版本历史见 [CHANGELOG.md](./CHANGELOG.md)。
 
 ---
 
@@ -41,7 +28,7 @@
 - **🎮 小游戏支持**：自动识别小游戏环境，异常 / 网络 / 设备监控开箱即用，并提供小游戏专属的**冷启动首帧耗时**与**帧率 / 卡顿监控**。
 - **🎯 全自动异常捕获**：无需侵入业务代码，自动监听并上报生命周期异常（`onError`、`onUnhandledRejection`、`onPageNotFound`、`onMemoryWarning`）。
 - **🍞 丰富的上下文面包屑**：自动记录设备信息、用户点击 / 触摸、网络请求（XHR）以及页面生命周期。
-- **🗺️ 内置 SourceMap 路径抹平**：自动统一多端虚拟堆栈路径，配合 sentry-cli 极简实现 Source Map 解析。
+- **🗺️ Source Map 与堆栈还原**：自动统一多端虚拟堆栈路径，兼容 Debug ID 注入，并可通过 `stackParser` 适配私有引擎或特殊堆栈格式。
 - **📡 弱网离线缓存**：断网或发送失败时自动缓存事件到本地 Storage，网络恢复后静默重试，确保数据不丢失。
 - **⚡ 深度性能监控**：采集导航性能（FCP/LCP）、渲染性能、资源加载耗时及自定义性能标记。
 - **🔗 分布式追踪**：自动注入 `sentry-trace` / `baggage` 头，可选追加 W3C `traceparent`，并将 API 请求耗时上报为 `http.client` span，串联小程序与后端调用链。


### PR DESCRIPTION
## 变更内容

- 删除 `README.md` / `README.en.md` 中的“当前版本亮点”折叠区，避免和“核心特性”重复。
- 在 README 顶部保留更轻量的 `CHANGELOG.md` 入口。
- 将 Source Map 核心特性补充为“Source Map 与堆栈还原”，覆盖 Debug ID 注入与 `stackParser` 高级配置。

## 设计取舍

README 聚焦项目定位、核心能力和快速接入；版本流水交给 `CHANGELOG.md` / GitHub Releases，官网首页继续承担近期能力导航入口。

## 验证

- `git diff --check`
- `yarn run lint`
- `yarn run test`
- `yarn run docs:build`
