### PR TITLE
docs: 优化 README 能力与接入文案

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 ---
 
-## ✨ 它适合解决哪些问题
+## ✨ 核心能力与适用场景
 
 - **异常自动捕获**：自动捕获全局异常、Promise rejection、页面异常和内存告警，把问题送进 Sentry Issues，而不是只停留在用户反馈里。
 - **排查上下文**：记录设备信息、页面生命周期、点击 / 触摸和网络请求面包屑，帮助还原用户出错前做了什么。
@@ -76,11 +76,19 @@ Sentry.captureException(new Error('sentry test'));
 
 ### 🤖 AI Coding Agent 辅助接入
 
-如果你使用支持读取仓库上下文的 AI Coding Agent，可以让它先读取本仓库的 `AGENTS.md` 和 `.agents/skills/sentry-miniapp-sdk/`，然后直接说：
+在 sentry-miniapp 仓库内使用时，支持仓库内 Agent Skills 的工具通常会自动发现 `sentry-miniapp-sdk`。
 
-> 帮我接入 sentry-miniapp，先识别平台和框架，再完成初始化并给出验证步骤。
+如果你是在自己的小程序 / 小游戏项目里接入，推荐把 skill 安装到当前项目的 `.agents/skills/`，这样支持仓库内 Agent Skills 的工具进入项目后就能自动发现：
 
-这样 Agent 会按仓库约定检查原生小程序 / Taro / uni-app、入口文件位置、初始化顺序和生产配置注意事项。
+```bash
+npx --yes degit lizhiyao/sentry-miniapp/.agents/skills/sentry-miniapp-sdk .agents/skills/sentry-miniapp-sdk
+```
+
+然后在你的项目里直接说：
+
+> 使用 `sentry-miniapp-sdk` skill 帮我接入 sentry-miniapp：先识别平台和框架，再完成初始化并给出验证步骤。
+
+如果想跨多个项目复用，也可以把命令最后的目标路径换成你的 Agent 全局 skills 目录。Agent 没有自动加载时，让它读取 `.agents/skills/sentry-miniapp-sdk/SKILL.md` 即可。这样 Agent 会按仓库约定检查原生小程序 / Taro / uni-app、入口文件位置、初始化顺序和生产配置注意事项。
 
 ---
 

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -23,7 +23,7 @@ Mini program runtimes do not provide browser APIs like `window`, `fetch`, or `XM
 
 ---
 
-## ✨ Problems It Helps Solve
+## ✨ Core Capabilities and Use Cases
 
 - **Automatic error capture**: Captures global errors, Promise rejections, page errors, and memory warnings automatically, then sends them to Sentry Issues instead of leaving them only in user feedback.
 - **Debugging context**: Records device info, page lifecycle, taps/touches, and network breadcrumbs to help reconstruct what happened before a user hit an error.
@@ -78,11 +78,19 @@ If nothing shows up, first check the DSN, trusted domain, initialization placeme
 
 ### 🤖 AI Coding Agent Setup
 
-If you use an AI coding agent that can read repository context, ask it to read this repo's `AGENTS.md` and `.agents/skills/sentry-miniapp-sdk/`, then say:
+When working inside the sentry-miniapp repository, agents that support repository Agent Skills can usually auto-discover `sentry-miniapp-sdk`.
 
-> Help me set up sentry-miniapp. Detect the platform and framework first, then update the entry file and give me verification steps.
+For your own mini program / mini game project, install the skill into the project's `.agents/skills/` directory so agents that support repository Agent Skills can auto-discover it:
 
-The agent can then follow the repo guidance to check native mini program / Taro / uni-app setup, entry-file placement, initialization order, and production configuration notes.
+```bash
+npx --yes degit lizhiyao/sentry-miniapp/.agents/skills/sentry-miniapp-sdk .agents/skills/sentry-miniapp-sdk
+```
+
+Then say from your project:
+
+> Use the `sentry-miniapp-sdk` skill to set up sentry-miniapp: detect the platform and framework first, then update the entry file and give me verification steps.
+
+To reuse it across multiple projects, change the command's destination path to your agent's global skills directory. If your agent does not auto-load the skill, point it to `.agents/skills/sentry-miniapp-sdk/SKILL.md`. The agent can then follow the repo guidance to check native mini program / Taro / uni-app setup, entry-file placement, initialization order, and production configuration notes.
 
 ---
 


### PR DESCRIPTION
## 背景

README 中「它适合解决哪些问题」这个标题略像问答，但该段内容实际是能力清单与适用场景说明。同时，AI Coding Agent 辅助接入需要说明用户在自己的业务项目中如何安装并调用 sentry-miniapp-sdk skill。

## 主要改动

- 中文 README：`它适合解决哪些问题` -> `核心能力与适用场景`
- 英文 README：`Problems It Helps Solve` -> `Core Capabilities and Use Cases`
- 优化 AI Coding Agent 辅助接入说明：区分仓库内自动发现和业务项目安装场景，改为使用 `npx degit` 一行把 `sentry-miniapp-sdk` 安装到当前项目 `.agents/skills/`
- 英文 README 同步以上调整

## 验证

- yarn run docs:build
- yarn run lint
- yarn run test