### PR TITLE
docs: 优化 README 接入阅读体验

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 一个基于 `@sentry/core` 核心构建的**小程序监控 SDK**，提供**异常监控**、**性能监控**、离线缓存、分布式追踪等能力。支持微信、支付宝、字节跳动、百度、QQ、钉钉、快手等多端小程序，以及微信 / 抖音等**小游戏**，并兼容 Taro / uni-app 等跨端框架。
 
-小程序运行时没有浏览器 `window` / `fetch` / `XMLHttpRequest`，本 SDK 会使用各平台的小程序 API 完成事件上报与自动捕获。如果你的目标是 H5 页面，请使用官方 `@sentry/browser`；如果目标是小程序或小游戏，用本 SDK。
+小程序运行时没有浏览器 `window` / `fetch` / `XMLHttpRequest`，本 SDK 会使用各平台的小程序 API 完成事件上报与自动捕获。如果你的目标是 H5 页面，请使用官方 [`@sentry/browser`](https://github.com/getsentry/sentry-javascript/tree/develop/packages/browser)；如果目标是小程序或小游戏，用本 SDK。
 
 > **📖 接入细节与生产配置**：[sentry-miniapp.pages.dev](https://sentry-miniapp.pages.dev/) —— 快速接入、框架指南、配置项、Source Map、FAQ、示例工程都在文档站。
 
@@ -48,14 +48,6 @@ npm install sentry-miniapp
 
 > 不使用 npm 时，也可直接将 `examples/wxapp/lib/sentry-miniapp.js` 复制到小程序项目中引入。
 
-### 🤖 AI Coding Agent 辅助接入
-
-如果你使用支持读取仓库上下文的 AI Coding Agent，可以让它先读取本仓库的 `AGENTS.md` 和 `.agents/skills/sentry-miniapp-sdk/`，然后直接说：
-
-> 帮我接入 sentry-miniapp，先识别平台和框架，再完成初始化并给出验证步骤。
-
-这样 Agent 会按仓库约定检查原生小程序 / Taro / uni-app、入口文件位置、初始化顺序和生产配置注意事项。
-
 在入口文件（`app.js` / `app.ts`）**最顶部、`App()` 之前**初始化：
 
 ```javascript
@@ -81,6 +73,14 @@ Sentry.captureException(new Error('sentry test'));
 然后到 Sentry 的 Issues 列表查看事件。
 
 没看到事件时，优先确认 DSN、合法域名、初始化位置和采样配置；完整排查清单见 [文档站 · 快速接入](https://sentry-miniapp.pages.dev/guide/getting-started) 与 [FAQ](https://sentry-miniapp.pages.dev/guide/faq#no-events)。
+
+### 🤖 AI Coding Agent 辅助接入
+
+如果你使用支持读取仓库上下文的 AI Coding Agent，可以让它先读取本仓库的 `AGENTS.md` 和 `.agents/skills/sentry-miniapp-sdk/`，然后直接说：
+
+> 帮我接入 sentry-miniapp，先识别平台和框架，再完成初始化并给出验证步骤。
+
+这样 Agent 会按仓库约定检查原生小程序 / Taro / uni-app、入口文件位置、初始化顺序和生产配置注意事项。
 
 ---
 
@@ -110,7 +110,7 @@ Sentry.captureFeedback({ message: '页面卡住了', name: '张三', email: 'zha
 // 接入诊断：排查接入问题时，可将诊断结果附到 issue
 console.log(Sentry.getDiagnostics());
 
-// 隐私合规：init({ requireConsent: true }) 后，用户同意隐私协议再补发缓冲
+// 隐私合规：初始化时设置 requireConsent: true，用户同意后再补发缓冲事件
 Sentry.setConsent(true);
 ```
 
@@ -123,7 +123,7 @@ Sentry.setConsent(true);
 | 我想做什么 | 看这里 |
 |----------|--------|
 | 按原生小程序完整接一遍 | [快速接入](https://sentry-miniapp.pages.dev/guide/getting-started) |
-| 接 Taro / uni-app，尤其是组件错误 | [Taro](https://sentry-miniapp.pages.dev/guide/taro) / [uni-app](https://sentry-miniapp.pages.dev/guide/uniapp) |
+| 在 Taro / uni-app 项目中接入，并处理组件错误 | [Taro](https://sentry-miniapp.pages.dev/guide/taro) / [uni-app](https://sentry-miniapp.pages.dev/guide/uniapp) |
 | 配 Source Map、Debug ID 或排查堆栈不还原 | [Source Map 配置](https://sentry-miniapp.pages.dev/guide/sourcemap) |
 | 配采样、Logs、隐私同意、`traceparent`、自定义 transport | [配置项参考](https://sentry-miniapp.pages.dev/guide/configuration) |
 | 确认各平台、小程序 / 小游戏能力差异 | [支持平台与能力](https://sentry-miniapp.pages.dev/guide/platforms) |
@@ -141,7 +141,7 @@ Sentry.setConsent(true);
 - **网络请求会随错误上报吗？** 会。默认记录 `url`、`method`、状态码、耗时等摘要，并作为面包屑随事件上报；默认不记录请求 / 响应体，需要时再开启 `traceNetworkBody` 并做好脱敏。
 - **uni-app / Taro 组件错误为什么还要额外接？** 框架可能先接住组件错误，不一定冒泡到平台全局 `onError`。Vue 用 `app.config.errorHandler` / `Vue.config.errorHandler`，Taro React 建议加 Error Boundary。
 - **隐私协议同意前会发请求吗？** 默认会按 SDK 配置正常上报；如果业务要求同意前禁止出网，请开启 `requireConsent`，并在用户同意后调用 `Sentry.setConsent(true)`。
-- **支持 Session Replay 或 H5 端吗？** 小程序没有 DOM，暂不支持官方 Session Replay；H5 端请用官方 `@sentry/browser`，小程序端继续用 `sentry-miniapp`。
+- **支持 Session Replay 或 H5 端吗？** 小程序没有 DOM，暂不支持官方 Session Replay；H5 端请用官方 [`@sentry/browser`](https://github.com/getsentry/sentry-javascript/tree/develop/packages/browser)，小程序端继续用 `sentry-miniapp`。
 
 > 每条的完整解答见 **[文档站 · 常见问题](https://sentry-miniapp.pages.dev/guide/faq)**。
 
@@ -149,12 +149,13 @@ Sentry.setConsent(true);
 
 ## 💬 联系与交流
 
-遇到问题？想探讨小程序 / 小游戏监控方案？由于微信群二维码有 7 天时效，请添加作者微信（**备注 sentry-miniapp**），由作者邀请入群：
+如果是接入问题或线上排查，建议优先在 GitHub 提出来，方便把排查结论沉淀为可搜索的答案：
+
+- **Bug / 没有数据 / Source Map 不还原**：[提交 Issue](https://github.com/lizhiyao/sentry-miniapp/issues/new/choose)，请附 SDK 版本、目标平台、复现步骤、关键配置和 `Sentry.getDiagnostics()` 输出。
+- **功能建议 / 监控方案讨论**：[发起 Discussion](https://github.com/lizhiyao/sentry-miniapp/discussions)，说明业务场景、目标平台和期望行为。
+
+请勿公开 DSN、token 或用户隐私数据；贴日志和配置前请先脱敏。
+
+想实时交流小程序 / 小游戏监控方案，可以加入微信群。由于微信群二维码有 7 天时效，请添加作者微信（**备注 sentry-miniapp**），由作者邀请入群：
 
 <img src="https://raw.githubusercontent.com/lizhiyao/sentry-miniapp/master/docs/qrcode/zhiyao.jpeg" alt="作者微信二维码" width="200" style="border-radius: 8px; box-shadow: 0 4px 8px rgba(0,0,0,0.1);" />
-
----
-
-## License
-
-[MIT](./LICENSE)

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -13,7 +13,7 @@
 
 A **mini program monitoring SDK** built on `@sentry/core`, providing **error monitoring**, **performance monitoring**, offline caching, and distributed tracing. It supports WeChat, Alipay, ByteDance, Baidu, QQ, DingTalk, and Kuaishou mini programs, **WeChat / Douyin mini games**, and Taro / uni-app mini program builds.
 
-Mini program runtimes do not provide browser APIs like `window`, `fetch`, or `XMLHttpRequest`, so this SDK uses each platform's native mini program APIs for event delivery and automatic capture. For H5/web builds, use the official `@sentry/browser`; for mini programs or mini games, use this SDK.
+Mini program runtimes do not provide browser APIs like `window`, `fetch`, or `XMLHttpRequest`, so this SDK uses each platform's native mini program APIs for event delivery and automatic capture. For H5/web builds, use the official [`@sentry/browser`](https://github.com/getsentry/sentry-javascript/tree/develop/packages/browser); for mini programs or mini games, use this SDK.
 
 > **What are Mini Programs?** Mini programs (小程序) are lightweight apps that run inside super-apps like WeChat, Alipay, and ByteDance/Douyin. They form a massive ecosystem in China with **hundreds of millions of daily active users**, but have no direct equivalent in the Western stack — think of them as a hybrid of PWAs and native apps, hosted within a platform's sandbox.
 
@@ -50,14 +50,6 @@ npm install sentry-miniapp
 
 > Not using npm? Copy `examples/wxapp/lib/sentry-miniapp.js` from this repo directly into your project.
 
-### 🤖 AI Coding Agent Setup
-
-If you use an AI coding agent that can read repository context, ask it to read this repo's `AGENTS.md` and `.agents/skills/sentry-miniapp-sdk/`, then say:
-
-> Help me set up sentry-miniapp. Detect the platform and framework first, then update the entry file and give me verification steps.
-
-The agent can then follow the repo guidance to check native mini program / Taro / uni-app setup, entry-file placement, initialization order, and production configuration notes.
-
 Initialize at the **top** of your entry file (`app.js` / `app.ts`), **before** `App()`:
 
 ```javascript
@@ -83,6 +75,14 @@ Sentry.captureException(new Error('sentry test'));
 Then check the Sentry Issues list.
 
 If nothing shows up, first check the DSN, trusted domain, initialization placement, and sampling config. The full checklist lives in [Getting Started](https://sentry-miniapp.pages.dev/guide/getting-started) and the [FAQ](https://sentry-miniapp.pages.dev/guide/faq#no-events).
+
+### 🤖 AI Coding Agent Setup
+
+If you use an AI coding agent that can read repository context, ask it to read this repo's `AGENTS.md` and `.agents/skills/sentry-miniapp-sdk/`, then say:
+
+> Help me set up sentry-miniapp. Detect the platform and framework first, then update the entry file and give me verification steps.
+
+The agent can then follow the repo guidance to check native mini program / Taro / uni-app setup, entry-file placement, initialization order, and production configuration notes.
 
 ---
 
@@ -112,7 +112,7 @@ Sentry.captureFeedback({ message: 'The page is frozen', name: 'John Doe', email:
 // Diagnostics: attach the output to issues when troubleshooting SDK setup
 console.log(Sentry.getDiagnostics());
 
-// Privacy consent: after init({ requireConsent: true }), flush buffered events once granted
+// Privacy consent: set requireConsent: true during initialization, then flush once granted
 Sentry.setConsent(true);
 ```
 
@@ -125,7 +125,7 @@ After the first event is working, pick the guide based on what you are doing nex
 | I want to... | Read this |
 |--------------|-----------|
 | Follow the full native mini program setup | [Getting Started](https://sentry-miniapp.pages.dev/guide/getting-started) |
-| Integrate Taro / uni-app, especially component errors | [Taro](https://sentry-miniapp.pages.dev/guide/taro) / [uni-app](https://sentry-miniapp.pages.dev/guide/uniapp) |
+| Set up Taro / uni-app projects and handle component errors | [Taro](https://sentry-miniapp.pages.dev/guide/taro) / [uni-app](https://sentry-miniapp.pages.dev/guide/uniapp) |
 | Configure Source Maps, Debug IDs, or unresolved stacks | [Source Map Configuration](https://sentry-miniapp.pages.dev/guide/sourcemap) |
 | Configure sampling, Logs, privacy consent, `traceparent`, or custom transport | [Configuration Reference](https://sentry-miniapp.pages.dev/guide/configuration) |
 | Check platform, mini program, and mini game capability differences | [Platforms & Capabilities](https://sentry-miniapp.pages.dev/guide/platforms) |
@@ -143,7 +143,7 @@ After the first event is working, pick the guide based on what you are doing nex
 - **Are network requests included with errors?** Yes. By default the SDK records `url`, `method`, status code, and duration summaries as breadcrumbs. Request / response bodies are not recorded by default; enable `traceNetworkBody` only when you also handle sanitization.
 - **Why do uni-app / Taro component errors need extra wiring?** Frameworks may catch component errors before they reach the platform global `onError`. Use `app.config.errorHandler` / `Vue.config.errorHandler` for Vue, and an Error Boundary for Taro React.
 - **Will it send requests before privacy consent?** By default the SDK reports normally according to your config. If your app must avoid network requests before consent, enable `requireConsent` and call `Sentry.setConsent(true)` once the user grants consent.
-- **Session Replay or H5 builds?** Mini programs have no DOM, so official Session Replay is not supported. For H5 builds, use official `@sentry/browser`; keep `sentry-miniapp` for mini program builds.
+- **Session Replay or H5 builds?** Mini programs have no DOM, so official Session Replay is not supported. For H5 builds, use official [`@sentry/browser`](https://github.com/getsentry/sentry-javascript/tree/develop/packages/browser); keep `sentry-miniapp` for mini program builds.
 
 > Full answers on the **[docs site · FAQ](https://sentry-miniapp.pages.dev/guide/faq)**.
 
@@ -151,12 +151,13 @@ After the first event is working, pick the guide based on what you are doing nex
 
 ## 💬 Community
 
-Have questions or want to discuss mini program / mini game monitoring? Due to WeChat group QR code expiration (7-day limit), please add the author on WeChat (**note: sentry-miniapp**) to be invited to the group:
+For setup issues or production troubleshooting, GitHub is the best first stop so answers stay searchable:
+
+- **Bugs / no events / Source Map issues**: [open an issue](https://github.com/lizhiyao/sentry-miniapp/issues/new/choose) with the SDK version, target platform, reproduction steps, relevant config, and `Sentry.getDiagnostics()` output.
+- **Feature requests / monitoring design discussions**: [start a discussion](https://github.com/lizhiyao/sentry-miniapp/discussions) with your scenario, target platforms, and expected behavior.
+
+Please redact DSNs, tokens, and user data before sharing logs or config.
+
+For real-time mini program / mini game monitoring discussion, you can join the WeChat group. Due to WeChat group QR code expiration (7-day limit), please add the author on WeChat (**note: sentry-miniapp**) to be invited:
 
 <img src="https://raw.githubusercontent.com/lizhiyao/sentry-miniapp/master/docs/qrcode/zhiyao.jpeg" alt="Author WeChat QR Code" width="200" style="border-radius: 8px; box-shadow: 0 4px 8px rgba(0,0,0,0.1);" />
-
----
-
-## License
-
-[MIT](../LICENSE)


### PR DESCRIPTION
## 背景

README 首屏会同时承担 SDK 选型和快速接入引导。本 PR 继续收紧 README 的阅读路径：补充官方 @sentry/browser 源码链接，移动 AI Coding Agent 辅助接入段落，强化联系与交流入口，并精简不必要的页脚信息。

## 主要改动

- README 首屏 H5 / 小程序选型说明中的 @sentry/browser 增加官方仓库链接。
- README FAQ 的 H5 端说明同步增加 @sentry/browser 链接。
- 将 AI Coding Agent 辅助接入段落移动到验证步骤之后、常用 API 之前，避免打断 5 分钟跑通主线。
- 删除中英文 README 底部 License 章节，保留顶部 license badge 和仓库 LICENSE 文件。
- 优化常用 API 里的 requireConsent 注释，改成更容易理解的初始化说明。
- 优化「下一步看哪里」中 Taro / uni-app 接入导航文案。
- 强化「联系与交流」：Issue 用于 Bug / 排查沉淀，Discussion 用于功能建议 / 方案讨论，微信群用于实时交流，并补充脱敏提醒。
- 英文 README 同步以上调整。

@sentry/browser 链接指向 Sentry 官方 sentry-javascript monorepo 的 packages/browser 目录。

## 验证

- yarn run docs:build
- yarn run lint
- yarn run test