### PR TITLE
docs: 移出根目录英文 README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ sentry-miniapp 是基于 `@sentry/core` 的跨端小程序 Sentry SDK，覆盖�
 - 涉及 commit、PR、分支或发版时，先看 `CONTRIBUTING.md`。
 - 功能改造前确认对所有已支持平台的影响；如果使用某个平台特有 API，必须提供条件判断或回退机制。
 - 交付前默认跑 `yarn run lint` 和 `yarn run test`（jest 单测）；涉及构建产物或跨端行为时，再跑 `yarn run build`。
-- 代码改造完成后，必须检查并更新相关文档，如 `README.md`、`README.en.md`、`docs/` 或示例工程文档。
+- 代码改造完成后，必须检查并更新相关文档，如 `README.md`、`docs/README.en.md`、`docs/` 或示例工程文档。
 
 ## 硬规则
 
@@ -56,7 +56,7 @@ cp -r .agents/skills/sentry-miniapp-sdk ~/.agents/skills/sentry-miniapp-sdk
 
 ## 参考
 
-- 用户文档：`README.md` / `README.en.md`
+- 用户文档：`README.md` / `docs/README.en.md`
 - 设计与使用文档：`docs/`
 - 示例工程：`examples/wxapp/`
 - sentry-miniapp skill 入场：`.agents/skills/sentry-miniapp-sdk/SKILL.md`（单一来源，见上节）

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![license](https://img.shields.io/github/license/lizhiyao/sentry-miniapp)](./LICENSE)
 [![文档站 docs](https://img.shields.io/badge/docs-sentry--miniapp.pages.dev-3eaf7c?logo=readthedocs&logoColor=white)](https://sentry-miniapp.pages.dev/)
 
-简体中文 | [English](./README.en.md)
+简体中文 | [English](https://github.com/lizhiyao/sentry-miniapp/blob/master/docs/README.en.md)
 
 一个基于 `@sentry/core` 核心构建的**小程序监控 SDK**，提供**异常监控**、**性能监控**、离线缓存、分布式追踪等能力。支持微信、支付宝、字节跳动、百度、QQ、钉钉、快手等多端小程序，以及微信 / 抖音等**小游戏**，并兼容 Taro / uni-app 等跨端框架。
 

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -6,10 +6,10 @@
 [![github stars](https://img.shields.io/github/stars/lizhiyao/sentry-miniapp?style=social)](https://github.com/lizhiyao/sentry-miniapp/stargazers)
 ![test coverage](https://img.shields.io/badge/test%20coverage-100%25-brightgreen.svg)
 [![Sentry Community SDK](https://img.shields.io/badge/Sentry-Community%20SDK-362d59?logo=sentry)](https://docs.sentry.io/platforms/#sdks-supported-by-our-community)
-[![license](https://img.shields.io/github/license/lizhiyao/sentry-miniapp)](./LICENSE)
+[![license](https://img.shields.io/github/license/lizhiyao/sentry-miniapp)](../LICENSE)
 [![docs](https://img.shields.io/badge/docs-sentry--miniapp.pages.dev-3eaf7c?logo=readthedocs&logoColor=white)](https://sentry-miniapp.pages.dev/)
 
-[简体中文](./README.md) | English
+[简体中文](../README.md) | English
 
 A **mini program monitoring SDK** built on `@sentry/core`, providing **error monitoring**, **performance monitoring**, offline caching, and distributed tracing. Supports WeChat, Alipay, ByteDance, Baidu, QQ, DingTalk, Kuaishou mini programs, **WeChat / Douyin mini games**, and cross-platform frameworks (Taro / uni-app).
 
@@ -171,4 +171,4 @@ Have questions or want to discuss mini program monitoring? Due to WeChat group Q
 
 ## License
 
-[MIT](./LICENSE)
+[MIT](../LICENSE)


### PR DESCRIPTION
## 背景

根目录的 `README.en.md` 会被 npm pack 作为 README 类文件自动纳入发布包，即使 `package.json#files` 没有显式包含，也无法通过 `.npmignore` 排除。

## 变更

- 将 `README.en.md` 移动到 `docs/README.en.md`，根目录只保留主 README
- 将中文 README 顶部英文入口改为 GitHub 绝对链接，避免 npm 包页出现包内断链
- 更新 `AGENTS.md` 中的文档路径说明

## 验证

- `yarn run build`
- `yarn run docs:build`
- `yarn run lint`
- `npm pack --dry-run --json`：发布包文件数从 76 变为 75，已不包含 `README.en.md`