### PR TITLE
feat: 新增 Source Map Doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ README 只保留结论，生产接入细节统一看官网：
 
 | 场景 | README 结论 | 详细文档 |
 |------|-------------|----------|
-| Source Map | `release` 需与上传时一致；SDK 默认归一化为 `app:///`，特殊堆栈可配 `stackParser` | [Source Map 完整配置指南](https://sentry-miniapp.pages.dev/guide/sourcemap) |
+| Source Map | `release` 需与上传时一致；SDK 默认归一化为 `app:///`，可用 `sentry-miniapp-sourcemap-doctor` 做本地体检 | [Source Map 完整配置指南](https://sentry-miniapp.pages.dev/guide/sourcemap) |
 | Taro / uni-app | 小程序端直接用 `sentry-miniapp`；H5 端用官方 `@sentry/browser` | [Taro](https://sentry-miniapp.pages.dev/guide/taro) / [uni-app](https://sentry-miniapp.pages.dev/guide/uniapp) |
 | 小游戏 | 初始化方式与小程序一致，小游戏环境会启用专属生命周期与帧率能力 | [支持平台与能力](https://sentry-miniapp.pages.dev/guide/platforms) |
 | 主包体积 | 关心主包体积时，用分包异步化 / 动态加载降低主包占用 | [主包体积优化](https://sentry-miniapp.pages.dev/guide/bundle-size) |

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -132,7 +132,7 @@ The README keeps only the decision-level summary. Production details live in the
 
 | Scenario | README Summary | Details |
 |----------|----------------|---------|
-| Source Map | `release` must match the upload; the SDK normalizes stacks to `app:///`; special stacks can use `stackParser` | [Source Map Configuration Guide](https://sentry-miniapp.pages.dev/guide/sourcemap) |
+| Source Map | `release` must match the upload; the SDK normalizes stacks to `app:///`; use `sentry-miniapp-sourcemap-doctor` for local checks | [Source Map Configuration Guide](https://sentry-miniapp.pages.dev/guide/sourcemap) |
 | Taro / uni-app | Use `sentry-miniapp` in mini program builds; use official `@sentry/browser` for H5 builds | [Taro](https://sentry-miniapp.pages.dev/guide/taro) / [uni-app](https://sentry-miniapp.pages.dev/guide/uniapp) |
 | Mini games | Initialization is the same; mini-game runtimes enable dedicated lifecycle and frame-rate integrations | [Platforms & Capabilities](https://sentry-miniapp.pages.dev/guide/platforms) |
 | Bundle size | If main-package size matters, use subpackage async loading / dynamic loading | [Bundle Size](https://sentry-miniapp.pages.dev/guide/bundle-size) |

--- a/docs/SOURCEMAP_GUIDE.md
+++ b/docs/SOURCEMAP_GUIDE.md
@@ -10,6 +10,7 @@
 - [第四步：上传 Source Map](#第四步上传-source-map)
 - [第五步：CI/CD 自动化](#第五步cicd-自动化)
 - [第六步：验证 Source Map 是否生效](#第六步验证-source-map-是否生效)
+- [本地 Source Map Doctor](#本地-source-map-doctor)
 - [平台特殊说明](#平台特殊说明)
 - [Debug ID 与自定义 stackParser](#debug-id-与自定义-stackparser)
 - [跨端框架的两层 Source Map 串联](#跨端框架的两层-source-map-串联)
@@ -442,6 +443,84 @@ Page({
 4. 如果仍显示压缩代码，点击堆栈帧右侧的 **"Source Map Debug"** 按钮，Sentry 会告诉你匹配失败的原因
 
 > 📌 **先看堆栈帧的文件名**：若是 `app:///appservice.app.js`（真机合并大文件）而你只上传了分页 Source Map，再正确的 `release` / `--url-prefix` 也解不出——见 [跨端框架的两层 Source Map 串联](#跨端框架的两层-source-map-串联)。
+
+---
+
+## 本地 Source Map Doctor
+
+从 `1.17.0` 起，包内提供轻量 sourcemap 静态体检命令。它不会登录 Sentry、不会上传文件、不会修改产物，只检查本地 `.js` / `.map` 是否具备上传前的基本条件，并给出可复制到 issue 的诊断结果。
+
+业务项目可直接用 npm 包里的 bin：
+
+```bash
+npx -p sentry-miniapp sentry-miniapp-sourcemap-doctor \
+  --dist ./dist \
+  --release "my-miniapp@1.0.0"
+```
+
+在 sentry-miniapp 仓库内开发时，也可以用：
+
+```bash
+npm run sourcemap:doctor -- \
+  --dist ./dist \
+  --release "my-miniapp@1.0.0"
+```
+
+Doctor 会检查：
+
+- 构建目录是否存在 `.js` 和 `.map`
+- `.js` 的 `sourceMappingURL` 是否断链；如果是 `hidden-source-map` 且同名 `.map` 存在，会作为提示而不是错误
+- `.map` 是否为合法 JSON、是否包含 `sources` / `mappings`
+- `sourcesContent` 是否完整，避免上传后只能看到路径、看不到源码内容
+- artifact 名称按 `--url-prefix` 推导后是否符合 sentry-miniapp 默认的 `app:///`
+- 是否传入 `--release`，提醒它必须与 `Sentry.init({ release })` 完全一致
+
+默认会忽略 TypeScript 声明文件的 `.d.ts.map`，只检查需要上传到 Sentry 的运行时 JS Source Map。
+
+建议在 CI 上传前跑一遍：
+
+```bash
+npm run build
+npx -p sentry-miniapp sentry-miniapp-sourcemap-doctor \
+  --dist ./dist \
+  --release "$SENTRY_RELEASE" \
+  --strict
+```
+
+需要留档或贴 issue 时加 `--json`：
+
+```bash
+npx -p sentry-miniapp sentry-miniapp-sourcemap-doctor \
+  --dist ./dist \
+  --release "$SENTRY_RELEASE" \
+  --json
+```
+
+### 微信两层 Source Map 体检
+
+如果真机堆栈文件名是 `app:///appservice.app.js`，可以先让 doctor 判断外层微信 map 与框架构建 map 是否能对齐：
+
+```bash
+npx -p sentry-miniapp sentry-miniapp-sourcemap-doctor \
+  --wechat ./wechat/appservice.app.js.map \
+  --build-maps ./dist/dev/mp-weixin \
+  --strip webpack:// \
+  --release "$SENTRY_RELEASE"
+```
+
+这一步只诊断匹配情况：`matched / unmatched / ambiguous`。如果需要真正合成 `appservice.app.js -> 源码` 的最终 map，再运行 [`scripts/merge-sourcemap.mjs`](https://github.com/lizhiyao/sentry-miniapp/blob/master/scripts/merge-sourcemap.mjs)。
+
+`merge-sourcemap` 只在离线合成时需要 `source-map`，为了不增加 SDK 运行时依赖，npx 示例显式临时安装它：
+
+```bash
+npx -p sentry-miniapp -p source-map sentry-miniapp-sourcemap-merge \
+  --wechat ./wechat/appservice.app.js.map \
+  --build-maps ./dist/dev/mp-weixin \
+  --out ./merged/appservice.app.js.map \
+  --strip webpack://
+```
+
+`doctor` 负责判断，`merge-sourcemap` 负责生成合成 map。两者复用同一套 source 名称归一化和构建 map 匹配逻辑，避免排查结果和实际合成行为不一致。
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "docs:dev": "vitepress dev website",
     "docs:build": "vitepress build website",
     "docs:preview": "vitepress preview website",
+    "sourcemap:doctor": "node scripts/doctor-sourcemap.mjs",
     "lint": "eslint src test --ext .ts",
     "typecheck": "tsc --noEmit",
     "test": "jest",
@@ -32,6 +33,10 @@
   "main": "dist/sentry-miniapp.cjs.js",
   "module": "dist/sentry-miniapp.esm.js",
   "types": "dist/types/index.d.ts",
+  "bin": {
+    "sentry-miniapp-sourcemap-doctor": "./scripts/doctor-sourcemap.mjs",
+    "sentry-miniapp-sourcemap-merge": "./scripts/merge-sourcemap.mjs"
+  },
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
@@ -42,6 +47,7 @@
   },
   "files": [
     "dist",
+    "scripts/*.mjs",
     "README.md",
     "LICENSE"
   ],

--- a/scripts/doctor-sourcemap.mjs
+++ b/scripts/doctor-sourcemap.mjs
@@ -1,0 +1,512 @@
+#!/usr/bin/env node
+
+import { existsSync, readFileSync, statSync } from 'node:fs';
+import { basename, dirname, join, relative, resolve } from 'node:path';
+import {
+  collectBuildMaps,
+  collectFiles,
+  isWechatAppserviceName,
+  normalizeName,
+  pickBuildMapCandidate,
+  readJsonFile,
+} from './sourcemap-utils.mjs';
+
+const DEFAULT_URL_PREFIX = 'app:///';
+
+const USAGE = `用法：
+  npm run sourcemap:doctor -- --dist <构建产物目录> --release <release> [--url-prefix app:///] [--strict] [--json]
+
+  # 微信 / Taro / uni-app 真机两层 Source Map 诊断
+  npm run sourcemap:doctor -- --wechat <appservice.app.js.map> --build-maps <框架构建 map 目录> --release <release> [--strip <前缀>]... [--json]
+
+选项：
+  --dist        普通构建产物目录，递归检查 .js 与 .map
+  --wechat      微信线上 Source Map（外层 Map B：appservice.app.js -> 编译产物 JS）
+  --build-maps  框架构建 Source Map 目录（内层 Map A：编译产物 JS -> 源码）
+  --release     SDK init({ release }) 与 sentry-cli 上传 release，必须完全一致
+  --url-prefix  上传 sourcemap 时使用的前缀，默认 app:///
+  --strip       诊断两层 map 匹配时，从 B.sources 中剥掉的前缀，可重复
+  --strict      有 warning 时也返回非 0
+  --json        输出 JSON，便于复制到 issue 或 CI 留档
+  --verbose     打印更多样例
+`;
+
+function parseArgs(argv) {
+  const out = { strip: [], urlPrefix: DEFAULT_URL_PREFIX };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--dist') out.dist = argv[++i];
+    else if (a === '--wechat') out.wechat = argv[++i];
+    else if (a === '--build-maps') out.buildMaps = argv[++i];
+    else if (a === '--release') out.release = argv[++i];
+    else if (a === '--url-prefix') out.urlPrefix = argv[++i];
+    else if (a === '--strip') {
+      const v = argv[++i];
+      if (v !== undefined) out.strip.push(v);
+    } else if (a === '--strict') out.strict = true;
+    else if (a === '--json') out.json = true;
+    else if (a === '--verbose') out.verbose = true;
+    else if (a === '--help' || a === '-h') out.help = true;
+  }
+  return out;
+}
+
+function createReport(args) {
+  return {
+    status: 'pass',
+    options: {
+      dist: args.dist ? resolve(args.dist) : null,
+      wechat: args.wechat ? resolve(args.wechat) : null,
+      buildMaps: args.buildMaps ? resolve(args.buildMaps) : null,
+      release: args.release ?? null,
+      urlPrefix: args.urlPrefix,
+      strip: args.strip,
+      strict: args.strict === true,
+    },
+    summary: {},
+    errors: [],
+    warnings: [],
+    notices: [],
+    suggestions: [],
+  };
+}
+
+function push(report, kind, code, message, details = {}) {
+  report[kind].push({ code, message, details });
+}
+
+function finalize(report) {
+  report.status = report.errors.length > 0 ? 'fail' : report.warnings.length > 0 ? 'warn' : 'pass';
+  return report;
+}
+
+function printReport(report) {
+  console.log('sentry-miniapp sourcemap doctor');
+  console.log(`状态：${report.status}`);
+
+  if (report.summary.dist) {
+    console.log(
+      `\n产物目录：${report.summary.dist.root}\n· JS 文件：${report.summary.dist.jsFiles}\n· Source Map：${report.summary.dist.mapFiles}`,
+    );
+  }
+
+  if (report.summary.wechat) {
+    const merge = report.summary.wechat.merge;
+    console.log(
+      `\n微信外层 Map：${report.summary.wechat.file}\n· sources：${report.summary.wechat.sources}`,
+    );
+    if (merge) {
+      console.log(
+        `· 两层匹配：${merge.matched} / ${merge.total}，未匹配 ${merge.unmatched}，歧义 ${merge.ambiguous}`,
+      );
+    }
+  }
+
+  printItems('错误', report.errors, '✗');
+  printItems('警告', report.warnings, '⚠');
+  printItems('提示', report.notices, '·');
+
+  if (report.suggestions.length > 0) {
+    console.log('\n建议：');
+    for (const item of report.suggestions) {
+      console.log(`- ${item}`);
+    }
+  }
+}
+
+function printItems(title, items, prefix) {
+  if (items.length === 0) return;
+  console.log(`\n${title}：`);
+  for (const item of items) {
+    console.log(`${prefix} [${item.code}] ${item.message}`);
+    if (item.details?.sample) {
+      console.log(`  示例：${item.details.sample}`);
+    }
+  }
+}
+
+function ensureExistingFile(report, file, code, label) {
+  if (!file || !existsSync(file) || !statSync(file).isFile()) {
+    push(report, 'errors', code, `${label}不存在或不是文件。`, { file });
+    return false;
+  }
+  return true;
+}
+
+function ensureExistingDir(report, dir, code, label) {
+  if (!dir || !existsSync(dir) || !statSync(dir).isDirectory()) {
+    push(report, 'errors', code, `${label}不存在或不是目录。`, { dir });
+    return false;
+  }
+  return true;
+}
+
+function normalizeUrlPrefix(urlPrefix) {
+  return urlPrefix.endsWith('/') ? urlPrefix : `${urlPrefix}/`;
+}
+
+function toArtifactName(name, mapFile, root, urlPrefix) {
+  const rawName = name || relative(root, mapFile).replace(/\.map$/, '');
+  const normalized = normalizeName(rawName, []);
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(normalized)) {
+    return normalized;
+  }
+  return `${normalizeUrlPrefix(urlPrefix)}${normalized}`;
+}
+
+function findSourceMappingUrl(jsFile) {
+  const content = readFileSync(jsFile, 'utf8');
+  const match = content.match(/[#@]\s*sourceMappingURL=([^\s*]+)/);
+  return match ? match[1] : null;
+}
+
+function inspectDist(report, args) {
+  const root = resolve(args.dist);
+  if (!ensureExistingDir(report, root, 'dist_not_found', '--dist')) return;
+
+  const jsFiles = collectFiles(root, (file) => file.endsWith('.js'));
+  const allMapFiles = collectFiles(root, (file) => file.endsWith('.map'));
+  const mapFiles = allMapFiles.filter((file) => !file.endsWith('.d.ts.map'));
+  report.summary.dist = {
+    root,
+    jsFiles: jsFiles.length,
+    mapFiles: mapFiles.length,
+    ignoredDeclarationMaps: allMapFiles.length - mapFiles.length,
+  };
+
+  if (jsFiles.length === 0) {
+    push(report, 'errors', 'missing_js', '产物目录中没有找到 .js 文件。', { root });
+  }
+  if (mapFiles.length === 0) {
+    push(report, 'errors', 'missing_map', '产物目录中没有找到 .map 文件。', { root });
+  }
+
+  const mapFilesByRelativeJs = new Map();
+  for (const mapFile of mapFiles) {
+    mapFilesByRelativeJs.set(
+      normalizeName(relative(root, mapFile).replace(/\.map$/, ''), []),
+      mapFile,
+    );
+  }
+
+  for (const jsFile of jsFiles) {
+    inspectJavaScriptFile(report, jsFile, root, mapFilesByRelativeJs);
+  }
+
+  const artifactSamples = [];
+  for (const mapFile of mapFiles) {
+    inspectMapFile(report, mapFile, root, args, artifactSamples);
+  }
+  report.summary.dist.artifactSamples = artifactSamples.slice(0, 5);
+}
+
+function inspectJavaScriptFile(report, jsFile, root, mapFilesByRelativeJs) {
+  const relJs = normalizeName(relative(root, jsFile), []);
+  const sourceMappingUrl = findSourceMappingUrl(jsFile);
+  const siblingMap = mapFilesByRelativeJs.get(relJs);
+
+  if (!sourceMappingUrl) {
+    if (siblingMap) {
+      push(
+        report,
+        'notices',
+        'hidden_source_map',
+        'JS 未包含 sourceMappingURL，但找到了同名 .map；作为仅上传到 Sentry 的 hidden source map 是合理的。',
+        { jsFile, mapFile: siblingMap },
+      );
+    } else {
+      push(
+        report,
+        'warnings',
+        'js_without_map',
+        'JS 未包含 sourceMappingURL，也没有找到同名 .map。',
+        {
+          jsFile,
+        },
+      );
+    }
+    return;
+  }
+
+  if (sourceMappingUrl.startsWith('data:')) {
+    push(
+      report,
+      'warnings',
+      'inline_source_map',
+      '检测到内联 source map；生产上传建议输出独立 .map。',
+      {
+        jsFile,
+      },
+    );
+    return;
+  }
+
+  const mapPath = resolve(dirname(jsFile), sourceMappingUrl);
+  if (!existsSync(mapPath)) {
+    push(report, 'errors', 'broken_source_mapping_url', 'sourceMappingURL 指向的 .map 不存在。', {
+      jsFile,
+      sourceMappingUrl,
+    });
+  }
+}
+
+function inspectMapFile(report, mapFile, root, args, artifactSamples) {
+  let raw;
+  try {
+    raw = readJsonFile(mapFile);
+  } catch (error) {
+    push(report, 'errors', 'invalid_map_json', 'Source Map 不是合法 JSON。', {
+      mapFile,
+      error: error.message,
+    });
+    return;
+  }
+
+  inspectRawMap(report, raw, mapFile);
+
+  const artifactName = toArtifactName(raw.file, mapFile, root, args.urlPrefix);
+  artifactSamples.push(artifactName);
+  if (!artifactName.startsWith('app:///')) {
+    push(
+      report,
+      'warnings',
+      'unexpected_url_prefix',
+      'sentry-miniapp 默认把堆栈归一化为 app:///，上传 sourcemap 时建议使用 --url-prefix "app:///"。',
+      { mapFile, artifactName },
+    );
+  }
+
+  if (isWechatAppserviceName(raw.file || basename(mapFile).replace(/\.map$/, ''))) {
+    push(
+      report,
+      'notices',
+      'wechat_appservice_map',
+      '检测到微信 appservice 合并文件 map；如果你还想解析到 .vue/.tsx 源码，需要两层 sourcemap 合成。',
+      { mapFile },
+    );
+    addMergeSuggestion(report);
+  }
+}
+
+function inspectRawMap(report, raw, mapFile) {
+  if (!raw || typeof raw !== 'object') {
+    push(report, 'errors', 'invalid_map_shape', 'Source Map 顶层结构不是对象。', { mapFile });
+    return;
+  }
+  if (raw.version !== 3) {
+    push(report, 'warnings', 'unexpected_map_version', 'Source Map version 不是 3。', {
+      mapFile,
+      version: raw.version,
+    });
+  }
+  if (!Array.isArray(raw.sources) || raw.sources.length === 0) {
+    push(report, 'errors', 'missing_sources', 'Source Map 缺少 sources 或 sources 为空。', {
+      mapFile,
+    });
+  }
+  if (typeof raw.mappings !== 'string') {
+    push(report, 'errors', 'missing_mappings', 'Source Map 缺少 mappings 字符串。', { mapFile });
+  } else if (raw.mappings.length === 0) {
+    push(
+      report,
+      'warnings',
+      'empty_mappings',
+      'Source Map 的 mappings 为空，上传后通常无法定位到源码行列。',
+      {
+        mapFile,
+      },
+    );
+  }
+
+  if (Array.isArray(raw.sources)) {
+    const sourcesContent = Array.isArray(raw.sourcesContent) ? raw.sourcesContent : [];
+    const missing = raw.sources.filter(
+      (_, index) => typeof sourcesContent[index] !== 'string' || sourcesContent[index].length === 0,
+    );
+    if (missing.length > 0) {
+      push(
+        report,
+        'warnings',
+        'missing_sources_content',
+        `有 ${missing.length} 个 source 缺少 sourcesContent，上传后可能只能定位文件路径，无法展示源码内容。`,
+        { mapFile, sample: missing[0] },
+      );
+    }
+  }
+}
+
+function inspectWechatMap(report, args) {
+  const wechatFile = resolve(args.wechat);
+  if (!ensureExistingFile(report, wechatFile, 'wechat_map_not_found', '--wechat')) return;
+
+  let rawB;
+  try {
+    rawB = readJsonFile(wechatFile);
+  } catch (error) {
+    push(report, 'errors', 'invalid_wechat_map_json', '微信外层 Source Map 不是合法 JSON。', {
+      wechatFile,
+      error: error.message,
+    });
+    return;
+  }
+
+  inspectRawMap(report, rawB, wechatFile);
+  const bSources = Array.isArray(rawB.sources) ? rawB.sources : [];
+  report.summary.wechat = {
+    file: wechatFile,
+    sources: bSources.length,
+    outputFile: rawB.file ?? null,
+  };
+
+  if (!isWechatAppserviceName(rawB.file || basename(wechatFile).replace(/\.map$/, ''))) {
+    push(
+      report,
+      'warnings',
+      'wechat_map_file_unexpected',
+      '传入的 --wechat map 看起来不像 appservice.app.js / app-service.js 对应的外层 map。',
+      { wechatFile, file: rawB.file },
+    );
+  }
+
+  addMergeSuggestion(report);
+
+  if (!args.buildMaps) {
+    push(
+      report,
+      'warnings',
+      'missing_build_maps',
+      '未提供 --build-maps，doctor 只能检查外层微信 map，无法判断两层 map 能否合成。',
+      { wechatFile },
+    );
+    return;
+  }
+
+  const buildMapsDir = resolve(args.buildMaps);
+  if (!ensureExistingDir(report, buildMapsDir, 'build_maps_not_found', '--build-maps')) return;
+
+  const { index, fileCount, invalidMaps } = collectBuildMaps(buildMapsDir);
+  if (invalidMaps.length > 0) {
+    push(
+      report,
+      'warnings',
+      'invalid_build_maps',
+      `构建 map 目录中有 ${invalidMaps.length} 个 .map 不是合法 JSON。`,
+      {
+        sample: invalidMaps[0].file,
+      },
+    );
+  }
+
+  const matched = [];
+  const unmatched = [];
+  const ambiguous = [];
+
+  for (const src of bSources) {
+    const key = normalizeName(src, args.strip);
+    let { hit, ambiguous: ambiguousHits } = pickBuildMapCandidate(index, key);
+    if (!hit && !ambiguousHits) {
+      ({ hit, ambiguous: ambiguousHits } = pickBuildMapCandidate(
+        index,
+        normalizeName(basename(key), []),
+      ));
+    }
+    if (ambiguousHits) {
+      ambiguous.push({ src, key, hits: ambiguousHits.map((item) => item.file) });
+    } else if (hit) {
+      matched.push({ src, map: hit.file });
+    } else {
+      unmatched.push(src);
+    }
+  }
+
+  report.summary.wechat.merge = {
+    buildMapsDir,
+    buildMapFiles: fileCount,
+    indexedKeys: index.size,
+    total: bSources.length,
+    matched: matched.length,
+    unmatched: unmatched.length,
+    ambiguous: ambiguous.length,
+    matchedSamples: matched.slice(0, args.verbose ? 20 : 5),
+    unmatchedSamples: unmatched.slice(0, args.verbose ? 20 : 5),
+    ambiguousSamples: ambiguous.slice(0, args.verbose ? 20 : 5),
+  };
+
+  if (matched.length === 0 && bSources.length > 0) {
+    push(
+      report,
+      'errors',
+      'merge_no_match',
+      '外层 map 的 sources 一个都没匹配到构建 map；通常需要调整 --strip 或对齐构建产物文件名。',
+      { sample: bSources[0] },
+    );
+  } else if (unmatched.length > 0) {
+    push(
+      report,
+      'warnings',
+      'merge_unmatched_sources',
+      `有 ${unmatched.length} 个外层 source 没匹配到构建 map，这些位置会停在编译产物 JS。`,
+      { sample: unmatched[0] },
+    );
+  }
+
+  if (ambiguous.length > 0) {
+    push(
+      report,
+      'warnings',
+      'merge_ambiguous_sources',
+      `有 ${ambiguous.length} 个外层 source 匹配到多个构建 map，merge 脚本会跳过以避免误合成。`,
+      { sample: ambiguous[0].src },
+    );
+  }
+}
+
+function addReleaseWarning(report, args) {
+  if (!args.release) {
+    push(
+      report,
+      'warnings',
+      'missing_release',
+      '未传入 --release；Source Map 上传使用的 release 必须与 SDK init({ release }) 完全一致。',
+    );
+  }
+}
+
+function addMergeSuggestion(report) {
+  const suggestion =
+    '需要解析微信真机 appservice.app.js 到源码时，运行 scripts/merge-sourcemap.mjs 合成两层 map 后，再以 --url-prefix "app:///" 上传。';
+  if (!report.suggestions.includes(suggestion)) {
+    report.suggestions.push(suggestion);
+  }
+}
+
+const args = parseArgs(process.argv.slice(2));
+if (args.help) {
+  console.log(USAGE);
+  process.exit(0);
+}
+
+if (!args.dist && !args.wechat) {
+  if (args.json) {
+    const report = finalize(createReport(args));
+    push(report, 'errors', 'missing_input', '请传入 --dist 或 --wechat。');
+    console.log(JSON.stringify(finalize(report), null, 2));
+  } else {
+    console.log(USAGE);
+  }
+  process.exit(1);
+}
+
+const report = createReport(args);
+addReleaseWarning(report, args);
+if (args.dist) inspectDist(report, args);
+if (args.wechat) inspectWechatMap(report, args);
+finalize(report);
+
+if (args.json) {
+  console.log(JSON.stringify(report, null, 2));
+} else {
+  printReport(report);
+}
+
+process.exitCode = report.errors.length > 0 || (args.strict && report.warnings.length > 0) ? 1 : 0;

--- a/scripts/merge-sourcemap.mjs
+++ b/scripts/merge-sourcemap.mjs
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 /**
  * 两层 Source Map 离线合成脚本（best-effort）
  * ===========================================
@@ -47,8 +49,14 @@
  * `--url-prefix "app:///"` 不变）。
  */
 
-import { readFileSync, writeFileSync, readdirSync, mkdirSync } from 'node:fs';
-import { basename, dirname, join, relative, resolve } from 'node:path';
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { basename, dirname, resolve } from 'node:path';
+import {
+  collectBuildMaps,
+  normalizeName,
+  pickBuildMapCandidate,
+  readJsonFile,
+} from './sourcemap-utils.mjs';
 
 // ---- 极简参数解析（不引第三方）----
 function parseArgs(argv) {
@@ -61,8 +69,7 @@ function parseArgs(argv) {
     else if (a === '--strip') {
       const v = argv[++i];
       if (v !== undefined) out.strip.push(v); // 防止 --strip 作为末尾参数时 push 进 undefined
-    }
-    else if (a === '--verbose') out.verbose = true;
+    } else if (a === '--verbose') out.verbose = true;
     else if (a === '--help' || a === '-h') out.help = true;
   }
   return out;
@@ -90,7 +97,9 @@ try {
   const sm = await import('source-map');
   ({ SourceMapConsumer, SourceMapGenerator } = sm.default ?? sm);
 } catch {
-  console.error('✗ 缺少依赖 source-map，请先安装：\n    npm i -D source-map\n  （它只在用本脚本合成时需要，不是 SDK 运行时依赖）');
+  console.error(
+    '✗ 缺少依赖 source-map，请先安装：\n    npm i -D source-map\n  （它只在用本脚本合成时需要，不是 SDK 运行时依赖）',
+  );
   process.exit(1);
 }
 
@@ -99,81 +108,13 @@ const destroyConsumer = (c) => {
   if (c && typeof c.destroy === 'function') c.destroy();
 };
 
-// ---- 工具：把一个 source 名字归一成「裸文件名」用于匹配 ----
-function normalizeName(name, strip) {
-  let n = String(name).split('?')[0].split('#')[0].replace(/\\/g, '/'); // 去 query / hash，统一路径分隔符
-  for (const p of strip) {
-    const prefix = String(p).replace(/\\/g, '/');
-    if (n.startsWith(prefix)) n = n.slice(prefix.length);
-  }
-  while (n.startsWith('./') || n.startsWith('/')) {
-    n = n.startsWith('./') ? n.slice(2) : n.slice(1);
-  }
-  return n;
-}
-
-function addBuildMapCandidate(index, key, hit) {
-  if (!key) return;
-  const existing = index.get(key);
-  if (!existing) {
-    index.set(key, [hit]);
-    return;
-  }
-  if (!existing.some((item) => item.file === hit.file)) {
-    existing.push(hit);
-  }
-}
-
-function pickBuildMapCandidate(index, key) {
-  const hits = index.get(key);
-  if (!hits) return { hit: null, ambiguous: null };
-  if (hits.length === 1) return { hit: hits[0], ambiguous: null };
-  return { hit: null, ambiguous: hits };
-}
-
-// ---- 递归收集构建 map 目录下的所有 *.map，建索引 ----
-function collectBuildMaps(dir) {
-  const found = [];
-  const root = resolve(dir);
-  const walk = (d) => {
-    // withFileTypes 省去逐条 statSync；symlink 既不算 isDirectory 也不算 isFile，
-    // 自然跳过，顺带避免符号链接成环。
-    for (const entry of readdirSync(d, { withFileTypes: true })) {
-      const full = join(d, entry.name);
-      if (entry.isDirectory()) walk(full);
-      else if (entry.isFile() && entry.name.endsWith('.map')) found.push(full);
-    }
-  };
-  walk(root);
-
-  // 建多键索引：用「map 内部 file 字段」「相对 build-maps 根目录的产物路径」
-  // 和「文件名去掉 .map」三种 key 都指向它。前两者保证 pages/a/index.js 与
-  // pages/b/index.js 这类同名文件能精确匹配；basename 只作为最后兜底。
-  const index = new Map();
-  for (const file of found) {
-    let raw;
-    try {
-      raw = JSON.parse(readFileSync(file, 'utf8'));
-    } catch {
-      continue; // 不是合法 JSON map，跳过
-    }
-    const hit = { file, raw };
-    const keys = new Set();
-    if (raw.file) keys.add(normalizeName(raw.file, []));
-    keys.add(normalizeName(relative(root, file).replace(/\.map$/, ''), []));
-    keys.add(normalizeName(basename(file).replace(/\.map$/, ''), []));
-    for (const k of keys) {
-      addBuildMapCandidate(index, k, hit);
-    }
-  }
-  return { index, fileCount: found.length };
-}
-
 // ---- 主流程 ----
-const rawB = JSON.parse(readFileSync(resolve(args.wechat), 'utf8'));
+const rawB = readJsonFile(args.wechat);
 const bSources = Array.isArray(rawB.sources) ? rawB.sources : [];
 if (bSources.length === 0) {
-  console.error('✗ 外层 map 没有 sources 字段，无法合成。确认 --wechat 传的是微信线上 appservice.app.js 的 map。');
+  console.error(
+    '✗ 外层 map 没有 sources 字段，无法合成。确认 --wechat 传的是微信线上 appservice.app.js 的 map。',
+  );
   process.exit(1);
 }
 
@@ -234,7 +175,8 @@ if (ambiguous.length > 0) {
     for (const h of item.hits.slice(0, 5)) console.warn(`      - ${h.file}`);
     if (item.hits.length > 5) console.warn(`      …（候选共 ${item.hits.length} 个）`);
   }
-  if (ambiguous.length > 10) console.warn(`    …（共 ${ambiguous.length} 条，加 --verbose 看全部）`);
+  if (ambiguous.length > 10)
+    console.warn(`    …（共 ${ambiguous.length} 条，加 --verbose 看全部）`);
 }
 
 if (matched.length === 0) {
@@ -249,15 +191,22 @@ if (matched.length === 0) {
 }
 
 if (unmatched.length > 0) {
-  console.warn(`\n⚠ 有 ${unmatched.length} 个 source 没匹配上，这些位置会停在「编译产物 JS」、解不到源码：`);
+  console.warn(
+    `\n⚠ 有 ${unmatched.length} 个 source 没匹配上，这些位置会停在「编译产物 JS」、解不到源码：`,
+  );
   for (const s of unmatched.slice(0, 10)) console.warn(`    ${s}`);
-  if (unmatched.length > 10) console.warn(`    …（共 ${unmatched.length} 条，加 --verbose 看全部）`);
+  if (unmatched.length > 10)
+    console.warn(`    …（共 ${unmatched.length} 条，加 --verbose 看全部）`);
 }
 
 const outFile = resolve(args.out);
 mkdirSync(dirname(outFile), { recursive: true });
 writeFileSync(outFile, generator.toString(), 'utf8');
 console.log(`\n✓ 已写出合成 map：${outFile}`);
-console.log('  接着以 `app:///appservice.app.js` 的名字上传到 Sentry（--url-prefix "app:///" 不变）。');
+console.log(
+  '  接着以 `app:///appservice.app.js` 的名字上传到 Sentry（--url-prefix "app:///" 不变）。',
+);
 console.log('  注意：合成后精度是「两份 map 的较小值」，定位到行没问题，个别列号可能略糙。');
-console.log('  ⚠ 合成 map 内嵌源码（sourcesContent），仅用于上传 Sentry，别打进小程序包或公开发布，用完即删。');
+console.log(
+  '  ⚠ 合成 map 内嵌源码（sourcesContent），仅用于上传 Sentry，别打进小程序包或公开发布，用完即删。',
+);

--- a/scripts/sourcemap-utils.mjs
+++ b/scripts/sourcemap-utils.mjs
@@ -1,0 +1,83 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { basename, join, relative, resolve } from 'node:path';
+
+export function readJsonFile(file) {
+  return JSON.parse(readFileSync(resolve(file), 'utf8'));
+}
+
+export function normalizeName(name, strip = []) {
+  let n = String(name).split('?')[0].split('#')[0].replace(/\\/g, '/');
+  for (const p of strip) {
+    const prefix = String(p).replace(/\\/g, '/');
+    if (n.startsWith(prefix)) n = n.slice(prefix.length);
+  }
+  while (n.startsWith('./') || n.startsWith('/')) {
+    n = n.startsWith('./') ? n.slice(2) : n.slice(1);
+  }
+  return n;
+}
+
+export function collectFiles(dir, predicate) {
+  const root = resolve(dir);
+  const found = [];
+  const walk = (d) => {
+    for (const entry of readdirSync(d, { withFileTypes: true })) {
+      const full = join(d, entry.name);
+      if (entry.isDirectory()) walk(full);
+      else if (entry.isFile() && predicate(full, entry)) found.push(full);
+    }
+  };
+  walk(root);
+  return found;
+}
+
+export function addBuildMapCandidate(index, key, hit) {
+  if (!key) return;
+  const existing = index.get(key);
+  if (!existing) {
+    index.set(key, [hit]);
+    return;
+  }
+  if (!existing.some((item) => item.file === hit.file)) {
+    existing.push(hit);
+  }
+}
+
+export function pickBuildMapCandidate(index, key) {
+  const hits = index.get(key);
+  if (!hits) return { hit: null, ambiguous: null };
+  if (hits.length === 1) return { hit: hits[0], ambiguous: null };
+  return { hit: null, ambiguous: hits };
+}
+
+export function collectBuildMaps(dir) {
+  const root = resolve(dir);
+  const found = collectFiles(root, (file) => file.endsWith('.map'));
+  const index = new Map();
+  const invalidMaps = [];
+
+  for (const file of found) {
+    let raw;
+    try {
+      raw = readJsonFile(file);
+    } catch (error) {
+      invalidMaps.push({ file, error });
+      continue;
+    }
+
+    const hit = { file, raw };
+    const keys = new Set();
+    if (raw.file) keys.add(normalizeName(raw.file, []));
+    keys.add(normalizeName(relative(root, file).replace(/\.map$/, ''), []));
+    keys.add(normalizeName(basename(file).replace(/\.map$/, ''), []));
+    for (const k of keys) {
+      addBuildMapCandidate(index, k, hit);
+    }
+  }
+
+  return { index, fileCount: found.length, invalidMaps, files: found };
+}
+
+export function isWechatAppserviceName(name) {
+  return /(^|\/)(appservice\.app|app-service|appservice)\.js$/i.test(normalizeName(name, []));
+}

--- a/test/sourcemap-doctor.test.ts
+++ b/test/sourcemap-doctor.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it, afterEach } from '@jest/globals';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const repoRoot = resolve(__dirname, '..');
+const doctorScript = join(repoRoot, 'scripts/doctor-sourcemap.mjs');
+const tmpRoots: string[] = [];
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'sentry-miniapp-sourcemap-doctor-'));
+  tmpRoots.push(dir);
+  return dir;
+}
+
+function writeJson(file: string, value: unknown): void {
+  writeFileSync(file, JSON.stringify(value), 'utf8');
+}
+
+function runDoctor(args: string[]): { status: number; stdout: string } {
+  try {
+    const stdout = execFileSync('node', [doctorScript, ...args, '--json'], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    });
+    return { status: 0, stdout };
+  } catch (error) {
+    const err = error as { status?: number; stdout?: Buffer | string };
+    return {
+      status: err.status ?? 1,
+      stdout: Buffer.isBuffer(err.stdout) ? err.stdout.toString('utf8') : (err.stdout ?? ''),
+    };
+  }
+}
+
+afterEach(() => {
+  for (const dir of tmpRoots.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('doctor-sourcemap', () => {
+  it('passes a dist with matching js and source map', () => {
+    const dist = makeTempDir();
+    writeFileSync(join(dist, 'app.js'), 'console.log("ok");\n//# sourceMappingURL=app.js.map\n');
+    writeJson(join(dist, 'app.js.map'), {
+      version: 3,
+      file: 'app.js',
+      sources: ['src/app.ts'],
+      sourcesContent: ['console.log("ok");'],
+      names: [],
+      mappings: 'AAAA',
+    });
+    writeJson(join(dist, 'app.d.ts.map'), {
+      version: 3,
+      file: 'app.d.ts',
+      sources: ['src/app.ts'],
+      names: [],
+      mappings: 'AAAA',
+    });
+
+    const result = runDoctor(['--dist', dist, '--release', 'miniapp@1.0.0']);
+    const report = JSON.parse(result.stdout);
+
+    expect(result.status).toBe(0);
+    expect(report.status).toBe('pass');
+    expect(report.summary.dist).toMatchObject({
+      jsFiles: 1,
+      mapFiles: 1,
+      ignoredDeclarationMaps: 1,
+    });
+  });
+
+  it('warns but does not fail for hidden source maps without release', () => {
+    const dist = makeTempDir();
+    writeFileSync(join(dist, 'app.js'), 'console.log("ok");\n');
+    writeJson(join(dist, 'app.js.map'), {
+      version: 3,
+      file: 'app.js',
+      sources: ['src/app.ts'],
+      names: [],
+      mappings: 'AAAA',
+    });
+
+    const result = runDoctor(['--dist', dist]);
+    const report = JSON.parse(result.stdout);
+    const warningCodes = report.warnings.map((warning: { code: string }) => warning.code);
+    const noticeCodes = report.notices.map((notice: { code: string }) => notice.code);
+
+    expect(result.status).toBe(0);
+    expect(report.status).toBe('warn');
+    expect(warningCodes).toEqual(
+      expect.arrayContaining(['missing_release', 'missing_sources_content']),
+    );
+    expect(noticeCodes).toContain('hidden_source_map');
+  });
+
+  it('fails invalid source map json', () => {
+    const dist = makeTempDir();
+    writeFileSync(join(dist, 'app.js'), 'console.log("ok");\n//# sourceMappingURL=app.js.map\n');
+    writeFileSync(join(dist, 'app.js.map'), '{ invalid json', 'utf8');
+
+    const result = runDoctor(['--dist', dist, '--release', 'miniapp@1.0.0']);
+    const report = JSON.parse(result.stdout);
+
+    expect(result.status).toBe(1);
+    expect(report.status).toBe('fail');
+    expect(report.errors.map((item: { code: string }) => item.code)).toContain('invalid_map_json');
+  });
+
+  it('checks whether wechat outer maps can match build maps', () => {
+    const root = makeTempDir();
+    const wechat = join(root, 'appservice.app.js.map');
+    const buildMaps = join(root, 'build');
+    mkdirSync(join(buildMaps, 'pages/index'), { recursive: true });
+
+    writeJson(wechat, {
+      version: 3,
+      file: 'appservice.app.js',
+      sources: ['webpack://pages/index/index.js'],
+      sourcesContent: ['Page({});'],
+      names: [],
+      mappings: 'AAAA',
+    });
+    writeJson(join(buildMaps, 'pages/index/index.js.map'), {
+      version: 3,
+      file: 'pages/index/index.js',
+      sources: ['src/pages/index.ts'],
+      sourcesContent: ['Page({});'],
+      names: [],
+      mappings: 'AAAA',
+    });
+
+    const result = runDoctor([
+      '--wechat',
+      wechat,
+      '--build-maps',
+      buildMaps,
+      '--strip',
+      'webpack://',
+      '--release',
+      'miniapp@1.0.0',
+    ]);
+    const report = JSON.parse(result.stdout);
+
+    expect(result.status).toBe(0);
+    expect(report.summary.wechat.merge).toMatchObject({
+      total: 1,
+      matched: 1,
+      unmatched: 0,
+      ambiguous: 0,
+    });
+    expect(report.errors).toHaveLength(0);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -7333,6 +7333,9 @@ __metadata:
     vite: "npm:^6.4.1"
     vite-plugin-dts: "npm:^4.5.4"
     vitepress: "npm:^1.6.4"
+  bin:
+    sentry-miniapp-sourcemap-doctor: ./scripts/doctor-sourcemap.mjs
+    sentry-miniapp-sourcemap-merge: ./scripts/merge-sourcemap.mjs
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## 变更说明
- 新增 `sentry-miniapp-sourcemap-doctor` CLI 与 `npm run sourcemap:doctor`，支持本地静态检查 dist 产物和微信两层 Source Map 匹配
- 新增 `sentry-miniapp-sourcemap-merge` CLI，复用现有两层 Source Map 合成能力
- 将 `merge-sourcemap` 的 source 名称归一化、构建 map 索引逻辑抽到 `scripts/sourcemap-utils.mjs`，doctor 与 merge 复用同一套匹配逻辑
- 通过 package `bin` 和 `files` 发布 `doctor` / `merge` / utils 脚本，并补齐可执行权限
- 更新 README 与 Source Map 指南，说明本地 doctor、CI strict 模式、JSON 留档和微信两层诊断方式
- 增加 doctor 单测，覆盖 dist 检查、hidden sourcemap、非法 map JSON、微信两层匹配

## 验证
- `yarn install --immutable`
- `npm run sourcemap:doctor -- --dist dist --release sentry-miniapp@1.16.0 --json`
- `yarn test sourcemap-doctor.test.ts`
- `yarn run lint`
- `yarn run typecheck`
- `yarn run test`
- `yarn run docs:build`
- `yarn run build`
- `npm pack --dry-run --json`