### PR TITLE
docs: 优化 README 用户接入文案

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,18 +19,16 @@
 
 > **📰 最新文章**：[《我给 Sentry 提了个 PR，后来 sentry-miniapp 进了官方文档》](https://juejin.cn/post/7636106283963760681) — sentry-miniapp 已被收录进 Sentry 官方文档的 community-supported SDK 列表。觉得有用请帮忙点个 ⭐ Star，让更多小程序团队找到它。
 
-完整版本历史见 [GitHub Releases](https://github.com/lizhiyao/sentry-miniapp/releases)。
-
 ---
 
-## ✨ 你可以用它解决什么
+## ✨ 它适合解决哪些问题
 
-- **异常自动捕获**：全局异常、Promise rejection、页面异常、内存告警开箱即采。
-- **排查上下文**：设备信息、页面生命周期、点击 / 触摸、网络请求会作为面包屑随错误一起上报。
-- **性能与链路追踪**：采集启动、页面渲染、资源加载和 API 请求耗时；请求可作为 `http.client` span 串联后端链路。
-- **Source Map 友好**：把不同平台的虚拟堆栈路径统一为 `app:///`，兼容 Debug ID，并支持用 `stackParser` 适配特殊运行时。
-- **弱网与合规场景**：断网或发送失败会本地缓存并重试；`requireConsent` 可在用户同意前只写缓冲、不发网络。
-- **小游戏专属能力**：微信 / 抖音小游戏可采集冷启动首帧、FPS 和 jank。
+- **异常自动捕获**：自动捕获全局异常、Promise rejection、页面异常和内存告警，把问题送进 Sentry Issues，而不是只停留在用户反馈里。
+- **排查上下文**：记录设备信息、页面生命周期、点击 / 触摸和网络请求面包屑，帮助还原用户出错前做了什么。
+- **性能与链路追踪**：采集启动、页面渲染、资源加载和 API 请求耗时；开启 tracing 后，请求可作为 `http.client` span 串联后端链路。
+- **Source Map 友好**：统一多平台虚拟堆栈路径为 `app:///`，配合 Source Map / Debug ID 还原源码位置；特殊运行时可用 `stackParser` 适配。
+- **弱网与合规场景**：上报失败会先进本地离线队列，网络恢复后自动重试；开启 `requireConsent` 后，事件只写入本地缓冲，不向 Sentry 发起请求，用户同意后再调用 `Sentry.setConsent(true)` 补发。
+- **小游戏专属能力**：微信 / 抖音小游戏可采集冷启动首帧、FPS 和 jank，便于定位卡顿和首帧慢问题。
 - **熟悉的 Sentry API**：支持 `captureException`、`setUser`、`addBreadcrumb`、`startSpan`、`captureFeedback`、`Sentry.logger.*` 等常用能力。
 
 ---
@@ -39,7 +37,7 @@
 
 **接入前确认**：
 
-- 已有 Sentry 项目（官方 SaaS 或私有化部署均可）。
+- 已有可用的 Sentry 服务（Sentry SaaS 或自托管实例均可），并在 Sentry 中创建好项目、复制该项目的 DSN。
 - 小程序后台已把 Sentry 上报域名加入 `request` 合法域名。
 
 安装：
@@ -50,13 +48,13 @@ npm install sentry-miniapp
 
 > 不使用 npm 时，也可直接将 `examples/wxapp/lib/sentry-miniapp.js` 复制到小程序项目中引入。
 
-### 🤖 使用 Codex 辅助接入
+### 🤖 AI Coding Agent 辅助接入
 
-在 [Codex](https://openai.com/codex/) 中打开你的小程序项目后，可以直接说：
+如果你使用支持读取仓库上下文的 AI Coding Agent，可以让它先读取本仓库的 `AGENTS.md` 和 `.agents/skills/sentry-miniapp-sdk/`，然后直接说：
 
 > 帮我接入 sentry-miniapp，先识别平台和框架，再完成初始化并给出验证步骤。
 
-Codex 会按 `sentry-miniapp-sdk` skill 检查原生小程序 / Taro / uni-app、入口文件位置、初始化顺序和生产配置注意事项。
+这样 Agent 会按仓库约定检查原生小程序 / Taro / uni-app、入口文件位置、初始化顺序和生产配置注意事项。
 
 在入口文件（`app.js` / `app.ts`）**最顶部、`App()` 之前**初始化：
 
@@ -82,12 +80,7 @@ Sentry.captureException(new Error('sentry test'));
 
 然后到 Sentry 的 Issues 列表查看事件。
 
-先排查这些常见问题：
-
-- `Sentry.init` 必须在 `App()` 之前执行，放进 `App.onLaunch` 会丢失部分启动阶段能力。
-- 默认集成已包含异常捕获、性能监控、Source Map 路径归一化、网络面包屑、Session 与网络状态监控，通常无需手动传 `integrations`。
-- `addBreadcrumb` 不会单独上报，只随下一次事件一起发送；只调它而不捕获事件，后台会一直没有数据。
-- `release` 要和 Source Map 上传时的 release 完全一致，否则源码堆栈无法还原。
+没看到事件时，优先确认 DSN、合法域名、初始化位置和采样配置；完整排查清单见 [文档站 · 快速接入](https://sentry-miniapp.pages.dev/guide/getting-started) 与 [FAQ](https://sentry-miniapp.pages.dev/guide/faq#no-events)。
 
 ---
 
@@ -136,17 +129,19 @@ Sentry.setConsent(true);
 | 确认各平台、小程序 / 小游戏能力差异 | [支持平台与能力](https://sentry-miniapp.pages.dev/guide/platforms) |
 | 关心主包体积 | [主包体积优化](https://sentry-miniapp.pages.dev/guide/bundle-size) |
 | 看可运行示例 | [示例工程](https://sentry-miniapp.pages.dev/guide/examples) |
+| 查看版本历史与每次发布内容 | [GitHub Releases](https://github.com/lizhiyao/sentry-miniapp/releases) |
 | 参与开发或贡献 | [开发指南](https://github.com/lizhiyao/sentry-miniapp/blob/master/DEVELOPMENT.md) / [贡献指南](https://github.com/lizhiyao/sentry-miniapp/blob/master/CONTRIBUTING.md) |
 
 ---
 
 ## ❓ 常见问题
 
-- **必须在 `onError` 里手动上报吗？** 不用，`init` 会自动挂全局错误监听。
-- **网络请求会随错误上报吗？** 会，默认开启，记成 `category: xhr` 面包屑随错误一起发。
-- **uni-app（Vue）组件内错误上报率很低？** Vue 吞掉了组件错误，需接 `app.config.errorHandler`；Taro（React）用错误边界。
-- **支持 Session Replay 吗？** 不支持（小程序无 DOM），用面包屑还原现场。
-- **H5 端怎么办？** 用官方 `@sentry/browser`，按端条件编译引入。
+- **初始化后 Sentry 里没有事件？** 先用 `captureException` 主动发一个测试事件，再检查 DSN、`request` 合法域名、`Sentry.init` 是否在 `App()` 前执行、`sampleRate` 是否过低，以及是否只调用了 `addBreadcrumb`。面包屑不会单独上报，只会随下一次事件发送。
+- **必须在 `onError` 里手动上报吗？** 不用。`Sentry.init` 会注册平台全局错误监听；前提是它在 `App()` 前执行。若初始化太晚，启动阶段生命周期、Session 和部分面包屑会降级。
+- **网络请求会随错误上报吗？** 会。默认记录 `url`、`method`、状态码、耗时等摘要，并作为面包屑随事件上报；默认不记录请求 / 响应体，需要时再开启 `traceNetworkBody` 并做好脱敏。
+- **uni-app / Taro 组件错误为什么还要额外接？** 框架可能先接住组件错误，不一定冒泡到平台全局 `onError`。Vue 用 `app.config.errorHandler` / `Vue.config.errorHandler`，Taro React 建议加 Error Boundary。
+- **隐私协议同意前会发请求吗？** 默认会按 SDK 配置正常上报；如果业务要求同意前禁止出网，请开启 `requireConsent`，并在用户同意后调用 `Sentry.setConsent(true)`。
+- **支持 Session Replay 或 H5 端吗？** 小程序没有 DOM，暂不支持官方 Session Replay；H5 端请用官方 `@sentry/browser`，小程序端继续用 `sentry-miniapp`。
 
 > 每条的完整解答见 **[文档站 · 常见问题](https://sentry-miniapp.pages.dev/guide/faq)**。
 
@@ -154,7 +149,7 @@ Sentry.setConsent(true);
 
 ## 💬 联系与交流
 
-遇到问题？想探讨小程序监控方案？由于微信群二维码有 7 天时效，请添加作者微信（**备注 sentry-miniapp**），由作者邀请入群：
+遇到问题？想探讨小程序 / 小游戏监控方案？由于微信群二维码有 7 天时效，请添加作者微信（**备注 sentry-miniapp**），由作者邀请入群：
 
 <img src="https://raw.githubusercontent.com/lizhiyao/sentry-miniapp/master/docs/qrcode/zhiyao.jpeg" alt="作者微信二维码" width="200" style="border-radius: 8px; box-shadow: 0 4px 8px rgba(0,0,0,0.1);" />
 

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -21,18 +21,16 @@ Mini program runtimes do not provide browser APIs like `window`, `fetch`, or `XM
 
 > **📰 Featured Article (Chinese)**: [《我给 Sentry 提了个 PR，后来 sentry-miniapp 进了官方文档》](https://juejin.cn/post/7636106283963760681) — How sentry-miniapp got listed in Sentry's official community-supported SDKs documentation. If you find this project useful, please consider giving it a ⭐ Star.
 
-See [GitHub Releases](https://github.com/lizhiyao/sentry-miniapp/releases) for version history.
-
 ---
 
-## ✨ What It Helps With
+## ✨ Problems It Helps Solve
 
-- **Automatic error capture**: Global errors, Promise rejections, page errors, and memory warnings.
-- **Useful debugging context**: Device info, page lifecycle, taps/touches, and network requests are recorded as breadcrumbs and sent with errors.
-- **Performance and tracing**: Startup, page rendering, resource loading, and API requests; requests can be reported as `http.client` spans for backend trace correlation.
-- **Source Map friendly stacks**: Platform-specific virtual paths are normalized to `app:///`, with Debug ID support and custom `stackParser` support for unusual runtimes.
-- **Weak-network and privacy flows**: Offline or failed sends are cached and retried; `requireConsent` can buffer events before user consent without sending network requests.
-- **Mini game support**: WeChat / Douyin mini games can report first frame, FPS, and jank.
+- **Automatic error capture**: Captures global errors, Promise rejections, page errors, and memory warnings automatically, then sends them to Sentry Issues instead of leaving them only in user feedback.
+- **Debugging context**: Records device info, page lifecycle, taps/touches, and network breadcrumbs to help reconstruct what happened before a user hit an error.
+- **Performance and tracing**: Tracks startup, page rendering, resource loading, and API timing; with tracing enabled, requests can be reported as `http.client` spans for backend correlation.
+- **Source Map friendly stacks**: Normalizes platform-specific virtual stack paths to `app:///`, supports Source Maps / Debug IDs, and exposes `stackParser` for unusual runtimes.
+- **Weak-network and privacy flows**: Failed sends go into the local offline queue and retry when the network recovers; with `requireConsent`, events are buffered locally without sending to Sentry until `Sentry.setConsent(true)` is called.
+- **Mini game support**: WeChat / Douyin mini games can report first frame, FPS, and jank to help diagnose slow startup and stutter.
 - **Familiar Sentry APIs**: `captureException`, `setUser`, `addBreadcrumb`, `startSpan`, `captureFeedback`, `Sentry.logger.*`, and more.
 
 ---
@@ -41,7 +39,7 @@ See [GitHub Releases](https://github.com/lizhiyao/sentry-miniapp/releases) for v
 
 Before you start:
 
-- Create a Sentry project (SaaS or self-hosted).
+- Have access to a working Sentry service (Sentry SaaS or self-hosted), then create a project in Sentry and copy its DSN.
 - Add your Sentry endpoint domain to the `request` trusted-domain list in your mini program console.
 
 Install:
@@ -52,13 +50,13 @@ npm install sentry-miniapp
 
 > Not using npm? Copy `examples/wxapp/lib/sentry-miniapp.js` from this repo directly into your project.
 
-### 🤖 Use Codex For Guided Setup
+### 🤖 AI Coding Agent Setup
 
-Open your mini program project in [Codex](https://openai.com/codex/) and ask:
+If you use an AI coding agent that can read repository context, ask it to read this repo's `AGENTS.md` and `.agents/skills/sentry-miniapp-sdk/`, then say:
 
 > Help me set up sentry-miniapp. Detect the platform and framework first, then update the entry file and give me verification steps.
 
-Codex can use the `sentry-miniapp-sdk` skill to check native mini program / Taro / uni-app setup, entry-file placement, initialization order, and production configuration notes.
+The agent can then follow the repo guidance to check native mini program / Taro / uni-app setup, entry-file placement, initialization order, and production configuration notes.
 
 Initialize at the **top** of your entry file (`app.js` / `app.ts`), **before** `App()`:
 
@@ -84,12 +82,7 @@ Sentry.captureException(new Error('sentry test'));
 
 Then check the Sentry Issues list.
 
-If nothing shows up, check these first:
-
-- `Sentry.init` must run before `App()`; putting it in `App.onLaunch` degrades startup instrumentation.
-- Default integrations already include exception capture, performance monitoring, Source Map path normalization, network breadcrumbs, session, and network status monitoring. You usually don't need to pass `integrations`.
-- `addBreadcrumb` is not reported on its own. It only ships with the next captured event.
-- `release` must exactly match the release used for Source Map upload, otherwise source stack traces cannot be resolved.
+If nothing shows up, first check the DSN, trusted domain, initialization placement, and sampling config. The full checklist lives in [Getting Started](https://sentry-miniapp.pages.dev/guide/getting-started) and the [FAQ](https://sentry-miniapp.pages.dev/guide/faq#no-events).
 
 ---
 
@@ -138,17 +131,19 @@ After the first event is working, pick the guide based on what you are doing nex
 | Check platform, mini program, and mini game capability differences | [Platforms & Capabilities](https://sentry-miniapp.pages.dev/guide/platforms) |
 | Reduce main-package size | [Bundle Size](https://sentry-miniapp.pages.dev/guide/bundle-size) |
 | See runnable examples | [Examples](https://sentry-miniapp.pages.dev/guide/examples) |
+| Check version history and release notes | [GitHub Releases](https://github.com/lizhiyao/sentry-miniapp/releases) |
 | Contribute to the project | [Development Guide](https://github.com/lizhiyao/sentry-miniapp/blob/master/DEVELOPMENT.md) / [Contributing Guide](https://github.com/lizhiyao/sentry-miniapp/blob/master/CONTRIBUTING.md) |
 
 ---
 
 ## ❓ FAQ
 
-- **Must I report manually in `onError`?** No — `init` hooks the global error listeners automatically.
-- **Are network requests included with errors?** Yes, on by default — recorded as `category: xhr` breadcrumbs shipped with the error.
-- **uni-app (Vue) component errors rarely reported?** Vue swallows component errors; wire `app.config.errorHandler`. Taro (React) uses an Error Boundary.
-- **Session Replay?** Not supported (no DOM); reconstruct via breadcrumbs.
-- **H5 build?** Use official `@sentry/browser`, branched via conditional compilation.
+- **No events in Sentry after initialization?** Send a test event with `captureException`, then check the DSN, `request` trusted domain, whether `Sentry.init` runs before `App()`, whether `sampleRate` is too low, and whether you only called `addBreadcrumb`. Breadcrumbs are not sent alone; they ship with the next captured event.
+- **Must I report manually in `onError`?** No. `Sentry.init` registers platform global error listeners automatically, as long as it runs before `App()`. If it runs too late, startup lifecycle, session, and some breadcrumbs are degraded.
+- **Are network requests included with errors?** Yes. By default the SDK records `url`, `method`, status code, and duration summaries as breadcrumbs. Request / response bodies are not recorded by default; enable `traceNetworkBody` only when you also handle sanitization.
+- **Why do uni-app / Taro component errors need extra wiring?** Frameworks may catch component errors before they reach the platform global `onError`. Use `app.config.errorHandler` / `Vue.config.errorHandler` for Vue, and an Error Boundary for Taro React.
+- **Will it send requests before privacy consent?** By default the SDK reports normally according to your config. If your app must avoid network requests before consent, enable `requireConsent` and call `Sentry.setConsent(true)` once the user grants consent.
+- **Session Replay or H5 builds?** Mini programs have no DOM, so official Session Replay is not supported. For H5 builds, use official `@sentry/browser`; keep `sentry-miniapp` for mini program builds.
 
 > Full answers on the **[docs site · FAQ](https://sentry-miniapp.pages.dev/guide/faq)**.
 
@@ -156,7 +151,7 @@ After the first event is working, pick the guide based on what you are doing nex
 
 ## 💬 Community
 
-Have questions or want to discuss mini program monitoring? Due to WeChat group QR code expiration (7-day limit), please add the author on WeChat (**note: sentry-miniapp**) to be invited to the group:
+Have questions or want to discuss mini program / mini game monitoring? Due to WeChat group QR code expiration (7-day limit), please add the author on WeChat (**note: sentry-miniapp**) to be invited to the group:
 
 <img src="https://raw.githubusercontent.com/lizhiyao/sentry-miniapp/master/docs/qrcode/zhiyao.jpeg" alt="Author WeChat QR Code" width="200" style="border-radius: 8px; box-shadow: 0 4px 8px rgba(0,0,0,0.1);" />
 

--- a/website/guide/examples.md
+++ b/website/guide/examples.md
@@ -23,4 +23,4 @@ uni-app 用 `npm run dev:mp-weixin`；wxapp 直接用微信开发者工具导入
 ## 关键集成点
 
 - **初始化封装**：各示例的 `src/utils/sentry.*` 是集成核心（DSN、采样、`traceNetworkBody`、标签）。
-- **组件错误**：uni-app 在 `main.js` 接 `errorHandler`；Taro(React) 用 `SentryBoundary` 错误边界。详见 [常见问题 · 组件内错误](/guide/faq#组件内错误)。
+- **组件错误**：uni-app 在 `main.js` 接 `errorHandler`；Taro(React) 用 `SentryBoundary` 错误边界。详见 [常见问题 · 组件内错误](/guide/faq#component-errors)。

--- a/website/guide/faq.md
+++ b/website/guide/faq.md
@@ -1,10 +1,34 @@
 # 常见问题 (FAQ)
 
+## 初始化后 Sentry 里没有数据，先查什么？ {#no-events}
+
+先用最小链路确认 SDK 是否能发出事件：
+
+```js
+Sentry.captureException(new Error('sentry test'));
+```
+
+如果 Sentry Issues 里仍然看不到事件，按这个顺序排查：
+
+- **DSN / Project 是否可用**：确认 DSN 属于当前要看的 Sentry Project，且没有把测试事件发到其它环境或其它项目里。
+- **request 合法域名是否配置**：把 DSN 里的实际 host 加入小程序后台「request 合法域名」，例如 `o0.ingest.sentry.io`；自托管则填写你的 Sentry 服务域名。
+- **初始化位置是否太晚**：`Sentry.init` 必须在 `App()` 调用之前执行。放进 `App.onLaunch` 后，手动 `captureException` 仍可能可用，但启动阶段生命周期、Session、部分面包屑和冷启动耗时会降级。
+- **是否只调用了 `addBreadcrumb`**：面包屑不会单独上报，只会随下一次 error / message / transaction 一起发送。验证接入时请用 `captureException` 或 `captureMessage`。
+- **采样是否过滤了事件**：确认 `sampleRate` 没有被设得太低；如果只验证性能 transaction，还要确认 `tracesSampleRate` 或 `tracesSampler`。
+- **开发者工具与真机差异**：微信开发者工具某些环境的报错不触发底层 `wx.onError`，建议用真机预览验证自动异常捕获。
+- **框架组件错误是否被吞掉**：uni-app / Taro 的组件错误可能被 Vue / React 先接住，不一定冒泡到平台全局 `onError`。这类错误需要接框架错误处理，见 [组件内错误](#component-errors)。
+
+排查时也可以打印诊断信息，并把输出贴到 GitHub issue：
+
+```js
+console.log(Sentry.getDiagnostics());
+```
+
 ## 初始化后必须在 `onError` 中手动调 API 吗？
 
 **不需要。** SDK 初始化时会自动劫持并注册平台底层的全局错误监听（如 `wx.onError`）。只要 `Sentry.init` 在 `App()` 调用**之前**执行，就能自动捕获未处理的 JS 异常。
 
-没上报时检查：① Sentry 域名是否加入小程序后台合法域名；② `sampleRate` 是否被设得太低；③ 微信开发者工具某些环境的报错不触发底层 `onError`，建议**真机预览**下测试。
+如果整体没有数据，先按 [初始化后没有数据](#no-events) 的清单排查；如果只有组件内错误缺失，继续看 [组件内错误](#component-errors)。
 
 ## 网络请求会随错误事件一起上报吗？
 
@@ -22,7 +46,7 @@
 
 `enableConsoleBreadcrumbs` 只会把 `console.log/warn/error` 记录成面包屑，随**下一次 error / message / transaction 事件**一起发送；如果后续没有事件，它不会单独出现在 Sentry。
 
-## 组件内错误 {#组件内错误}
+## 组件内错误 {#component-errors}
 
 ### uni-app（Vue）组件内的错误没上报 / 上报率很低？
 
@@ -58,6 +82,27 @@ class SentryBoundary extends React.Component {
 ```
 
 完整示例见 [示例工程](/guide/examples)。
+
+## 隐私协议同意前如何避免发送 Sentry 网络请求？ {#privacy-consent}
+
+默认情况下，SDK 会按你的初始化配置正常上报事件。如果业务要求用户同意隐私协议前不能发出 Sentry 网络请求，可以开启 `requireConsent`：
+
+```js
+Sentry.init({
+  dsn: 'https://your-dsn@o0.ingest.sentry.io/0',
+  requireConsent: true,
+});
+```
+
+开启后，同意前捕获到的事件会写入本地缓冲，不会向 Sentry 发起请求。用户同意后调用：
+
+```js
+Sentry.setConsent(true);
+```
+
+SDK 会恢复发送，并补发仍在缓冲期内的事件。用户撤回同意时可调用 `Sentry.setConsent(false)`，后续事件会继续进入缓冲而不是出网。
+
+这个能力适合隐私协议弹窗、分端合规开关、灰度验证等场景；如果只是想降低上报量，优先使用 `sampleRate` / `tracesSampleRate`，不要把 `requireConsent` 当采样开关。
 
 ## 支持 Session Replay（屏幕操作回放）吗？
 

--- a/website/guide/getting-started.md
+++ b/website/guide/getting-started.md
@@ -64,7 +64,9 @@ Sentry.captureException(new Error('sentry test'));
 
 - **合法域名**：自托管 Sentry / 真机预览时，需把 Sentry 上报域名加入小程序后台「request 合法域名」白名单（开发者工具可临时勾选「不校验合法域名」绕过）。
 - **真机 vs 开发者工具**：微信开发者工具某些环境下的报错不会触发底层 `wx.onError`，建议在真机预览下测试。
-- **uni-app / Taro 框架**：组件内的错误可能被框架接住、不冒泡到 `wx.onError`，需接框架的错误处理。详见 [Taro 接入指南](/guide/taro)、[uni-app 接入指南](/guide/uniapp) 或 [常见问题](/guide/faq#组件内错误)。
+- **uni-app / Taro 框架**：组件内的错误可能被框架接住、不冒泡到 `wx.onError`，需接框架的错误处理。详见 [Taro 接入指南](/guide/taro)、[uni-app 接入指南](/guide/uniapp) 或 [常见问题](/guide/faq#component-errors)。
+
+仍然没有数据时，按 [FAQ · 初始化后没有数据](/guide/faq#no-events) 的完整清单逐项排查。
 
 ## 下一步
 

--- a/website/guide/taro.md
+++ b/website/guide/taro.md
@@ -99,7 +99,7 @@ export default class SentryBoundary extends Component<{ children: ReactNode }, {
 事件回调 / `setTimeout` / 异步里的错误，错误边界捕获不到——那些请直接 `try/catch` 后 `Sentry.captureException`，或交给 SDK 的全局 / TryCatch 集成。
 :::
 
-> 这是 Taro(React) 对应 uni-app(Vue) `errorHandler` 的做法。对比见 [常见问题 · 组件内错误](/guide/faq#组件内错误)。
+> 这是 Taro(React) 对应 uni-app(Vue) `errorHandler` 的做法。对比见 [常见问题 · 组件内错误](/guide/faq#component-errors)。
 
 ## 5. 分端接入（同时要 H5）
 

--- a/website/guide/uniapp.md
+++ b/website/guide/uniapp.md
@@ -75,7 +75,7 @@ Vue.config.errorHandler = (err, vm, info) => {
 };
 ```
 
-> 这是 uni-app(Vue) 对应 Taro(React) 错误边界的做法。对比见 [常见问题 · 组件内错误](/guide/faq#组件内错误)。
+> 这是 uni-app(Vue) 对应 Taro(React) 错误边界的做法。对比见 [常见问题 · 组件内错误](/guide/faq#component-errors)。
 
 ## 4. 分端接入（同时要 H5）
 


### PR DESCRIPTION
## 背景

根据 README 与官网文档的阅读体验反馈，重新梳理首页文案与 FAQ 分工：README 更偏快速判断和入口导航，官网 FAQ 承担完整排查步骤。

## 主要改动

- 将 README 的「它适合解决哪些问题」调整为“能力标题 + 用户视角说明”，兼顾扫读效率与场景解释。
- 将顶部版本历史入口移到「下一步看哪里」，避免打断新用户首屏阅读。
- 将接入辅助文案调整为「AI Coding Agent 辅助接入」，不特指某个工具，并引导 Agent 读取 AGENTS.md 与仓库内 skill。
- 扩写 README FAQ，覆盖初始化无事件、onError、网络面包屑、框架组件错误、隐私同意、Session Replay / H5 等高频问题。
- 官网 FAQ 新增「初始化后没有数据」完整排查清单和 `requireConsent` 隐私同意说明。
- 更新站内组件错误 FAQ 锚点，避免链接失效。

## 验证

- yarn run docs:build
- yarn run lint
- yarn run test