### PR TITLE
docs: 按用户任务重构官网内容体系

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,9 +132,11 @@ Sentry.setConsent(true);
 |----------|--------|
 | 按原生小程序完整接一遍 | [快速接入](https://sentry-miniapp.pages.dev/guide/getting-started) |
 | 在 Taro / uni-app 项目中接入，并处理组件错误 | [Taro](https://sentry-miniapp.pages.dev/guide/taro) / [uni-app](https://sentry-miniapp.pages.dev/guide/uniapp) |
-| 配 Source Map、Debug ID 或排查堆栈不还原 | [Source Map 配置](https://sentry-miniapp.pages.dev/guide/sourcemap) |
-| 配采样、Logs、隐私同意、`traceparent`、自定义 transport | [配置项参考](https://sentry-miniapp.pages.dev/guide/configuration) |
-| 确认各平台、小程序 / 小游戏能力差异 | [支持平台与能力](https://sentry-miniapp.pages.dev/guide/platforms) |
+| 接入微信 / 抖音小游戏和性能监控 | [小游戏接入与性能](https://sentry-miniapp.pages.dev/guide/minigame) |
+| 配异常上下文、Logs、性能、追踪或隐私同意 | [能力指南](https://sentry-miniapp.pages.dev/guide/errors-and-context) |
+| 查公开方法和完整初始化参数 | [常用 API](https://sentry-miniapp.pages.dev/guide/api) / [配置项参考](https://sentry-miniapp.pages.dev/guide/configuration) |
+| 上传 Source Map 或排查 Debug ID、微信合并文件 | [上线指南](https://sentry-miniapp.pages.dev/guide/sourcemap) / [进阶排障](https://sentry-miniapp.pages.dev/guide/sourcemap-advanced) |
+| 确认各平台、小程序 / 小游戏能力差异 | [支持范围](https://sentry-miniapp.pages.dev/guide/platforms) |
 | 关心主包体积 | [主包体积优化](https://sentry-miniapp.pages.dev/guide/bundle-size) |
 | 看可运行示例 | [示例工程](https://sentry-miniapp.pages.dev/guide/examples) |
 | 查看版本历史与每次发布内容 | [GitHub Releases](https://github.com/lizhiyao/sentry-miniapp/releases) |

--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -134,9 +134,11 @@ After the first event is working, pick the guide based on what you are doing nex
 |--------------|-----------|
 | Follow the full native mini program setup | [Getting Started](https://sentry-miniapp.pages.dev/guide/getting-started) |
 | Set up Taro / uni-app projects and handle component errors | [Taro](https://sentry-miniapp.pages.dev/guide/taro) / [uni-app](https://sentry-miniapp.pages.dev/guide/uniapp) |
-| Configure Source Maps, Debug IDs, or unresolved stacks | [Source Map Configuration](https://sentry-miniapp.pages.dev/guide/sourcemap) |
-| Configure sampling, Logs, privacy consent, `traceparent`, or custom transport | [Configuration Reference](https://sentry-miniapp.pages.dev/guide/configuration) |
-| Check platform, mini program, and mini game capability differences | [Platforms & Capabilities](https://sentry-miniapp.pages.dev/guide/platforms) |
+| Set up WeChat / Douyin mini games and performance monitoring | [Mini Game Guide](https://sentry-miniapp.pages.dev/guide/minigame) |
+| Configure error context, Logs, performance, tracing, or privacy consent | [Capability Guides](https://sentry-miniapp.pages.dev/guide/errors-and-context) |
+| Look up public methods and initialization options | [Common APIs](https://sentry-miniapp.pages.dev/guide/api) / [Configuration Reference](https://sentry-miniapp.pages.dev/guide/configuration) |
+| Upload Source Maps or troubleshoot Debug IDs and WeChat merged bundles | [Deployment Guide](https://sentry-miniapp.pages.dev/guide/sourcemap) / [Advanced Troubleshooting](https://sentry-miniapp.pages.dev/guide/sourcemap-advanced) |
+| Check platform, mini program, and mini game capability differences | [Supported Scope](https://sentry-miniapp.pages.dev/guide/platforms) |
 | Reduce main-package size | [Bundle Size](https://sentry-miniapp.pages.dev/guide/bundle-size) |
 | See runnable examples | [Examples](https://sentry-miniapp.pages.dev/guide/examples) |
 | Check version history and release notes | [GitHub Releases](https://github.com/lizhiyao/sentry-miniapp/releases) |

--- a/website/.vitepress/config.mts
+++ b/website/.vitepress/config.mts
@@ -7,7 +7,7 @@ export default defineConfig({
   lang: 'zh-CN',
   title: 'sentry-miniapp',
   description:
-    '跨端小程序 Sentry SDK — 微信 / 支付宝 / 字节跳动 / 钉钉 / QQ / 百度 / 快手 + Taro / uni-app，异常、性能与网络监控开箱即用。',
+    '基于 @sentry/core 的跨端小程序与小游戏监控 SDK，支持异常、性能、日志、离线缓存、链路追踪，以及 Taro / uni-app。',
   base: '/', // Cloudflare Pages 部署在根域，无子路径
   lastUpdated: true,
   cleanUrls: true,
@@ -19,40 +19,65 @@ export default defineConfig({
 
     nav: [
       { text: '快速接入', link: '/guide/getting-started' },
-      { text: '配置', link: '/guide/configuration' },
+      {
+        text: '能力指南',
+        items: [
+          { text: '异常、日志与上下文', link: '/guide/errors-and-context' },
+          { text: '性能与链路追踪', link: '/guide/performance-and-tracing' },
+          { text: '可靠上报与隐私同意', link: '/guide/reliability-and-privacy' },
+        ],
+      },
+      {
+        text: 'API 与配置',
+        items: [
+          { text: '常用 API', link: '/guide/api' },
+          { text: '配置项参考', link: '/guide/configuration' },
+          { text: '支持范围', link: '/guide/platforms' },
+          { text: 'npm 包', link: 'https://www.npmjs.com/package/sentry-miniapp' },
+        ],
+      },
       { text: 'Source Map', link: '/guide/sourcemap' },
-      { text: 'FAQ', link: '/guide/faq' },
-      { text: 'GitHub', link: GITHUB },
-      { text: 'npm', link: 'https://www.npmjs.com/package/sentry-miniapp' },
+      { text: '排障', link: '/guide/faq' },
     ],
 
     sidebar: {
       '/guide/': [
         {
-          text: '先判断与接入',
+          text: '开始使用',
           items: [
             { text: '它适合我吗？', link: '/guide/when-to-use' },
             { text: '快速接入（原生小程序）', link: '/guide/getting-started' },
             { text: 'Taro（React）', link: '/guide/taro' },
             { text: 'uni-app（Vue）', link: '/guide/uniapp' },
+            { text: '小游戏接入与性能', link: '/guide/minigame' },
             { text: '示例工程', link: '/guide/examples' },
           ],
         },
         {
-          text: '上线前配置',
+          text: '能力指南',
+          items: [
+            { text: '异常、日志与上下文', link: '/guide/errors-and-context' },
+            { text: '性能与链路追踪', link: '/guide/performance-and-tracing' },
+            { text: '可靠上报与隐私同意', link: '/guide/reliability-and-privacy' },
+          ],
+        },
+        {
+          text: '生产上线',
           items: [
             { text: '配置项参考', link: '/guide/configuration' },
-            { text: 'Source Map 配置', link: '/guide/sourcemap' },
+            { text: 'Source Map 上线指南', link: '/guide/sourcemap' },
+            { text: 'Source Map 进阶与排障', link: '/guide/sourcemap-advanced' },
             { text: '主包体积优化', link: '/guide/bundle-size' },
           ],
         },
         {
-          text: '能力与排查',
+          text: '参考与排障',
           items: [
-            { text: '支持平台与能力', link: '/guide/platforms' },
-            { text: '平台兼容性详解', link: '/guide/platform-compatibility' },
-            { text: '工作原理', link: '/guide/how-it-works' },
+            { text: '常用 API', link: '/guide/api' },
+            { text: '支持范围', link: '/guide/platforms' },
+            { text: '跨平台差异与降级', link: '/guide/platform-compatibility' },
             { text: '常见问题 (FAQ)', link: '/guide/faq' },
+            { text: '工作原理', link: '/guide/how-it-works' },
           ],
         },
       ],
@@ -75,7 +100,7 @@ export default defineConfig({
     },
 
     footer: {
-      message: '基于 @sentry/core 的跨端小程序 SDK · MIT Licensed',
+      message: '基于 @sentry/core 的跨端小程序与小游戏 SDK · MIT Licensed',
       copyright: `Copyright © 2019-present <a href="${GITHUB}">sentry-miniapp</a>`,
     },
   },

--- a/website/guide/api.md
+++ b/website/guide/api.md
@@ -1,0 +1,170 @@
+# 常用 API
+
+`sentry-miniapp` 直接导出常用的 `@sentry/core` API，并补充小程序专属的初始化、隐私同意、诊断和反馈能力。建议统一使用命名空间导入：
+
+```js
+import * as Sentry from 'sentry-miniapp';
+```
+
+本页用于快速查找常用调用。初始化参数的类型、默认值和完整说明见[配置项参考](/guide/configuration)。
+
+## 初始化与状态
+
+| API | 用途 |
+|-----|------|
+| `init(options)` | 初始化 SDK，返回当前 `MiniappClient`；不在支持的小程序运行时中返回 `undefined` |
+| `isEnabled()` | 判断当前 client 是否可发送事件 |
+| `getClient()` | 读取当前 client |
+| `flush(timeout?)` | 等待待发送事件完成，适合应用即将退出前 |
+| `close(timeout?)` | flush 后关闭 client |
+| `lastEventId()` | 获取最近一次捕获事件的 id |
+
+```js
+Sentry.init({
+  dsn: 'YOUR_DSN',
+  release: 'my-miniapp@1.0.0',
+  environment: 'production',
+});
+```
+
+## 捕获事件
+
+| API | 适合场景 | 返回值 |
+|-----|----------|--------|
+| `captureException(error)` | 异常对象或未知错误值 | event id |
+| `captureMessage(message, level?)` | 没有异常对象的业务告警 | event id |
+| `captureEvent(event)` | 需要完全控制事件结构的高级场景 | event id |
+| `captureFeedback(params)` | 原生反馈表单提交的用户反馈 | event id |
+
+```js
+Sentry.captureException(new Error('payment failed'));
+Sentry.captureMessage('库存接口已降级', 'warning');
+```
+
+小程序不能使用浏览器 HTML `showReportDialog`。请自行实现原生表单，并调用：
+
+```js
+Sentry.captureFeedback({
+  message: '页面一直处于加载状态',
+  name: '用户昵称',
+  email: 'user@example.com',
+  associatedEventId: Sentry.lastEventId(),
+  tags: { page: 'checkout' },
+});
+```
+
+## 用户与上下文
+
+| API | 用途 |
+|-----|------|
+| `setUser(user)` | 关联或清除当前用户 |
+| `setTag(key, value)` / `setTags(tags)` | 添加可筛选标签 |
+| `setContext(name, context)` | 添加一组结构化上下文 |
+| `setExtra(key, value)` / `setExtras(extras)` | 添加辅助调试数据 |
+| `addBreadcrumb(breadcrumb)` | 记录用户操作或业务步骤 |
+
+```js
+Sentry.setUser({ id: 'user_123' });
+Sentry.setTags({ channel: 'wechat', plan: 'pro' });
+Sentry.setContext('order', { orderId: 'order_456', itemCount: 3 });
+Sentry.addBreadcrumb({ category: 'checkout', message: '用户确认支付' });
+```
+
+`addBreadcrumb` 不会单独发送事件，只随下一次异常或消息一起发送。上下文使用方法与脱敏建议见[异常、日志与上下文](/guide/errors-and-context)。
+
+## 临时作用域
+
+使用 `withScope` 只给一次操作附加数据，避免污染后续事件：
+
+```js
+Sentry.withScope(scope => {
+  scope.setTag('operation', 'coupon.apply');
+  scope.setContext('coupon', { couponId: 'coupon_123' });
+  Sentry.captureException(error);
+});
+```
+
+高级场景还可使用 `getCurrentScope()`、`getIsolationScope()` 和 `addEventProcessor()`。
+
+## Logs
+
+先在 `init` 中设置 `enableLogs: true`，再使用：
+
+```js
+Sentry.logger.trace('cache lookup', { key: 'profile' });
+Sentry.logger.debug('feature decision', { variant: 'B' });
+Sentry.logger.info('checkout completed', { orderId: 'order_456' });
+Sentry.logger.warn('api degraded', { service: 'inventory' });
+Sentry.logger.error('payment retry failed', { attempt: 3 });
+Sentry.logger.fatal('bootstrap unavailable');
+```
+
+这些日志会作为独立 log 发送，不等同于 console 面包屑。
+
+## 性能 API
+
+| API | 用途 |
+|-----|------|
+| `startSpan(options, callback)` | 测量一个有明确回调生命周期的操作 |
+| `startInactiveSpan(options)` | 创建需要手动结束的 span |
+| `getPerformanceManager()` | 读取宿主小程序 Performance API 适配对象，可能为 `null` |
+
+```js
+const result = await Sentry.startSpan(
+  { name: 'checkout.submit', op: 'ui.action' },
+  () => submitOrder(),
+);
+```
+
+使用前应开启 `tracesSampleRate` 或 `tracesSampler`。详见[性能与链路追踪](/guide/performance-and-tracing)。
+
+## 隐私同意与诊断
+
+| API | 用途 |
+|-----|------|
+| `setConsent(true)` | 放行发送并补发同意前缓冲 |
+| `setConsent(false)` | 重新阻止 Sentry 网络请求，后续事件进入缓冲 |
+| `getConsent()` | 读取当前同意状态 |
+| `getDiagnostics()` | 获取脱敏后的平台、配置、集成、transport 与 warning 摘要 |
+
+```js
+Sentry.init({ dsn: 'YOUR_DSN', requireConsent: true });
+
+// 用户完成隐私授权后
+Sentry.setConsent(true);
+
+console.log(Sentry.getDiagnostics());
+```
+
+诊断信息不会发送事件，也不会暴露完整 DSN。提交 Issue 时建议附上脱敏后的输出。
+
+## 集成与高级扩展
+
+| API / 导出 | 用途 |
+|------------|------|
+| `getDefaultIntegrations()` | 获取一份新的默认集成列表 |
+| `addIntegration(integration)` | 初始化后追加集成 |
+| `Integrations` | 小程序集成命名空间 |
+| `Transports` | 内置 transport 与离线 store 命名空间 |
+| `miniappStackParser` | 默认小程序堆栈解析器 |
+| `wrap(fn)` | 包裹函数，捕获后继续抛出异常 |
+
+传入 `integrations` 会替换核心默认集成，通常不需要设置。需要在默认能力上追加时：
+
+```js
+Sentry.init({
+  dsn: 'YOUR_DSN',
+  integrations: [
+    ...Sentry.getDefaultIntegrations(),
+    new Sentry.Integrations.ConsoleBreadcrumbs(),
+  ],
+});
+```
+
+自定义 transport、集成或 `stackParser` 会扩大维护范围，只有默认能力无法覆盖目标运行时时再使用。相关配置见[配置项参考 · 集成](/guide/configuration#集成)与 [Source Map 进阶](/guide/sourcemap-advanced#debug-id-与自定义-stackparser)。
+
+## Session API
+
+SDK 默认启用自动 Session Tracking，大多数项目不需要手动管理。确实需要时仍可使用 `startSession`、`endSession`、`captureSession`，以及底层的 `makeSession`、`updateSession`、`closeSession`。
+
+不确定某个 API 是否适合当前问题时，先从[能力指南](/guide/errors-and-context)按任务选择，避免为了调用 API 而关闭默认自动能力。

--- a/website/guide/configuration.md
+++ b/website/guide/configuration.md
@@ -1,6 +1,8 @@
 # 配置项参考
 
-`Sentry.init({ ... })` 支持的全部选项。**通常只需 `dsn` + `release` 即可上手**（见[快速接入](/guide/getting-started)），下面是完整清单，按需取用。
+`Sentry.init({ ... })` 支持的全部选项。通常只需 `dsn` + `release` 即可上手（见[快速接入](/guide/getting-started)），下面按参数类别列出类型、默认值和行为。
+
+如果你还在判断“为什么需要这个选项”，先看对应的[异常、日志与上下文](/guide/errors-and-context)、[性能与链路追踪](/guide/performance-and-tracing)、[可靠上报与隐私同意](/guide/reliability-and-privacy)或[小游戏](/guide/minigame)指南。
 
 ## 基础
 
@@ -91,10 +93,12 @@ console.log(diagnostics.warnings);
 
 | 选项 | 类型 | 默认 | 说明 |
 |------|------|------|------|
-| `enableSourceMap` | `boolean` | `true` | 自动将各平台虚拟堆栈路径归一化为 `app:///` 前缀。详见 [Source Map 配置](/guide/sourcemap) |
+| `enableSourceMap` | `boolean` | `true` | 自动将各平台虚拟堆栈路径归一化为 `app:///` 前缀。详见 [Source Map 上线指南](/guide/sourcemap) |
 | `stackParser` | `StackParser` | `miniappStackParser` | 自定义堆栈解析器；私有引擎或特殊堆栈格式才需要覆盖 |
 
 ## 离线缓存（弱网可靠性）
+
+工作方式与验证步骤见[可靠上报与隐私同意](/guide/reliability-and-privacy#弱网离线缓存)。
 
 | 选项 | 类型 | 默认 | 说明 |
 |------|------|------|------|
@@ -103,6 +107,8 @@ console.log(diagnostics.warnings);
 | `offlineCacheMaxAge` | `number` | `86400000` | 缓存过期时间（ms），默认 24 小时，超时丢弃 |
 
 ## 隐私合规（同意后上报）
+
+开始配置前建议先阅读[用户同意前不发送 Sentry 网络](/guide/reliability-and-privacy#用户同意前不发送-sentry-网络)。
 
 | 选项 | 类型 | 默认 | 说明 |
 |------|------|------|------|
@@ -135,6 +141,8 @@ Sentry.setConsent(false);
 
 ## 分布式追踪
 
+追踪头的用途、域名限制与验证方式见[性能与链路追踪](/guide/performance-and-tracing#串联小程序与服务端)。
+
 | 选项 | 类型 | 默认 | 说明 |
 |------|------|------|------|
 | `enableTracePropagation` | `boolean` | `true` | 是否注入分布式追踪头（`sentry-trace` / `baggage`，以及可选 `traceparent`）。只控制传播，不关闭本地 API 请求 span |
@@ -156,7 +164,7 @@ Sentry.setConsent(false);
 | `enableMinigameFrameRate` | `boolean` | 小游戏 `true` / 小程序 `false` | 帧率（FPS）/ 卡顿（jank）监控；小程序无全局 rAF，开启也安全 no-op |
 | `minigameFrameRateOptions` | `object` | 见下 | 帧率监控细调，仅 `enableMinigameFrameRate` 生效时使用 |
 
-`minigameFrameRateOptions` 子项：`fpsWarningThreshold`（默认 `30`）、`longFrameThresholdMs`（默认 `50`）、`reportInterval`（默认 `10000`）、`maxJankBreadcrumbsPerWindow`（默认 `3`）、`jankLevels`（可选，分级卡顿阈值）。详见 [支持平台与能力](/guide/platforms)。
+`minigameFrameRateOptions` 子项：`fpsWarningThreshold`（默认 `30`）、`longFrameThresholdMs`（默认 `50`）、`reportInterval`（默认 `10000`）、`maxJankBreadcrumbsPerWindow`（默认 `3`）、`jankLevels`（可选，分级卡顿阈值）。使用方法与数据去向见[小游戏接入与性能](/guide/minigame)。
 
 `jankLevels` 为 `{ minor?, major?, severe? }`（毫秒，各档全可选）。提供后切换为**分级统计**：每帧卡顿按命中的最高档归类，面包屑带 `jankLevel`，会话汇总额外增发 `jank_minor_count` / `jank_major_count` / `jank_severe_count`（仅启用的档）。不提供时沿用 `longFrameThresholdMs` 单档，行为与历史完全一致；两者同时提供时 `jankLevels` 优先。
 

--- a/website/guide/errors-and-context.md
+++ b/website/guide/errors-and-context.md
@@ -1,0 +1,141 @@
+# 异常、日志与上下文
+
+把错误发进 Sentry 只是第一步。真正能缩短排查时间的是：自动捕获没有被业务代码处理的异常，并在事件上附带用户、页面、操作和网络上下文。
+
+## 默认会捕获什么
+
+`Sentry.init()` 会按宿主实际提供的能力注册监听，不需要在每个 `onError` 中重复调用 `captureException`。
+
+| 信号 | 默认行为 | 缺少宿主 API 时 |
+|------|----------|-----------------|
+| 未处理 JavaScript 异常 | 监听平台 `onError` | 跳过，可继续手动捕获 |
+| 未处理 Promise rejection | 监听 `onUnhandledRejection` | 跳过对应监听 |
+| 页面不存在 | 监听 `onPageNotFound` | 跳过对应监听 |
+| 内存告警 | 监听 `onMemoryWarning` | 跳过对应监听 |
+| 定时器回调异常 | 默认 TryCatch 集成包裹 | 不影响其它捕获能力 |
+
+初始化必须尽可能早。原生小程序应在入口文件顶部、`App()` 之前执行；小游戏应放在游戏入口最前面。
+
+> Taro / uni-app 的组件错误可能先被 React 或 Vue 接住，不再冒泡到宿主全局监听。请分别按照 [Taro 错误边界](/guide/taro#_4-组件错误-用-react-错误边界)或 [uni-app errorHandler](/guide/uniapp#_3-main-js-尽早初始化-接-vue-errorhandler-关键) 接入。
+
+## 主动上报已处理的问题
+
+当业务代码已经捕获异常，但仍希望记录到 Sentry 时，主动调用上报 API：
+
+```js
+try {
+  await submitOrder();
+} catch (error) {
+  Sentry.captureException(error);
+  showRetryMessage();
+}
+
+Sentry.captureMessage('库存接口连续降级', 'warning');
+```
+
+不要在平台全局 `onError` 中再次上报同一个错误，否则可能与 SDK 自动捕获产生重复事件。
+
+## 给事件补充排查上下文
+
+### 用户、标签与业务数据
+
+```js
+Sentry.setUser({ id: 'user_123' });
+Sentry.setTag('miniapp.channel', 'wechat-search');
+Sentry.setContext('order', {
+  orderId: 'order_456',
+  paymentMethod: 'balance',
+});
+```
+
+- `setUser`：关联当前用户，退出登录后可用 `Sentry.setUser(null)` 清除。
+- `setTag` / `setTags`：适合可筛选、可聚合的短值。
+- `setContext` / `setExtra`：适合辅助理解问题的结构化数据。
+
+不要写入密码、访问令牌、完整身份证号等敏感信息。需要全局脱敏时使用 `beforeSend`。
+
+### 面包屑
+
+SDK 默认记录页面生命周期、点击 / 触摸和网络请求摘要。业务关键动作可以手动补充：
+
+```js
+Sentry.addBreadcrumb({
+  category: 'checkout',
+  message: '用户确认支付',
+  level: 'info',
+  data: { orderId: 'order_456' },
+});
+```
+
+`addBreadcrumb` **不会单独发送网络请求**。它只会随下一次异常或消息事件一起发送，因此不能用它验证接入是否成功。
+
+网络面包屑默认包含 URL、方法、状态码和耗时，不记录请求体与响应体。确实需要 body 时再开启 `traceNetworkBody`，并通过 `beforeBreadcrumb` 删除敏感字段。
+
+## 独立业务日志
+
+需要在 Sentry Logs 中单独检索、聚合或告警时，开启 Logs：
+
+```js
+Sentry.init({
+  dsn: 'YOUR_DSN',
+  enableLogs: true,
+});
+
+Sentry.logger.info('checkout completed', {
+  orderId: 'order_456',
+  durationMs: 380,
+});
+```
+
+| 方式 | 是否独立发送 | 适合用途 |
+|------|:------------:|----------|
+| `Sentry.logger.*` | 是 | 业务日志查询、聚合、告警 |
+| `console.*` + `enableConsoleBreadcrumbs` | 否 | 随错误还原附近的控制台输出 |
+| `addBreadcrumb` | 否 | 描述用户操作与业务步骤 |
+
+可用级别为 `trace`、`debug`、`info`、`warn`、`error`、`fatal`。用 `beforeSendLog` 修改或丢弃不应发送的日志。
+
+## 收集用户反馈
+
+小程序没有浏览器 DOM，不能使用 Sentry 默认 HTML 反馈弹窗。请用原生组件实现表单，再提交数据：
+
+```js
+const eventId = Sentry.lastEventId();
+
+Sentry.captureFeedback({
+  message: '点击支付后页面一直加载',
+  name: '用户昵称',
+  associatedEventId: eventId,
+  tags: { page: 'checkout' },
+});
+```
+
+`showReportDialog` 仅为兼容旧代码保留，当前会提示弃用且不会展示界面。
+
+## 控制噪声与敏感数据
+
+优先使用声明式过滤；需要按业务逻辑处理时再使用钩子：
+
+```js
+Sentry.init({
+  dsn: 'YOUR_DSN',
+  ignoreErrors: [/request:fail abort/i],
+  denyUrls: [/vendor\/unstable-plugin/],
+  beforeSend(event) {
+    if (event.user) delete event.user.email;
+    return event;
+  },
+});
+```
+
+完整过滤项与钩子签名见[配置项参考 · 过滤与钩子](/guide/configuration#过滤与钩子)。
+
+## 验证清单
+
+1. 主动调用一次 `captureException`，确认 Sentry Issues 中出现事件。
+2. 检查事件是否包含 release、environment、用户、标签和预期面包屑。
+3. 在框架组件内主动抛错，确认 React Error Boundary 或 Vue errorHandler 生效。
+4. 开启 Logs 后发送一条 `logger.info`，到 Sentry Logs 单独确认。
+5. 真机与开发者工具都验证一次；宿主监听和网络行为可能不同。
+
+接下来可查看[常用 API](/guide/api)、[性能与链路追踪](/guide/performance-and-tracing)或[常见问题](/guide/faq)。

--- a/website/guide/examples.md
+++ b/website/guide/examples.md
@@ -23,4 +23,4 @@ uni-app 用 `npm run dev:mp-weixin`；wxapp 直接用微信开发者工具导入
 ## 关键集成点
 
 - **初始化封装**：各示例的 `src/utils/sentry.*` 是集成核心（DSN、采样、`traceNetworkBody`、标签）。
-- **组件错误**：uni-app 在 `main.js` 接 `errorHandler`；Taro(React) 用 `SentryBoundary` 错误边界。详见 [常见问题 · 组件内错误](/guide/faq#component-errors)。
+- **组件错误**：uni-app 在 `main.js` 接 `errorHandler`；Taro React 使用错误边界。详见 [uni-app 接入](/guide/uniapp)与 [Taro 接入](/guide/taro)。

--- a/website/guide/faq.md
+++ b/website/guide/faq.md
@@ -50,59 +50,27 @@ console.log(Sentry.getDiagnostics());
 
 ### uni-app（Vue）组件内的错误没上报 / 上报率很低？
 
-uni-app 底层是 Vue。**组件内（render / 生命周期 / watch / `@click` 方法）抛的错会被 Vue 自己的 `errorHandler` 接住、不冒泡到 `wx.onError`**，SDK 默认捕获不到——这是「`sampleRate` 设了 1 却只偶尔上报一条」的常见根因。把 Vue 的 `errorHandler` 接到 Sentry：
-
-```js
-// uni-app Vue3（main.js / main.ts）
-export function createApp() {
-  const app = createSSRApp(App);
-  app.config.errorHandler = (err, instance, info) => {
-    Sentry.captureException(err, { extra: { lifecycleHook: info } });
-  };
-  return { app };
-}
-```
-
-Vue2 用 `Vue.config.errorHandler`。
+uni-app 底层是 Vue。组件渲染、生命周期、watch 或模板事件中的异常可能先被 Vue `errorHandler` 接住，不再冒泡到平台 `onError`。Vue 3 需要接 `app.config.errorHandler`，Vue 2 使用 `Vue.config.errorHandler`。完整代码只在 [uni-app 接入指南](/guide/uniapp#_3-main-js-尽早初始化-接-vue-errorhandler-关键)维护。
 
 ### Taro 呢？
 
-**Taro 不是 Vue**，默认用 React（也支持 Vue）。用 **Vue** 时同理接 `errorHandler`；用 **React** 时，React 不像 Vue 那样静默吞错，但可加一个**错误边界（Error Boundary）**把渲染错误转给 Sentry：
-
-```jsx
-class SentryBoundary extends React.Component {
-  componentDidCatch(error, info) {
-    Sentry.captureException(error, { extra: info });
-  }
-  render() {
-    return this.props.children;
-  }
-}
-// 包住根组件：<SentryBoundary><App /></SentryBoundary>
-```
-
-完整示例见 [示例工程](/guide/examples)。
+Taro React 的渲染期错误建议由 Error Boundary 捕获并转交 Sentry；事件回调和异步错误不属于 Error Boundary 的捕获范围。使用 Taro Vue 时按 Vue `errorHandler` 处理。完整代码见 [Taro 接入指南](/guide/taro#_4-组件错误-用-react-错误边界)。
 
 ## 隐私协议同意前如何避免发送 Sentry 网络请求？ {#privacy-consent}
 
-默认情况下，SDK 会按你的初始化配置正常上报事件。如果业务要求用户同意隐私协议前不能发出 Sentry 网络请求，可以开启 `requireConsent`：
+默认情况下，SDK 会按初始化配置正常上报。如果业务要求用户同意隐私协议前不能发出 Sentry 网络请求，初始化时设置 `requireConsent: true`，用户明确同意后调用 `Sentry.setConsent(true)`。
 
 ```js
 Sentry.init({
   dsn: 'https://your-dsn@o0.ingest.sentry.io/0',
   requireConsent: true,
 });
-```
 
-开启后，同意前捕获到的事件会写入本地缓冲，不会向 Sentry 发起请求。用户同意后调用：
-
-```js
+// 用户明确同意隐私协议后
 Sentry.setConsent(true);
 ```
 
-SDK 会恢复发送，并补发仍在缓冲期内的事件。用户撤回同意时可调用 `Sentry.setConsent(false)`，后续事件会继续进入缓冲而不是出网。
-
-这个能力适合隐私协议弹窗、分端合规开关、灰度验证等场景；如果只是想降低上报量，优先使用 `sampleRate` / `tracesSampleRate`，不要把 `requireConsent` 当采样开关。
+同意前事件会写入本地缓冲；放行后会补发并恢复实时上报。撤回同意、缓存上限和验证方法见[可靠上报与隐私同意](/guide/reliability-and-privacy)。如果只是想降低上报量，请使用采样配置，不要把 consent 当作采样开关。
 
 ## 支持 Session Replay（屏幕操作回放）吗？
 

--- a/website/guide/getting-started.md
+++ b/website/guide/getting-started.md
@@ -2,7 +2,7 @@
 
 `sentry-miniapp` 是基于 [`@sentry/core`](https://github.com/getsentry/sentry-javascript) 的跨端小程序 Sentry SDK，覆盖微信、支付宝、字节跳动、钉钉、QQ、百度、快手，并兼容 Taro / uni-app。
 
-> 本页即**原生小程序**（微信 / 支付宝 / 字节等原生工程）的接入方式。用 Taro / uni-app 框架的另见 [Taro 接入指南](/guide/taro) 与 [uni-app 接入指南](/guide/uniapp)。
+> 本页是**原生小程序**的最短接入路径。Taro、uni-app 或小游戏请直接进入 [Taro](/guide/taro)、[uni-app](/guide/uniapp)或[小游戏](/guide/minigame)指南。
 
 ## 1. 安装
 
@@ -24,18 +24,6 @@ Sentry.init({
   // release 是 Source Map 生效的关键，需与上传 Source Map 时的 release 完全一致
   release: 'my-miniapp@1.0.0',
   environment: 'production',
-
-  // 采样
-  sampleRate: 1.0, // error 采样率
-  tracesSampleRate: 1.0, // 性能采样率；开启后 API 请求会作为 http.client span 上报
-
-  // 面包屑开关（均为默认值）
-  enableUserInteractionBreadcrumbs: true,
-  enableNavigationBreadcrumbs: true,
-  enableConsoleBreadcrumbs: false,
-
-  // 网络请求体：默认只记 url/method/状态码/耗时，开启后连请求/响应体也记录（内置脱敏）
-  traceNetworkBody: false,
 });
 ```
 
@@ -43,9 +31,9 @@ Sentry.init({
 不要把 `Sentry.init` 放进 `App.onLaunch` 里：此时 `App()` 已注册完成，SDK 无法再提前包装本次 `onLaunch`。这会导致 App 生命周期面包屑、首次 Session 启动，以及依赖 `onLaunch` 起点的冷启动耗时缺失。若只关心后续异常、网络面包屑和手动上报，放在 `onLaunch` 内仍可工作，但启动阶段能力会降级。
 :::
 
-默认初始化路径已包含：**自动异常捕获、性能监控、Source Map 路径归一化、网络面包屑、Session 与网络状态监控**。通常无需手动传 `integrations`——只有要替换核心默认集成时才传；Source Map / 网络 / Session 等能力仍由各自顶层开关控制。
+默认初始化路径已包含自动异常捕获、Source Map 路径归一化、网络面包屑、Session、网络状态与可用的平台性能集成。通常无需手动传 `integrations`。
 
-> 上面只是最小配置。离线缓存、采样、追踪头注入、面包屑开关、小游戏等**完整配置项**见 [配置项参考](/guide/configuration)。
+先用最小配置跑通事件，再按需要开启性能采样、Logs、隐私同意或其它能力。全部选项见[配置项参考](/guide/configuration)。
 
 ## 3. 验证是否打通
 
@@ -70,9 +58,8 @@ Sentry.captureException(new Error('sentry test'));
 
 ## 下一步
 
-- [配置项参考](/guide/configuration) — 全部 `init` 选项
-- [支持平台与能力矩阵](/guide/platforms)
-- [Taro 接入指南](/guide/taro) · [uni-app 接入指南](/guide/uniapp)
-- [常见问题 (FAQ)](/guide/faq)
-- [Source Map 配置](/guide/sourcemap)
-- [示例工程](/guide/examples)
+- 让线上堆栈还原到源码：[Source Map 上线指南](/guide/sourcemap)
+- 配置错误上下文和 Logs：[异常、日志与上下文](/guide/errors-and-context)
+- 开启性能数据和请求链路：[性能与链路追踪](/guide/performance-and-tracing)
+- 处理弱网和隐私授权：[可靠上报与隐私同意](/guide/reliability-and-privacy)
+- 查调用方式或参数：[常用 API](/guide/api) · [配置项参考](/guide/configuration)

--- a/website/guide/how-it-works.md
+++ b/website/guide/how-it-works.md
@@ -1,6 +1,6 @@
 # 工作原理
 
-理解 SDK 怎么跑，能帮你更快定位「为什么没上报 / 堆栈对不上 / 上报率低」这类问题。本页讲设计，不讲 API（API 见[配置项参考](/guide/configuration)）。
+理解 SDK 怎么跑，能帮你更快定位「为什么没上报 / 堆栈对不上 / 上报率低」这类问题。本页讲设计，不讲调用方式；调用方式见[常用 API](/guide/api)，初始化选项见[配置项参考](/guide/configuration)。
 
 ## 为什么不能直接用 `@sentry/browser`
 
@@ -39,7 +39,7 @@ sentry-miniapp（init + 默认集成）
 
 ### 平台 API 抹平
 
-各平台全局对象（`wx` / `my` / `tt` / `dd` / `qq` / `swan` / `ks`）和 API 命名、入参、返回结构都有差异（如支付宝是 `my.httpRequest`、状态码字段叫 `status`）。SDK 在初始化时检测平台并把它们代理成统一调用，上层逻辑只面向一套 API。差异细节见[平台兼容性详解](/guide/platform-compatibility)。
+各平台全局对象（`wx` / `my` / `tt` / `dd` / `qq` / `swan` / `ks`）和 API 命名、入参、返回结构都有差异（如支付宝是 `my.httpRequest`、状态码字段叫 `status`）。SDK 在初始化时检测平台并把它们代理成统一调用，上层逻辑只面向一套 API。差异细节见[跨平台差异与降级](/guide/platform-compatibility)。
 
 ### 全局异常捕获
 
@@ -59,7 +59,7 @@ sentry-miniapp（init + 默认集成）
 
 ### Source Map 路径归一化
 
-小程序错误栈里的文件路径是各平台虚拟路径（如微信 `appservice/pages/index.js`、抖音小游戏 `tt://main/index.js`、Cocos `chunks:///_virtual/runtime.js`）。`RewriteFrames` 集成在上报前把它们统一重写为 `app:///` 前缀，这样你只需用 `--url-prefix "app:///"` 上传一次 Source Map 就能匹配。SDK 还会兼容 Debug ID map 被注入到非 `globalThis` 全局对象的小游戏场景；私有引擎或特殊堆栈格式可通过 `stackParser` 覆盖默认解析器。**真机上微信可能把逻辑层合并成单个 `appservice.app.js`**，这是另一种情况——见 [Source Map 配置](/guide/sourcemap)。
+小程序错误栈里的文件路径是各平台虚拟路径（如微信 `appservice/pages/index.js`、抖音小游戏 `tt://main/index.js`、Cocos `chunks:///_virtual/runtime.js`）。`RewriteFrames` 集成在上报前把它们统一重写为 `app:///` 前缀。SDK 还会兼容 Debug ID map 被注入到非 `globalThis` 全局对象的小游戏场景；私有引擎或特殊堆栈格式可通过 `stackParser` 覆盖默认解析器。真机上微信可能把逻辑层合并成 `appservice.app.js`，详见 [Source Map 进阶与排障](/guide/sourcemap-advanced)。
 
 ### 弱网离线缓存
 
@@ -81,4 +81,4 @@ Sentry 收到 → 用 app:/// 前缀匹配 Source Map → 展示源码位置
 
 ## 下一步
 
-- [配置项参考](/guide/configuration) · [支持平台与能力](/guide/platforms) · [Source Map 配置](/guide/sourcemap)
+- [常用 API](/guide/api) · [配置项参考](/guide/configuration) · [支持范围](/guide/platforms) · [Source Map 上线指南](/guide/sourcemap)

--- a/website/guide/minigame.md
+++ b/website/guide/minigame.md
@@ -1,0 +1,100 @@
+# 小游戏接入与性能监控
+
+`sentry-miniapp` 支持微信小游戏和抖音小游戏。小游戏没有小程序的 `App()`、`Page()` 和页面路由，但仍可使用平台异常监听、网络、Storage 和设备信息 API。
+
+## 最小接入
+
+在游戏入口文件最前面初始化，早于业务模块加载和首帧逻辑：
+
+```js
+import * as Sentry from 'sentry-miniapp';
+
+Sentry.init({
+  dsn: 'YOUR_DSN',
+  release: 'my-game@1.0.0',
+  environment: 'production',
+  tracesSampleRate: 0.2,
+});
+
+Sentry.captureException(new Error('minigame sentry test'));
+```
+
+小游戏运行时会自动启用生命周期和帧率集成；普通小程序中默认关闭。通常不需要手动传 `integrations`。
+
+## 能捕获什么
+
+| 能力 | 微信小游戏 | 抖音小游戏 | 说明 |
+|------|:----------:|:----------:|------|
+| 全局异常与 Promise rejection | 支持 | 支持 | 以宿主实际提供的监听 API 为准 |
+| 网络请求面包屑与 `http.client` span | 支持 | 支持 | 走 `wx.request` / `tt.request` |
+| 设备信息与离线缓存 | 支持 | 支持 | 依赖宿主系统信息与 Storage API |
+| 冷启动首帧 | 支持 | 支持 | 上报 `minigame.coldstart` |
+| FPS 与卡顿 | 支持 | 支持 | 依赖全局 `requestAnimationFrame` |
+| 页面路由、点击面包屑 | 不适用 | 不适用 | 没有 Page 模型，自动跳过 |
+
+## 冷启动与帧率数据在哪里看
+
+开启 `tracesSampleRate` 或 `tracesSampler` 后：
+
+- 冷启动作为 `minigame.coldstart` transaction 上报，包含 `cold_start` measurement；
+- FPS 与卡顿在退后台或会话结束时汇总为 `minigame.framerate.summary`；
+- 汇总包含 `fps_avg`、`fps_p95`、`fps_min` 和 `jank_count`，不会每个采样窗口都发送事件。
+
+未开启 tracing 时，小游戏性能数据仍可作为上下文和面包屑附在后续错误事件上，但不会形成可聚合的独立 Performance 数据。
+
+## 调整帧率与卡顿参数
+
+默认值适合先跑通。确实需要调整告警阈值或汇总周期时：
+
+```js
+Sentry.init({
+  dsn: 'YOUR_DSN',
+  tracesSampleRate: 0.2,
+  minigameFrameRateOptions: {
+    fpsWarningThreshold: 30,
+    longFrameThresholdMs: 50,
+    reportInterval: 10000,
+    maxJankBreadcrumbsPerWindow: 3,
+  },
+});
+```
+
+`reportInterval` 控制本地统计窗口，不代表每个窗口都会发送 transaction。会话汇总仍在退后台或会话结束时发送。
+
+## 按严重程度区分卡顿
+
+需要分别统计轻微、明显和严重卡顿时使用 `jankLevels`：
+
+```js
+Sentry.init({
+  dsn: 'YOUR_DSN',
+  tracesSampleRate: 0.2,
+  minigameFrameRateOptions: {
+    jankLevels: {
+      minor: 17,
+      major: 33,
+      severe: 100,
+    },
+  },
+});
+```
+
+阈值单位为毫秒，并且必须满足 `minor < major < severe`。只传 `{ major, severe }` 也可以；低于最低启用档的帧不计入卡顿。设置 `jankLevels` 后会优先于 `longFrameThresholdMs`。
+
+单帧间隔超过 5000ms 通常来自退后台或调试器暂停，SDK 会当作采样断点丢弃，不计入 jank。
+
+## Source Map 与游戏引擎
+
+小游戏堆栈可能使用 `tt://`、`assets/`、`chunks://` 等虚拟路径，SDK 会尽量归一化为 `app:///`。上传时应同时上传同一次构建的 `.js` 与 `.map`。
+
+Cocos、私有引擎、Debug ID 或特殊堆栈解析属于进阶场景，请看 [Source Map 进阶与排障](/guide/sourcemap-advanced#debug-id-与自定义-stackparser)。
+
+## 验证清单
+
+1. 在真机主动发送测试错误，确认 Issues 中的 `platform` 与 release 正确。
+2. 将 `tracesSampleRate` 临时设为 `1.0`，完整启动并运行一段时间。
+3. 退到后台，确认出现 `minigame.coldstart` 和 `minigame.framerate.summary`。
+4. 检查 summary 是否包含 FPS 与 jank measurements。
+5. 上传 Source Map 后再触发一次真机错误，确认堆栈能还原到源码。
+
+如果没有性能 transaction，先检查 tracing 采样是否开启，再确认运行时存在全局 `requestAnimationFrame`。完整选项见[配置项参考 · 小游戏](/guide/configuration#小游戏)。

--- a/website/guide/performance-and-tracing.md
+++ b/website/guide/performance-and-tracing.md
@@ -1,0 +1,111 @@
+# 性能与链路追踪
+
+性能监控回答“哪里慢”，链路追踪回答“一次请求在小程序和服务端分别花了多久”。两者共用 trace，但不是同一件事。
+
+## 先开启性能采样
+
+设置 `tracesSampleRate` 后，SDK 才会发送性能 transaction 和 span：
+
+```js
+Sentry.init({
+  dsn: 'YOUR_DSN',
+  release: 'my-miniapp@1.0.0',
+  tracesSampleRate: 0.2,
+});
+```
+
+`0.2` 表示约 20% 的 trace 被采样。测试环境可临时使用 `1.0`，生产环境应结合流量和 Sentry 配额设置。
+
+错误事件由 `sampleRate` 控制，性能数据由 `tracesSampleRate` 或 `tracesSampler` 控制，两套采样互不替代。
+
+## 按页面或场景动态采样
+
+关键链路全采、普通页面降采时使用 `tracesSampler`：
+
+```js
+Sentry.init({
+  dsn: 'YOUR_DSN',
+  tracesSampler: ({ name, inheritOrSampleWith }) => {
+    if (name.includes('pages/pay')) return 1;
+    if (name.includes('pages/about')) return 0.05;
+    return inheritOrSampleWith(0.2);
+  },
+});
+```
+
+设置 `tracesSampler` 后，它的优先级高于 `tracesSampleRate`。
+
+## 自动采集哪些性能数据
+
+默认性能集成会在宿主支持时读取小程序 Performance API：
+
+| 数据 | 在 Sentry 中的用途 |
+|------|--------------------|
+| 导航与启动 | 判断页面进入和启动阶段耗时 |
+| 渲染与 `setData` | 发现渲染过慢、更新过重 |
+| 资源加载 | 定位大资源或慢资源 |
+| API 请求 | 作为 `http.client` span 查看请求耗时 |
+| 小游戏冷启动、FPS、jank | 作为小游戏专属 transaction 与 measurement |
+
+宿主没有对应 Performance API 时，相关采集会跳过，不影响异常上报。小游戏性能请看[小游戏接入与性能](/guide/minigame)。
+
+## 添加业务 span
+
+需要测量登录、支付、数据转换等业务操作时，可以使用熟悉的 Sentry API：
+
+```js
+await Sentry.startSpan(
+  {
+    name: 'checkout.submit',
+    op: 'ui.action',
+    attributes: { paymentMethod: 'balance' },
+  },
+  async () => {
+    await submitOrder();
+  },
+);
+```
+
+`startSpan` 会管理回调生命周期。只有确实需要跨越多个回调手动结束时，才使用 `startInactiveSpan`。
+
+## 串联小程序与服务端
+
+开启 tracing 后，SDK 默认可向非 Sentry 请求注入：
+
+- `sentry-trace`：trace id、span id 与采样状态；
+- `baggage`：Sentry Dynamic Sampling Context；
+- `traceparent`：仅在 `propagateTraceparent: true` 时额外注入，用于兼容 W3C Trace Context / OpenTelemetry 后端。
+
+生产环境建议用 `tracePropagationTargets` 限制只向自己的 API 域名发送追踪头：
+
+```js
+Sentry.init({
+  dsn: 'YOUR_DSN',
+  tracesSampleRate: 0.2,
+  tracePropagationTargets: [
+    /^https:\/\/api\.example\.com\//,
+    /^https:\/\/gateway\.example\.com\//,
+  ],
+  propagateTraceparent: true,
+});
+```
+
+只有后端网关或 OpenTelemetry 链路明确需要 W3C `traceparent` 时才打开 `propagateTraceparent`。Sentry 原生服务只需要默认的 `sentry-trace` 与 `baggage`。
+
+`enableTracePropagation: false` 只停止追踪头注入，不会关闭本地 `http.client` span。要停止性能采集，应移除性能采样配置。
+
+## 请求名称基数
+
+请求 span 名会保留 URL 路径，例如 `GET https://api.example.com/users/123`。如果路径中的订单号、用户 id 导致维度过高，可在 `beforeSendTransaction` 中把动态段统一改为 `:id`。SDK 不会自行猜测路由模板，避免误改合法路径。
+
+## 验证链路
+
+1. 测试环境临时设置 `tracesSampleRate: 1.0`。
+2. 发起一次目标 API 请求，在 Sentry Performance / Traces 中确认 `http.client` span。
+3. 在真机网络面板或服务端日志中确认预期追踪头存在。
+4. 确认第三方域名没有收到不必要的追踪头。
+5. 打印 `Sentry.getDiagnostics()`，检查采样率、传播开关和 warnings。
+
+没有 span 时，先确认性能采样已开启；本地 span 正常但服务端没有串联时，再检查 `tracePropagationTargets`、网关透传和后端 Sentry / OpenTelemetry 配置。
+
+所有相关选项见[配置项参考 · 采样](/guide/configuration#采样)与[配置项参考 · 分布式追踪](/guide/configuration#分布式追踪)。

--- a/website/guide/platform-compatibility.md
+++ b/website/guide/platform-compatibility.md
@@ -1,8 +1,8 @@
-# 平台兼容性详解
+# 跨平台差异与降级
 
 同一份 `sentry-miniapp` 配置可以运行在多个小程序平台，但平台提供的网络、Storage、异常监听和系统信息 API 并不完全一致。本页说明 SDK 如何抹平这些差异，以及某项能力在特定平台缺失时会发生什么。
 
-如果你只想确认某个平台是否支持异常、性能、小游戏或 Source Map，请先看[支持平台与能力](/guide/platforms)。遇到“微信正常、支付宝或钉钉异常”这类分端问题时，再回到本页排查。
+如果你只想确认某个平台是否支持异常、性能、小游戏或 Source Map，请先看[支持范围](/guide/platforms)。遇到“微信正常、支付宝或钉钉异常”这类分端问题时，再回到本页排查。
 
 ## SDK 如何处理平台差异
 
@@ -87,7 +87,7 @@ https://appx/pages/a.js    -> app:///pages/a.js
 tt://pages/b.js            -> app:///pages/b.js
 ```
 
-上传 Source Map 时仍需保证 `release` 与 SDK 初始化值完全一致。微信真机合并脚本、Debug ID、自定义 `stackParser` 等情况见 [Source Map 配置](/guide/sourcemap)。
+上传 Source Map 时仍需保证 `release` 与 SDK 初始化值完全一致。微信真机合并脚本、Debug ID、自定义 `stackParser` 等情况见 [Source Map 进阶与排障](/guide/sourcemap-advanced)。
 
 ## 分端问题怎么排查
 
@@ -99,6 +99,6 @@ tt://pages/b.js            -> app:///pages/b.js
 
 ## 下一步
 
-- [支持平台与能力](/guide/platforms)
+- [支持范围](/guide/platforms)
 - [配置项参考](/guide/configuration)
 - [常见问题](/guide/faq)

--- a/website/guide/platforms.md
+++ b/website/guide/platforms.md
@@ -1,4 +1,6 @@
-# 支持平台与能力
+# 支持范围
+
+本页只回答“当前运行时支持哪些平台和能力”。遇到某个平台行为不同，请看[跨平台差异与降级](/guide/platform-compatibility)；要接入小游戏性能，请看[小游戏接入与性能](/guide/minigame)。
 
 ## 支持的平台
 
@@ -31,49 +33,9 @@
 | Source Map 路径归一化 | ✅ | ✅ | 各平台虚拟路径统一为 `app:///` |
 | 多平台堆栈解析 | ✅ | ✅ | 支持 V8 / Safari / JavaScriptCore 格式，配合 Source Map 精准定位 |
 | 弱网离线缓存重试 | ✅ | ✅ | 失败缓存到本地 Storage |
+| 隐私同意前停止网络发送 | ✅ | ✅ | 开启 `requireConsent` 后进入本地缓冲 |
+| Sentry Logs | ✅ | ✅ | 需开启 `enableLogs` |
 
 > ➖ 表示该环境无对应能力，SDK 自动跳过（no-op），不会报错。
 
-如果你正在排查某个平台独有的网络、Storage、异常监听或系统信息问题，请继续阅读[平台兼容性详解](/guide/platform-compatibility)。
-
-## 小游戏：性能数据独立上报
-
-小游戏的冷启动与帧率数据**不只挂在 error 事件上**——开启 tracing 后会作为独立 transaction 上报，可在 Sentry **Performance 页**做跨会话的趋势 / 分布 / P95 聚合：
-
-- **冷启动** → `minigame.coldstart` transaction（含 `cold_start` measurement）。
-- **帧率 / 卡顿** → 会话维度累积，在**退后台（onHide）/ 会话结束**时发一个 `minigame.framerate.summary` transaction（含 `fps_avg` / `fps_p95` / `fps_min` / `jank_count` measurements）——不每窗口发事件，配额友好。
-
-```js
-Sentry.init({
-  dsn: 'YOUR_DSN',
-  tracesSampleRate: 1.0, // 启用性能采样（与 error 的 sampleRate 解耦）
-});
-```
-
-> 需设置 `tracesSampleRate`（或 `tracesSampler`）才会上报性能 transaction，其采样**独立于** error 的 `sampleRate`。未启用 tracing 时退化为原有行为：性能数据仅作为 `minigame` / `minigame.framerate` 上下文 + 面包屑挂在 error 事件上。
-
-### 卡顿分级（可选）
-
-默认所有卡顿合并为一个 `jank_count`。若想区分严重程度，传 `jankLevels` 把卡顿按 `minor` / `major` / `severe` 三档分级（毫秒阈值，各档全可选）：
-
-```js
-Sentry.init({
-  dsn: 'YOUR_DSN',
-  tracesSampleRate: 1.0,
-  minigameFrameRateOptions: {
-    jankLevels: { minor: 17, major: 33, severe: 100 }, // 约对应 60fps 丢 1 帧 / 30fps 丢 1 帧 / 明显卡死
-  },
-});
-```
-
-启用后：
-
-- 每帧卡顿按命中的**最高档**归类，`minigame.jank` 面包屑 `data` 带 `jankLevel`（`minor` / `major` / `severe`）。
-- 会话汇总 transaction **额外**增发 `jank_minor_count` / `jank_major_count` / `jank_severe_count`（仅启用的档），可在 Performance 页分级聚合；`jank_count` 仍为总数，老看板不受影响。
-- 入档阈值取**最低启用档**，因此只想要两档时可只传 `{ major, severe }`，低于 `major` 的帧不计卡顿。
-- 启用档的阈值须按 `minor` < `major` < `severe` **严格递增**；若误传非单调阈值（如 `{ minor: 100, severe: 17 }`，会把重卡标成 `minor`），SDK 会 `warn` 并忽略分级、回退单档。
-- 与 `longFrameThresholdMs` 同时提供时 **`jankLevels` 优先**，老参数忽略；不传 `jankLevels` 则沿用单档，行为与历史完全一致。
-
-> 阈值应为**亚秒级**（建议 < 5000ms）。卡顿（jank）是丢帧，量级在几十～几百毫秒；单帧间隔超过 5000ms 会被当作后台暂停 / 调试器停顿（采样断点）丢弃，不计入卡顿——这种秒级停顿属于卡死（ANR），不是 jank。
-
-帧率监控依赖全局 `requestAnimationFrame`：小游戏有（绑定真实渲染帧），小程序为双线程架构、逻辑层没有，因此小程序中即使开启也会安全 no-op。
+如果你正在排查某个平台独有的网络、Storage、异常监听或系统信息问题，请继续阅读[跨平台差异与降级](/guide/platform-compatibility)。小游戏冷启动、FPS、jank 和验证步骤集中在[小游戏接入与性能](/guide/minigame)。

--- a/website/guide/reliability-and-privacy.md
+++ b/website/guide/reliability-and-privacy.md
@@ -1,0 +1,92 @@
+# 可靠上报与隐私同意
+
+小程序可能在弱网、断网或授权弹窗出现前产生事件。SDK 提供两种本地缓冲，但它们解决的问题不同。
+
+## 两种缓冲分别解决什么
+
+| 能力 | 什么时候进入缓冲 | 什么时候补发 | 默认状态 |
+|------|------------------|--------------|----------|
+| 弱网离线缓存 | Sentry 请求发送失败或当前离线 | 网络恢复后自动重试 | 开启 |
+| 隐私同意门禁 | 开启 `requireConsent` 后，用户尚未同意 | 调用 `setConsent(true)` 后 | 关闭，按需开启 |
+
+它们复用平台 Storage 和离线 transport，但策略与上限可以分别配置。
+
+## 弱网离线缓存
+
+默认配置已经适合大多数项目：
+
+```js
+Sentry.init({
+  dsn: 'YOUR_DSN',
+  enableOfflineCache: true,
+  offlineCacheLimit: 30,
+  offlineCacheMaxAge: 24 * 60 * 60 * 1000,
+});
+```
+
+发送失败的事件会写入本地 Storage；网络恢复或后续 flush 时静默重试。超过条数或有效期的事件会被淘汰，避免长期占用用户存储空间。
+
+如果宿主缺少必要的 Storage API，SDK 仍可初始化并尝试实时上报，但持久化重试会降级。可通过 `Sentry.getDiagnostics()` 查看 transport 状态。
+
+## 用户同意前不发送 Sentry 网络
+
+需要先取得隐私授权的项目，在初始化时开启门禁：
+
+```js
+Sentry.init({
+  dsn: 'YOUR_DSN',
+  requireConsent: true,
+});
+```
+
+这时 SDK 仍会监听异常、记录面包屑和构建事件，但在用户同意前不会向 Sentry 发请求，事件先写入本地缓冲。
+
+用户明确同意后调用：
+
+```js
+Sentry.setConsent(true);
+```
+
+SDK 会开始补发同意前的缓冲事件，并恢复后续实时上报。用户撤回同意时可调用：
+
+```js
+Sentry.setConsent(false);
+```
+
+之后的新事件会再次只进入本地缓冲，不发 Sentry 网络。`Sentry.getConsent()` 可读取当前状态；没有开启 `requireConsent` 时恒为 `true`。
+
+> `requireConsent` 是网络发送门禁，不是采样开关。要减少上报量，请配置 `sampleRate`、`tracesSampleRate` 或过滤规则。
+
+## 控制同意前缓冲上限
+
+同意等待期可能比短时断网更长，因此默认允许缓存更多事件：
+
+```js
+Sentry.init({
+  dsn: 'YOUR_DSN',
+  requireConsent: true,
+  consentCacheLimit: 100,
+  consentCacheMaxBytes: 900 * 1024,
+  consentCacheMaxAge: 24 * 60 * 60 * 1000,
+  onConsentCacheDrop({ reason, dropped }) {
+    console.warn('Sentry consent cache dropped', reason, dropped);
+  },
+});
+```
+
+当前同意缓冲与弱网缓存使用同一个 Storage key。受部分小程序单 key 容量限制影响，`consentCacheMaxBytes` 不建议超过默认约 900KB。
+
+传入自定义 `transport` 时，SDK 仍会在外层应用 consent 门禁；开启 `requireConsent` 也会隐含启用同意前缓冲，即使 `enableOfflineCache` 设置为 `false`。
+
+## 上线前怎样验证
+
+1. 清空本地 Storage，重新启动应用且暂不点击同意。
+2. 主动调用 `captureException`，确认没有 Sentry 网络请求。
+3. 检查平台 Storage 中出现缓冲数据。
+4. 调用 `setConsent(true)`，确认缓冲事件被补发并能在 Sentry 中看到。
+5. 断网再触发一个事件，恢复网络后确认弱网缓存也能补发。
+6. 打印 `getDiagnostics()`，检查 consent、离线缓存和 warnings 是否符合预期。
+
+合规要求会因应用、地区和数据类型而异。SDK 只提供技术门禁，项目仍需根据自己的隐私政策决定何时初始化、采集哪些字段以及何时调用 `setConsent(true)`。
+
+完整参数见[配置项参考 · 离线缓存](/guide/configuration#离线缓存-弱网可靠性)和[配置项参考 · 隐私合规](/guide/configuration#隐私合规-同意后上报)。

--- a/website/guide/sourcemap-advanced.md
+++ b/website/guide/sourcemap-advanced.md
@@ -1,0 +1,172 @@
+# Source Map 进阶与排障
+
+本页处理普通上传流程之外的问题。尚未完成基础配置时，请先按 [Source Map 上线指南](/guide/sourcemap)生成、上传并验证一组 `.js` + `.map`。
+
+## 本地 Source Map Doctor
+
+包内提供静态体检命令。它不会登录 Sentry、不会上传或修改文件，只检查本地产物是否具备上传条件。
+
+```bash
+npx -p sentry-miniapp sentry-miniapp-sourcemap-doctor \
+  --dist ./dist \
+  --release "my-miniapp@1.0.0"
+```
+
+Doctor 会检查：
+
+- 构建目录是否同时存在运行时 `.js` 和 `.map`；
+- `sourceMappingURL` 是否断链，或是否为合理的 hidden source map；
+- map 是否为合法 JSON，是否包含 `sources`、`mappings` 和完整 `sourcesContent`；
+- 按 `--url-prefix` 推导的 artifact 是否符合默认 `app:///` 路径；
+- 是否提供 release，并提醒与 `Sentry.init({ release })` 保持一致。
+
+CI 中建议开启严格模式：
+
+```bash
+npx -p sentry-miniapp sentry-miniapp-sourcemap-doctor \
+  --dist ./dist \
+  --release "$SENTRY_RELEASE" \
+  --strict
+```
+
+提交 Issue 或为 CI 留档时可加 `--json`。Doctor 默认忽略 `.d.ts.map`，只检查需要上传的运行时 artifact。
+
+## 先按现象选择排查路径
+
+| 事件中的表现 | 优先检查 |
+|--------------|----------|
+| `filename` 是分页文件，但显示压缩代码 | release、artifact 名称、JS/map 是否成对、sourcesContent |
+| `filename` 是 `app:///appservice.app.js` | 微信真机两层 Source Map |
+| filename 使用 `chunks://`、`assets/` 或私有协议 | 平台路径与上传 artifact 结构 |
+| 事件有 `debug_meta` 但仍未解析 | Debug ID 是否注入到最终发布的 JS、对应 bundle 是否上传 |
+| 堆栈本身就缺少 filename / 行列 | 自定义 `stackParser` 或运行时堆栈能力 |
+
+## 平台路径差异
+
+### 微信小程序
+
+尽量让 Webpack / Vite 完成转译和压缩，并关闭微信开发者工具中会再次改变 JS 行列号的编译选项。SDK 会剥离 `appservice/`、`app-service/` 和 `WAService/` 等虚拟前缀。
+
+真机可能把逻辑层合并为 `appservice.app.js`。这不是路径前缀问题，需按下一节处理。
+
+### 支付宝、字节、百度与其它平台
+
+- 支付宝的 `https://appx/` 会归一为 `app:///`；
+- 字节小程序 / 抖音小游戏的 `tt://` 会被剥离；
+- 百度的 `swan://` 会被剥离；
+- QQ、钉钉、快手等协议前缀也会归一化。
+
+抖音小游戏接入 Cocos 时，`chunks:///_virtual/foo.js` 和 `chunks:///assets/foo.js` 会分别变成 `app:///chunks/_virtual/foo.js` 与 `app:///chunks/assets/foo.js`。上传目录也要保留相同的 `chunks/...` 相对路径。
+
+## 微信真机的两层 Source Map
+
+Taro / uni-app 项目在微信真机上常见这样的堆栈：
+
+```text
+app:///appservice.app.js:123456:78
+```
+
+框架构建产物却是 `app.js`、`vendors.js` 和 `pages/*/index.js`。此时上传分页 map 无法解析，因为真机执行文件与上传 artifact 根本不是同一个文件。
+
+### 为什么有两层
+
+```text
+源码 .vue / .tsx
+  ↓ 框架构建 Map A
+分页编译产物 JS
+  ↓ 微信合并与转译 Map B
+appservice.app.js
+```
+
+- 只上传 Map A：能描述分页 JS 到源码，但匹配不到 `appservice.app.js`；
+- 只上传 Map B：能回到分页编译产物，但无法继续到 `.vue` / `.tsx`；
+- 要还原到源码，需要把 Map B 与 Map A 离线合成。
+
+### 1. 获取两层 map
+
+- Map B：从微信“ We 分析 → 性能 / JS 报错 → 下载线上 Source Map”获取与体验版或线上版完全一致的 `appservice.app.js.map`；
+- Map A：在 Taro / uni-app 构建中开启 Source Map，保留所有分页构建 map。
+
+开发预览的 map 不能替代线上版本，外层 map 必须与实际发布构建一致。
+
+### 2. 先检查能否匹配
+
+```bash
+npx -p sentry-miniapp sentry-miniapp-sourcemap-doctor \
+  --wechat ./wechat/appservice.app.js.map \
+  --build-maps ./dist/dev/mp-weixin \
+  --strip webpack:// \
+  --release "$SENTRY_RELEASE"
+```
+
+结果会列出 `matched`、`unmatched` 和 `ambiguous`。文件名对不齐时，按输出调整 `--strip` 或构建产物路径。
+
+### 3. 合成最终 map
+
+合成工具临时需要 `source-map`，不会增加 SDK 运行时依赖：
+
+```bash
+npx -p sentry-miniapp -p source-map sentry-miniapp-sourcemap-merge \
+  --wechat ./wechat/appservice.app.js.map \
+  --build-maps ./dist/dev/mp-weixin \
+  --out ./merged/appservice.app.js.map \
+  --strip webpack://
+```
+
+脚本优先按相对路径精确匹配，最后才按文件名兜底。多个页面都叫 `index.js` 时会标记歧义并跳过，避免静默套错 map。
+
+### 4. 上传并验证
+
+把合成 map 与对应的 `appservice.app.js` 按 `app:///appservice.app.js` 的名称上传。新触发一个真机错误，确认堆栈能一路还原到源码。
+
+合成精度取两份 map 中较低的一层；个别列号可能不精确。该方案属于 best-effort，匹配效果取决于框架、打包器和版本产生的 source 名称。
+
+相关背景见 [issue #162](https://github.com/lizhiyao/sentry-miniapp/issues/162) 与 [issue #173](https://github.com/lizhiyao/sentry-miniapp/issues/173)。
+
+## Debug ID 与自定义 stackParser
+
+SDK 会同步当前小程序 / 小游戏运行时可见全局对象上的 `_sentryDebugIds` 与 `_debugIds`，兼容 Debug ID 被注入到 `window`、`global`、`self` 等对象的情况。
+
+大多数项目无需设置 `stackParser`。内置 `miniappStackParser` 已覆盖常见 V8、Safari、JavaScriptCore 以及小程序虚拟路径格式。
+
+只有私有引擎、特殊打包器或非标准堆栈无法解析时才覆盖：
+
+```js
+import * as Sentry from 'sentry-miniapp';
+
+Sentry.init({
+  dsn: 'YOUR_DSN',
+  release: 'my-game@1.0.0',
+  stackParser: (stack, skipFirstLines, framesToPop) => {
+    // 可先委托默认解析器，再按私有格式补充或修正 StackFrame。
+    return Sentry.miniappStackParser(stack, skipFirstLines, framesToPop);
+  },
+});
+```
+
+`stackParser` 只负责把运行时字符串解析成 StackFrame，不会生成或上传 Source Map，也不会放宽 release / artifact 匹配要求。
+
+## 上传成功仍无法还原
+
+按这个顺序检查，通常比反复重传更快：
+
+1. 在新事件原始 JSON 中确认 release、`filename`、行号和列号。
+2. 用 `sentry-cli releases files <release> list` 对照 artifact 名称。
+3. 确认上传的是同一次生产构建生成的 JS 与 map，并包含 `sourcesContent`。
+4. 检查 `filename` 是否为 `appservice.app.js`，避免拿分页 map 匹配合并文件。
+5. 使用 Sentry 的 Source Map Debug；支持时也可运行 `sentry-cli sourcemaps explain <event-id>`。
+6. 上传完成后重新触发事件；Sentry 不会回溯处理旧事件。
+7. 自托管 Sentry 还需检查 symbolicator、worker 与 artifact 存储是否正常。
+
+### CI 上传失败
+
+确认 Token 权限、`SENTRY_ORG`、`SENTRY_PROJECT`、自托管地址和网络连通性。Source Map 很大时检查 CLI 超时配置，并确认产物没有被预先 gzip。
+
+### 安全要求
+
+- Auth Token 只放在 CI Secret 或未入库的本地配置中；
+- 上传完成后删除 `.map`，不要打进小程序包或公开托管；
+- 合成 map 内含 `sourcesContent`，同样只能用于上传；
+- 先上传 artifact，再发布对应构建，避免事件先于 map 到达 Sentry。
+
+仍无法定位时，提交 Issue 时附 SDK 版本、平台、框架、事件 filename、release、Doctor JSON 输出和脱敏后的 `Sentry.getDiagnostics()`。

--- a/website/guide/sourcemap.md
+++ b/website/guide/sourcemap.md
@@ -1,183 +1,110 @@
-# Source Map 完整配置指南
+# Source Map 上线指南
 
-> 🚀 **只想最快跑通？** 大多数项目只需三步：[第一步 SDK 配置 `release`](#第一步sdk-配置) → [第三步生成 Source Map](#第三步生成-source-map) → [第四步上传](#第四步上传-source-map)，再用[第六步](#第六步验证-source-map-是否生效)验证。
->
-> [跨端框架的两层 Source Map 串联](#跨端框架的两层-source-map-串联)属于进阶场景：仅当你使用 Taro / uni-app，并且真机错误栈文件名是合并后的 `app:///appservice.app.js`（分页 Source Map 无法解析）时才需要。多数项目不需要，遇到后再处理。
+Source Map 让 Sentry 把线上压缩代码的堆栈还原到 `.ts`、`.tsx` 或 `.vue` 源码。第一次配置时只沿着本页主线完成：**release 一致、生成 map、同时上传 JS 与 map、真机验证**。
 
-## 概述
+> 真机堆栈如果是 `app:///appservice.app.js`，或者项目使用 Cocos、Debug ID、私有引擎，请直接看 [Source Map 进阶与排障](/guide/sourcemap-advanced)。
 
-在小程序中，错误堆栈的路径通常是各平台的虚拟路径（如微信的 `appservice/pages/index.js`、支付宝的 `https://appx/pages/index.js`），这导致上传到 Sentry 的 Source Map 无法被正确匹配和解析。
+## 先理解匹配关系
 
-**SDK 的解决方案：** `sentry-miniapp` 内置了 `RewriteFrames` 集成，在上报错误时自动将各平台虚拟路径归一化为统一的 `app:///` 前缀。例如：
+小程序堆栈通常使用平台虚拟路径。SDK 默认把它们归一为 `app:///`：
 
-```
-微信:     appservice/pages/index.js    →  app:///pages/index.js
-支付宝:   https://appx/pages/index.js  →  app:///pages/index.js
-字节跳动: tt://pages/index.js          →  app:///pages/index.js
-抖音小游戏: assets/main/index.js        →  app:///assets/main/index.js
-Cocos:    chunks:///_virtual/foo.js    →  app:///chunks/_virtual/foo.js
-百度:     swan://pages/index.js        →  app:///pages/index.js
+```text
+appservice/pages/index.js    -> app:///pages/index.js
+https://appx/pages/index.js  -> app:///pages/index.js
+tt://pages/index.js          -> app:///pages/index.js
+swan://pages/index.js        -> app:///pages/index.js
 ```
 
-因此，你在上传 Source Map 时只需统一使用 `--url-prefix "app:///"` 即可，无需关心各平台差异。
+上传后的 artifact 名称必须与事件堆栈中的文件名一致，Sentry 才能找到对应 Source Map。
 
-> ⚠️ **真机可能是另一种形态。** 真机上微信常把逻辑层 JS 合并成单个 `app:///appservice.app.js`（用 Taro / uni-app 时几乎必然），分页 Source Map 解不出。**上传前先在真机触发一个错误、看清堆栈文件名，再决定传哪种 map**——详见 [跨端框架的两层 Source Map 串联](#跨端框架的两层-source-map-串联)。
-
-**端到端流程：**
-
+```text
+同一次构建生成 .js + .map
+        ↓
+以同一个 release 上传到 Sentry，路径前缀为 app:///
+        ↓
+SDK 捕获错误并归一化堆栈路径
+        ↓
+Sentry 按 release + 文件名匹配 artifact，还原源码
 ```
-构建工具生成 .js + .map 文件
-        ↓
-sentry-cli 上传 .map 到 Sentry（url-prefix: app:///）
-        ↓
-小程序运行时发生错误
-        ↓
-SDK 捕获错误，RewriteFrames 归一化堆栈路径为 app:///
-        ↓
-Sentry 收到事件，匹配 app:/// 前缀找到对应 Source Map
-        ↓
-Sentry 面板展示原始源码位置
-```
-
----
 
 ## 前置条件
 
-1. **Sentry 账号**：SaaS 版（sentry.io）或自托管版均可
-2. **Sentry 项目**：已创建对应的项目
-3. **Auth Token**：在 Sentry 设置中创建，需具备 `project:releases` 和 `org:read` 权限
-   - SaaS 版：`https://sentry.io/settings/auth-tokens/`
-   - 自托管版：`https://<your-sentry>/settings/auth-tokens/`
+- 已有可用的 Sentry 服务和项目 DSN；
+- Sentry Auth Token，可用于 CI 创建 release 和上传 artifact；
+- 构建工具能够为生产构建生成独立 `.map` 文件；
+- 小程序构建产物目录，例如 `dist` 或 `dist/build/mp-weixin`。
 
----
+Token 建议使用 Sentry 的 CI / release 上传权限，并保存在环境变量中，不要提交到仓库。
 
 ## 第一步：SDK 配置
 
 ### 配置 `release`
 
-**`release` 是 Source Map 生效的关键**——SDK 初始化时设置的 `release` 值必须与 sentry-cli 上传时使用的 release 名称**完全一致**。
+SDK 初始化值必须与上传命令使用的 release **完全一致**：
 
-```javascript
+```js
 import * as Sentry from 'sentry-miniapp';
 
 Sentry.init({
-  dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0',
-  release: 'my-miniapp@1.0.0',  // 必须与上传时的 release 名称一致
+  dsn: 'YOUR_DSN',
+  release: 'my-miniapp@1.0.0',
   environment: 'production',
-  // enableSourceMap: true,  // 默认已开启，无需显式设置（仅控制堆栈路径归一化，与 .map 文件生成无关）
 });
 ```
 
-### `release` 命名建议
+推荐在构建时注入 release，避免代码和上传脚本分别维护：
 
-| 方式 | 示例 | 适用场景 |
-|------|------|---------|
-| 语义化版本 | `my-miniapp@1.2.3` | 有明确版本号的项目 |
-| Git Commit SHA | `my-miniapp@a1b2c3d` | 持续部署场景 |
-| 构建编号 | `my-miniapp@build-456` | CI/CD 自动构建 |
-
-### 动态注入 release
-
-推荐在构建时通过环境变量注入，避免手动维护版本号：
-
-**Webpack（Taro）：**
-
-```javascript
-// config/index.js
-const config = {
-  defineConstants: {
-    SENTRY_RELEASE: JSON.stringify(process.env.SENTRY_RELEASE || 'dev'),
-  },
-};
-```
-
-**Vite：**
-
-```javascript
-// vite.config.js
-export default defineConfig({
-  define: {
-    __SENTRY_RELEASE__: JSON.stringify(process.env.SENTRY_RELEASE || 'dev'),
-  },
-});
-```
-
-然后在代码中使用：
-
-```javascript
+```js
 Sentry.init({
-  dsn: '...',
-  release: SENTRY_RELEASE, // 或 __SENTRY_RELEASE__
+  dsn: 'YOUR_DSN',
+  release: SENTRY_RELEASE,
 });
 ```
 
-### 关于 `enableSourceMap`
+| 命名方式 | 示例 | 适合场景 |
+|----------|------|----------|
+| 应用名 + 语义化版本 | `my-miniapp@1.2.3` | 有明确发布版本 |
+| 应用名 + Git SHA | `my-miniapp@a1b2c3d` | 持续部署 |
+| 应用名 + 构建号 | `my-miniapp@build-456` | CI 构建 |
 
-SDK 默认开启路径归一化（`enableSourceMap: true`），通常无需修改。
-
-> ℹ️ **这个开关名容易误解：** 它**只控制错误上报时把平台虚拟路径归一化为 `app:///`**（即 `RewriteFrames`），**不负责生成 `.map` 文件**——`.map` 由你的构建工具产出。关掉它只是不再归一化堆栈路径，不会影响构建产物。
-
-如果你因特殊原因需要禁用：
-
-```javascript
-Sentry.init({
-  enableSourceMap: false, // 禁用路径归一化
-});
-```
-
----
+`enableSourceMap` 默认为 `true`，只控制 SDK 是否把虚拟堆栈路径归一为 `app:///`，**不会生成 `.map` 文件**。
 
 ## 第二步：安装和配置 sentry-cli
 
-### 安装
-
 ```bash
-# 推荐：作为开发依赖安装
 npm install @sentry/cli --save-dev
-
-# 或全局安装
-npm install -g @sentry/cli
 ```
 
-### 配置认证
-
-**方式一：`.sentryclirc` 文件**（推荐本地开发）
-
-在项目根目录创建 `.sentryclirc`：
+本地可创建不入库的 `.sentryclirc`：
 
 ```ini
 [auth]
-token=your-auth-token-here
+token=your-auth-token
 
 [defaults]
-org=your-org-slug
-project=your-project-slug
+org=your-org
+project=your-project
 ```
 
-> **重要：** 将 `.sentryclirc` 添加到 `.gitignore`，防止 Token 泄露。
-
-**方式二：环境变量**（推荐 CI/CD）
+CI 中使用环境变量：
 
 ```bash
-export SENTRY_AUTH_TOKEN=your-auth-token-here
-export SENTRY_ORG=your-org-slug
-export SENTRY_PROJECT=your-project-slug
+export SENTRY_AUTH_TOKEN=your-auth-token
+export SENTRY_ORG=your-org
+export SENTRY_PROJECT=your-project
 ```
 
----
+将 `.sentryclirc` 加入 `.gitignore`。自托管 Sentry 还需要按实际地址配置 `url`。
 
 ## 第三步：生成 Source Map
 
-根据你使用的构建工具，配置 Source Map 生成。
+### Webpack / Taro
 
-### Webpack（Taro 项目）
-
-```javascript
-// config/index.js（Taro 配置）
+```js
+// config/index.js
 const config = {
   mini: {
     webpackChain(chain) {
-      // 使用 hidden-source-map，避免在产物中暴露 .map 文件引用
       chain.devtool('hidden-source-map');
     },
   },
@@ -186,32 +113,7 @@ const config = {
 
 ### Vite
 
-```javascript
-// vite.config.js
-export default defineConfig({
-  build: {
-    sourcemap: 'hidden', // 生成 .map 文件但不在 .js 中添加 sourceMappingURL 注释
-  },
-});
-```
-
-### uni-app
-
-**Vue CLI 模式：**
-
-```javascript
-// vue.config.js
-module.exports = {
-  productionSourceMap: true,
-  configureWebpack: {
-    devtool: 'hidden-source-map',
-  },
-};
-```
-
-**Vite 模式（uni-app 3.x+）：**
-
-```javascript
+```js
 // vite.config.js
 export default defineConfig({
   build: {
@@ -220,504 +122,136 @@ export default defineConfig({
 });
 ```
 
-> **提示：** 推荐使用 `hidden-source-map`（Webpack）或 `sourcemap: 'hidden'`（Vite），这样生成 `.map` 文件用于上传，但不会在产物 JS 文件中添加 `//# sourceMappingURL` 注释，避免在生产环境暴露源码映射。
+### uni-app
 
----
+Vue CLI 项目可设置 `productionSourceMap: true` 和 `devtool: 'hidden-source-map'`；Vite 模式使用 `build.sourcemap: 'hidden'`。最终以实际小程序产物目录中同时出现 `.js` 和 `.map` 为准。
+
+`hidden-source-map` 会生成独立 map，但不会在生产 JS 中留下可公开加载的 `sourceMappingURL`。上传完成后，不要把 `.map` 发布进小程序包。
 
 ## 第四步：上传 Source Map
 
-### 方式一：sentry-cli 手动上传
+使用与 SDK 完全一致的 release，并且**同时上传同一次构建的 `.js` 和 `.map`**：
 
 ```bash
-# 定义 release 名称（与 SDK 中的 release 一致）
-VERSION="my-miniapp@1.0.0"
+SENTRY_RELEASE="my-miniapp@1.0.0"
 
-# 1. 创建 release
-npx sentry-cli releases new "$VERSION"
-
-# 2. 上传 Source Map
-npx sentry-cli releases files "$VERSION" upload-sourcemaps ./dist \
+npx sentry-cli releases new "$SENTRY_RELEASE"
+npx sentry-cli releases files "$SENTRY_RELEASE" upload-sourcemaps ./dist \
   --url-prefix "app:///" \
-  --ext js --ext map
-
-# 3. 完成 release
-npx sentry-cli releases finalize "$VERSION"
+  --ext js \
+  --ext map \
+  --validate
+npx sentry-cli releases finalize "$SENTRY_RELEASE"
 ```
 
-**参数说明：**
-
-| 参数 | 说明 |
+| 参数 | 作用 |
 |------|------|
-| `--url-prefix "app:///"` | 与 SDK 的 RewriteFrames 归一化前缀对应，**必须设置** |
-| `--ext js --ext map` | 只上传 `.js` 和 `.map` 文件 |
-| `./dist` | 构建产物目录，根据实际情况调整 |
+| `./dist` | 实际小程序构建产物目录 |
+| `--url-prefix "app:///"` | 与 SDK 归一化后的路径对应 |
+| `--ext js --ext map` | 上传运行时代码及对应 Source Map |
+| `--validate` | 上传前检查 map 结构与引用 |
 
-### 方式二：Webpack 插件（适用于 Taro）
+只上传 `.map` 通常不够。Sentry 需要压缩后的 JS 与对应 map 建立 artifact 关系，缺少 JS 时可能无法完成还原。
 
-```bash
-npm install @sentry/webpack-plugin --save-dev
-```
+### 使用构建插件
 
-```javascript
-// config/index.js（Taro）
-const { sentryWebpackPlugin } = require('@sentry/webpack-plugin');
+Taro / Webpack 和 Vite 项目也可使用 `@sentry/webpack-plugin` 或 `@sentry/vite-plugin`，让插件在生产构建后注入 Debug ID、上传 artifact 并删除本地 map。
 
-const config = {
-  mini: {
-    webpackChain(chain) {
-      chain.devtool('hidden-source-map');
-      chain.plugin('sentry').use(sentryWebpackPlugin, [{
-        authToken: process.env.SENTRY_AUTH_TOKEN,
-        org: 'your-org',
-        project: 'your-project',
-        release: { name: process.env.SENTRY_RELEASE },
-        urlPrefix: 'app:///',
-        sourcemaps: { filesToDeleteAfterUpload: ['**/*.map'] },
-      }]);
-    },
-  },
-};
-```
-
-### 方式三：Vite 插件
-
-```bash
-npm install @sentry/vite-plugin --save-dev
-```
-
-```javascript
-// vite.config.js
-import { sentryVitePlugin } from '@sentry/vite-plugin';
-
-export default defineConfig({
-  build: {
-    sourcemap: true,
-  },
-  plugins: [
-    sentryVitePlugin({
-      authToken: process.env.SENTRY_AUTH_TOKEN,
-      org: 'your-org',
-      project: 'your-project',
-      release: { name: process.env.SENTRY_RELEASE },
-      urlPrefix: 'app:///',
-      sourcemaps: { filesToDeleteAfterUpload: ['**/*.map'] },
-    }),
-  ],
-});
-```
-
-> **提示：** 使用构建插件时，Source Map 会在构建完成后自动上传，并可通过 `filesToDeleteAfterUpload` 自动清理 `.map` 文件，避免发布到生产环境。
-
----
+插件版本与配置项会随 Sentry 工具链更新，建议以 Sentry 官方的 [JavaScript Source Maps 文档](https://docs.sentry.io/platforms/javascript/sourcemaps/)为准。无论使用 CLI 还是插件，都必须保证上传的是最终发布的那次构建，并且 SDK 事件带有对应 release 或 Debug ID。
 
 ## 第五步：CI/CD 自动化
 
-### GitHub Actions 示例
-
 ```yaml
-name: Build & Upload SourceMaps
+name: Build and upload source maps
 
 on:
   push:
-    tags:
-      - 'v*'
+    tags: ['v*']
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-node@v4
         with:
           node-version: 20
 
-      - name: 安装依赖
-        run: npm install
-
-      - name: 构建（生成 Source Map）
+      - run: npm ci
+      - name: Build
         run: npm run build
         env:
           SENTRY_RELEASE: ${{ github.ref_name }}
 
-      - name: 上传 Source Map 到 Sentry
+      - name: Check local source maps
+        run: |
+          npx -p sentry-miniapp sentry-miniapp-sourcemap-doctor \
+            --dist ./dist \
+            --release "$SENTRY_RELEASE" \
+            --strict
+        env:
+          SENTRY_RELEASE: ${{ github.ref_name }}
+
+      - name: Upload source maps
         run: |
           npx sentry-cli releases new "$SENTRY_RELEASE"
           npx sentry-cli releases files "$SENTRY_RELEASE" upload-sourcemaps ./dist \
             --url-prefix "app:///" \
-            --ext js --ext map
+            --ext js --ext map \
+            --validate
           npx sentry-cli releases finalize "$SENTRY_RELEASE"
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: your-org
           SENTRY_PROJECT: your-project
           SENTRY_RELEASE: ${{ github.ref_name }}
-
-      - name: 清理 Source Map 文件
-        run: find ./dist -name "*.map" -delete
-
-      # 后续部署步骤...
 ```
 
-### 通用 Shell 脚本
-
-```bash
-#!/bin/bash
-# upload-sourcemaps.sh
-set -e
-
-VERSION=${SENTRY_RELEASE:-$(node -p "require('./package.json').version")}
-
-echo "上传 Source Map，release: $VERSION"
-
-npx sentry-cli releases new "$VERSION"
-npx sentry-cli releases files "$VERSION" upload-sourcemaps ./dist \
-  --url-prefix "app:///" \
-  --ext js --ext map
-npx sentry-cli releases finalize "$VERSION"
-
-echo "上传完成，清理 .map 文件..."
-find ./dist -name "*.map" -delete
-
-echo "完成"
-```
-
----
+上传成功后再清理 `.map` 并发布小程序产物。构建、Doctor、上传和发布必须使用同一份产物，避免“map 来自上一次构建”。
 
 ## 第六步：验证 Source Map 是否生效
 
-### 1. 检查已上传的文件
+### 1. 检查已上传 artifact
 
 ```bash
 npx sentry-cli releases files "my-miniapp@1.0.0" list
 ```
 
-输出应包含类似条目：
+应能看到成对的文件：
 
-```
-Name                              Size
-app:///pages/index.js             12.5 KB
-app:///pages/index.js.map         45.2 KB
-```
-
-### 2. 触发测试错误
-
-在小程序代码中故意抛出一个错误：
-
-```javascript
-// pages/index.js
-Page({
-  onLoad() {
-    throw new Error('Source Map 测试错误');
-  },
-});
+```text
+app:///pages/index.js
+app:///pages/index.js.map
 ```
 
-> Taro / uni-app 等框架：在任意页面组件的生命周期或方法里 `throw new Error('Source Map 测试错误')` 同理，不必是 `Page({ onLoad })` 这种原生写法。
-
-### 3. 在 Sentry 面板验证
-
-1. 登录 Sentry，进入对应项目
-2. 找到刚触发的错误事件
-3. 查看堆栈信息——如果显示的是**原始源码**而非压缩代码，说明 Source Map 配置成功
-4. 如果仍显示压缩代码，点击堆栈帧右侧的 **"Source Map Debug"** 按钮，Sentry 会告诉你匹配失败的原因
-
-> 📌 **先看堆栈帧的文件名**：若是 `app:///appservice.app.js`（真机合并大文件）而你只上传了分页 Source Map，再正确的 `release` / `--url-prefix` 也解不出——见 [跨端框架的两层 Source Map 串联](#跨端框架的两层-source-map-串联)。
-
----
-
-## 本地 Source Map Doctor
-
-从 `1.17.0` 起，包内提供轻量 sourcemap 静态体检命令。它不会登录 Sentry、不会上传文件、不会修改产物，只检查本地 `.js` / `.map` 是否具备上传前的基本条件，并给出可复制到 issue 的诊断结果。
-
-业务项目可直接用 npm 包里的 bin：
-
-```bash
-npx -p sentry-miniapp sentry-miniapp-sourcemap-doctor \
-  --dist ./dist \
-  --release "my-miniapp@1.0.0"
-```
-
-在 sentry-miniapp 仓库内开发时，也可以用：
-
-```bash
-npm run sourcemap:doctor -- \
-  --dist ./dist \
-  --release "my-miniapp@1.0.0"
-```
-
-Doctor 会检查：
-
-- 构建目录是否存在 `.js` 和 `.map`
-- `.js` 的 `sourceMappingURL` 是否断链；如果是 `hidden-source-map` 且同名 `.map` 存在，会作为提示而不是错误
-- `.map` 是否为合法 JSON、是否包含 `sources` / `mappings`
-- `sourcesContent` 是否完整，避免上传后只能看到路径、看不到源码内容
-- artifact 名称按 `--url-prefix` 推导后是否符合 sentry-miniapp 默认的 `app:///`
-- 是否传入 `--release`，提醒它必须与 `Sentry.init({ release })` 完全一致
-
-默认会忽略 TypeScript 声明文件的 `.d.ts.map`，只检查需要上传到 Sentry 的运行时 JS Source Map。
-
-建议在 CI 上传前跑一遍：
-
-```bash
-npm run build
-npx -p sentry-miniapp sentry-miniapp-sourcemap-doctor \
-  --dist ./dist \
-  --release "$SENTRY_RELEASE" \
-  --strict
-```
-
-需要留档或贴 issue 时加 `--json`：
-
-```bash
-npx -p sentry-miniapp sentry-miniapp-sourcemap-doctor \
-  --dist ./dist \
-  --release "$SENTRY_RELEASE" \
-  --json
-```
-
-### 微信两层 Source Map 体检
-
-如果真机堆栈文件名是 `app:///appservice.app.js`，可以先让 doctor 判断外层微信 map 与框架构建 map 是否能对齐：
-
-```bash
-npx -p sentry-miniapp sentry-miniapp-sourcemap-doctor \
-  --wechat ./wechat/appservice.app.js.map \
-  --build-maps ./dist/dev/mp-weixin \
-  --strip webpack:// \
-  --release "$SENTRY_RELEASE"
-```
-
-这一步只诊断匹配情况：`matched / unmatched / ambiguous`。如果需要真正合成 `appservice.app.js -> 源码` 的最终 map，再运行 [`scripts/merge-sourcemap.mjs`](https://github.com/lizhiyao/sentry-miniapp/blob/master/scripts/merge-sourcemap.mjs)。
-
-`merge-sourcemap` 只在离线合成时需要 `source-map`，为了不增加 SDK 运行时依赖，npx 示例显式临时安装它：
-
-```bash
-npx -p sentry-miniapp -p source-map sentry-miniapp-sourcemap-merge \
-  --wechat ./wechat/appservice.app.js.map \
-  --build-maps ./dist/dev/mp-weixin \
-  --out ./merged/appservice.app.js.map \
-  --strip webpack://
-```
-
-`doctor` 负责判断，`merge-sourcemap` 负责生成合成 map。两者复用同一套 source 名称归一化和构建 map 匹配逻辑，避免排查结果和实际合成行为不一致。
-
----
-
-## 平台特殊说明
-
-### 微信小程序
-
-**必须关闭微信开发者工具自带的编译选项：**
-
-- **ES6 转 ES5** → 关闭
-- **代码压缩** → 关闭
-- **样式补全** → 关闭（可选）
-
-这些工作应交给 Webpack/Vite 等构建工具处理，否则会导致行列号错位，Source Map 无法正确匹配。
-
-**路径归一化：** SDK 自动剥离 `appservice/`、`app-service/`、`WAService/` 前缀。
-
-#### ⚠️ 跨端框架（Taro / uni-app）：真机栈是合并的 `appservice.app.js`
-
-用 Taro / uni-app 等框架时，真机错误栈的文件名通常是合并后的 `app:///appservice.app.js`，分页 Source Map 解不出，需要单独处理（含两层 map 的离线合成脚本）——详见独立专节 [跨端框架的两层 Source Map 串联](#跨端框架的两层-source-map-串联)。
-
-### 支付宝小程序
-
-**路径归一化：** SDK 自动剥离 `https://appx/` 等 HTTP 协议前缀。
-
-### 字节跳动小程序 / 抖音小游戏
-
-**路径归一化：** SDK 自动剥离 `tt://` 协议前缀；没有协议的 `assets/...`、`main/index.js` 会直接补成 `app:///assets/...`、`app:///main/index.js`。
-
-抖音小游戏接入 Cocos Creator 时，错误栈可能出现 `chunks:///_virtual/foo.js` 或 `chunks:///assets/foo.js`。SDK 会保留 `chunks/` 命名空间，分别归一化为 `app:///chunks/_virtual/foo.js`、`app:///chunks/assets/foo.js`，避免和普通 `assets/...` 产物混在一起。上传 Source Map 时也要确保 artifact 路径包含同样的 `chunks/...` 相对路径。
-
-### 百度小程序
-
-**路径归一化：** SDK 自动剥离 `swan://` 协议前缀。
-
-### 其他平台
-
-SDK 会自动剥离所有 `协议://` 格式的前缀，因此 QQ、钉钉、快手等平台的虚拟路径也能被正确处理。
-
----
-
-## Debug ID 与自定义 stackParser
-
-从 `1.16.0` 起，SDK 会在事件进入 `@sentry/core` 准备流程前，同步当前运行时可见全局对象上的 `_sentryDebugIds` / `_debugIds`。这用于兼容微信小游戏等宿主里 Debug ID map 可能被注入到 `window` / `global` / `self`，而 core 默认只读取 `globalThis` 的情况。
-
-大多数项目无需配置：内置 `miniappStackParser` 已覆盖常见 V8 / Safari / JavaScriptCore 堆栈格式，以及小程序 / 小游戏常见路径形态。
-
-只有私有引擎、特殊打包器或非标准堆栈格式解析失败时，才需要传入自定义 `stackParser`：
+### 2. 在真机触发新错误
 
 ```js
-import * as Sentry from 'sentry-miniapp';
-
-Sentry.init({
-  dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0',
-  release: 'my-miniapp@1.0.0',
-  stackParser: (stack, skipFirstLines, framesToPop) => {
-    // 返回 Sentry StackFrame[]，filename 需能对应真实产物文件名
-    return Sentry.miniappStackParser(stack, skipFirstLines, framesToPop);
-  },
-});
+Sentry.captureException(new Error('Source Map verification'));
 ```
 
-`stackParser` 不替代 Source Map 上传，也不放宽 `release` 匹配要求；它只影响 SDK / core 如何把运行时堆栈解析成帧，再和上传的 map 或 Debug ID 关联。
+Source Map 上传不会回溯处理上传前已经收到的旧事件，因此应在上传完成后产生一个新事件。
 
----
+### 3. 检查事件
 
-## 跨端框架的两层 Source Map 串联
+在 Sentry 事件详情中确认：
 
-如果你用 Taro / uni-app 等框架，且在**真机**上发现 Sentry 里堆栈的文件名是 `app:///appservice.app.js`（行列号动辄上万 / 几十万），而你上传的是构建产物里的**分页 Source Map**（如 `app:///pages/index/index.js.map`），那么**无论 `release`、`--url-prefix` 配置得多正确都解析不出来**。原因：
+1. event release 与上传 release 一致；
+2. 堆栈 `filename` 与已上传 artifact 名称一致；
+3. 堆栈显示项目源码，而不是压缩后的构建代码；
+4. Source Map Debug 没有提示缺文件、release 不匹配或 sourcesContent 缺失。
 
-- **真机跑的是合并后的单文件。** 微信运行时会把逻辑层所有 JS 合并成一个 `appservice.app.js`（部分版本叫 `app-service.js`）来执行，错误栈的行列号是**这个合并大文件**里的位置。
-- **这个文件你的构建根本不产、也没上传。** Taro `taro build --type weapp` 的产物是 `app.js` / `pages/*/index.js` / `vendors.js` 等分页文件，`appservice.app.js` 是微信侧合并出来的——Sentry 里没有这个 artifact，自然匹配不到。这不是行号偏移，而是**目标文件压根没传**。
-- **产物默认是压缩混淆的。** Taro 生产构建默认用 Terser 压缩（函数名变成 `l` / `ge` / `nn` 这种）。这与微信开发者工具里的「代码压缩」开关**无关**，关那个开关不会取消 Taro 自己的压缩。
+如果真机 filename 是 `app:///appservice.app.js`，普通分页 map 无法直接匹配，应按进阶指南处理微信两层 Source Map。
 
-> **为什么会有「两层」map：** 框架构建（webpack / vite）先把源码压成「编译产物 JS」（产出第一层 map A：编译产物 JS → 源码）；微信上传时再 es6→es5 + 压缩，并合并成 `appservice.app.js`（产出第二层 map B：`appservice.app.js` → 编译产物 JS）。两层叠加，单独任一层的 map 都到不了源码——只传 A 对不上合并文件，只传 B 又停在编译产物 JS。
+<span id="本地-source-map-doctor"></span>
+<span id="debug-id-与自定义-stackparser"></span>
+<span id="跨端框架的两层-source-map-串联"></span>
 
-**怎么办**（两种，按需要的深度选）：
+## 进阶场景与排障
 
-1. **快速定位到「分页编译后 JS」**
-   - 从微信 **「We 分析 → 性能 / JS 报错 → 下载线上 Source Map」** 拿到 `appservice.app.js` 对应的 `.map`（注意：只有**体验版 / 线上版**有，`miniprogram-ci` 预览的开发版拿不到；版本要与线上一致）；
-   - 以 **`app:///appservice.app.js`** 的名字上传到 Sentry（`--url-prefix "app:///"` 不变）；
-   - 想让解析结果可读，再关闭框架的 JS 压缩（参考 Taro / uni-app 文档对应版本的压缩 / `terser` 配置）。
-   - 结果：能定位到**分页文件 + 行列**，但停在框架编译后的 JS，**不是源码（`.vue` / `.tsx`）**。Sentry 一次只应用一层 Source Map，不会自动再串到框架的分页 map。
+以下内容已集中到 [Source Map 进阶与排障](/guide/sourcemap-advanced)：
 
-2. **一路解析到源码（`.vue` / `.tsx`）**
-   把「微信合并 map（`appservice.app.js` → 编译产物 JS）」与「框架构建 map（编译产物 JS → 源码）」**离线合成一份** `appservice.app.js` → 源码 的 map，再以 `app:///appservice.app.js` 上传。能到源码，但需要自己合成——WeChat / Sentry / uni-app / Taro 都没有一键方案。
-
-   仓库提供了一个 best-effort 合成脚本 [`scripts/merge-sourcemap.mjs`](https://github.com/lizhiyao/sentry-miniapp/blob/master/scripts/merge-sourcemap.mjs)，用 `source-map` 的 `applySourceMap` 把两份 map 串起来：
-
-   ```bash
-   # 1) 装依赖（只在合成时用，不是 SDK 运行时依赖）
-   npm i -D source-map
-
-   # 2) 准备两份 map：
-   #    - Map B（外层）：微信「We 分析 → 性能 / JS 报错 → 下载线上 Source Map」拿 appservice.app.js 的 .map
-   #    - Map A（内层）：框架构建里开 sourcemap（uni-app 对 mp-weixin 默认常关；
-   #      vite 设 build.sourcemap、webpack 设 devtool: 'source-map'），得到一批编译产物 JS 的 .map
-
-   # 3) 合成
-   node scripts/merge-sourcemap.mjs \
-     --wechat   ./wechat/appservice.app.js.map \
-     --build-maps ./dist/dev/mp-weixin \
-     --out      ./merged/appservice.app.js.map
-
-   # 4) 把 ./merged/appservice.app.js.map 以 app:///appservice.app.js 的名字上传 Sentry
-   ```
-
-   合并算法是稳的，**难点在两份 map 的文件名能否对齐**（`B.sources` 里的名字 ↔ 构建 map 描述的文件名）。不同框架 / 打包器 / 版本命名各异，对不齐时脚本会逐条列出 `B.sources`，照提示加 `--strip <前缀>`（如 `--strip webpack://`）或对齐产物文件名即可。脚本会优先按相对路径精确匹配（如 `pages/foo/index.js`），最后才用文件名兜底；如果多个页面都叫 `index.js`，兜底匹配会被判为歧义并跳过，避免静默套错 map。合成后精度取「两份 map 的较小值」，定位到行没问题。这是 best-effort 起点，其它框架的匹配策略欢迎 PR。
-
-> 这不是 SDK 的问题：`sentry-miniapp` 的堆栈解析与 `RewriteFrames` 已正确把 `appservice.app.js` 归一为 `app:///appservice.app.js`；能否解析取决于你上传的 map 是否对应这个**合并后的文件**。相关讨论见 [issue #162](https://github.com/lizhiyao/sentry-miniapp/issues/162) 与 [#173](https://github.com/lizhiyao/sentry-miniapp/issues/173)。
-
----
-
-## 安全注意事项
-
-1. **不要将 `.map` 文件发布到生产环境**——Source Map 包含原始源码，泄露可能带来安全风险。上传到 Sentry 后应立即删除本地 `.map` 文件。
-2. **不要将 Auth Token 提交到代码仓库**——使用环境变量或将 `.sentryclirc` 添加到 `.gitignore`。
-3. **使用 `hidden-source-map`**——避免在产物中生成 `sourceMappingURL` 注释，防止浏览器或调试工具直接加载 `.map` 文件。
-4. **离线合成的 map 同样含源码**——`scripts/merge-sourcemap.mjs` 产出的合成 `.map` 内嵌 `sourcesContent`（即原始源码），只用于上传 Sentry，**别打进小程序包、别发布到任何公开位置**，用完即删。
-
----
-
-## 常见问题排查
-
-### Q: 上传成功但 Sentry 仍显示压缩代码
-
-**检查项：**
-1. `release` 名称是否一致？SDK 中的 `release` 必须与 `sentry-cli releases new` 的 release 名称完全匹配
-2. `--url-prefix` 是否为 `app:///`？
-3. 是否禁用了微信开发者工具的 "ES6 转 ES5" 和 "代码压缩"？
-4. 在 Sentry 事件详情中，点击 "Source Map Debug" 查看具体匹配失败原因
-
-### Q: 堆栈中的文件路径与上传的文件不匹配
-
-**排查方法：**
-1. 在 Sentry 事件的原始 JSON 中查看实际的 `filename` 字段（应以 `app:///` 开头）
-2. 用 `sentry-cli releases files <release> list` 查看已上传文件的名称
-3. 确认两者路径完全一致
-
-### Q: Source Map 文件太大，上传超时
-
-**解决方案：**
-- 增加超时时间：在 `.sentryclirc` 中添加 `[http]` 的 `timeout` 配置
-- 拆分上传：按目录分批上传
-- 检查是否有不必要的大文件被包含
-
-### Q: CI 中上传失败
-
-**检查项：**
-1. Auth Token 是否有效且具备 `project:releases` 权限
-2. `SENTRY_ORG` 和 `SENTRY_PROJECT` 是否正确
-3. 网络是否能访问 Sentry 服务器（自托管需检查内网连通性）
-
----
-
-## 完整配置示例
-
-以下是一个 **Taro + Webpack** 项目的完整 Source Map 配置示例：
-
-**1. SDK 初始化（`app.js`）：**
-
-```javascript
-import * as Sentry from 'sentry-miniapp';
-
-Sentry.init({
-  dsn: 'https://examplePublicKey@o0.ingest.sentry.io/0',
-  release: SENTRY_RELEASE, // 构建时注入
-  environment: 'production',
-  // enableSourceMap 默认为 true
-});
-```
-
-**2. Taro 构建配置（`config/index.js`）：**
-
-```javascript
-const config = {
-  defineConstants: {
-    SENTRY_RELEASE: JSON.stringify(process.env.SENTRY_RELEASE || `my-miniapp@${require('./package.json').version}`),
-  },
-  mini: {
-    webpackChain(chain) {
-      chain.devtool('hidden-source-map');
-    },
-  },
-};
-```
-
-**3. `.sentryclirc`（本地开发）：**
-
-```ini
-[auth]
-token=sntrys_xxx
-
-[defaults]
-org=my-org
-project=my-miniapp
-```
-
-**4. `.gitignore`：**
-
-```
-.sentryclirc
-```
-
-**5. 上传脚本（`package.json`）：**
-
-```json
-{
-  "scripts": {
-    "upload:sourcemaps": "sentry-cli releases new $npm_package_version && sentry-cli releases files $npm_package_version upload-sourcemaps ./dist --url-prefix 'app:///' --ext js --ext map && sentry-cli releases finalize $npm_package_version"
-  }
-}
-```
-
-**6. 构建并上传：**
-
-```bash
-SENTRY_RELEASE="my-miniapp@1.0.0" npm run build
-SENTRY_RELEASE="my-miniapp@1.0.0" npm run upload:sourcemaps
-```
+- 用 `sentry-miniapp-sourcemap-doctor` 在上传前检查本地产物；
+- 微信真机 `appservice.app.js` 与 Taro / uni-app 两层 map 合成；
+- Cocos、小游戏虚拟路径、Debug ID 与自定义 `stackParser`；
+- 上传成功但仍无法还原时的逐项排查。

--- a/website/guide/taro.md
+++ b/website/guide/taro.md
@@ -28,14 +28,6 @@ Sentry.init({
   dsn: 'https://your-dsn@o0.ingest.sentry.io/0',
   release: 'my-taro-app@1.0.0', // 与上传 Source Map 时的 release 完全一致
   environment: 'production',
-
-  platform: 'wechat',
-  sampleRate: 1.0, // error 采样率
-  tracesSampleRate: 1.0, // 性能采样率；开启后 API 请求会作为 http.client span 上报
-
-  // 网络面包屑默认开启（自动包裹平台请求 API；Taro.request 最终也走它，无需额外配置）。
-  // 开 traceNetworkBody 连请求 / 响应体也记录（内置脱敏）。
-  traceNetworkBody: false,
 });
 
 Sentry.setTag('app.framework', 'taro-react');
@@ -43,7 +35,7 @@ Sentry.setTag('app.framework', 'taro-react');
 export default Sentry;
 ```
 
-默认初始化路径已含：自动异常捕获、性能监控、Source Map 路径归一化、网络面包屑、Session 与网络状态监控。**通常无需手动传 `integrations`**——只有要替换核心默认集成时才传；Source Map / 网络 / Session 等能力仍由各自顶层开关控制。
+平台会自动识别。默认初始化路径已含自动异常捕获、Source Map 路径归一化、网络面包屑、Session 与网络状态监控，通常无需手动传 `integrations`。
 
 ## 3. 尽早初始化
 
@@ -121,8 +113,9 @@ if (process.env.TARO_ENV === 'h5') {
 ## 6. 其它
 
 - **网络**：`Taro.request` 最终走对应小程序端被包裹的全局请求 API，请求会自动记成 `xhr` 面包屑、随错误事件上报，无需额外配置。
-- **Source Map**：Taro 经过编译，错误栈是编译后代码，需上传 Source Map 才能还原。配置见 [Source Map 配置](/guide/sourcemap)。
+- **性能与追踪**：需要独立性能数据时再设置采样率，见[性能与链路追踪](/guide/performance-and-tracing)。
+- **Source Map**：Taro 经过编译，错误栈是编译后代码，需上传 Source Map 才能还原。配置见 [Source Map 上线指南](/guide/sourcemap)。
 
 ## 下一步
 
-- [示例工程](/guide/examples) · [常见问题](/guide/faq) · [支持平台与能力](/guide/platforms)
+- [示例工程](/guide/examples) · [异常、日志与上下文](/guide/errors-and-context) · [常见问题](/guide/faq)

--- a/website/guide/uniapp.md
+++ b/website/guide/uniapp.md
@@ -23,13 +23,6 @@ Sentry.init({
   dsn: 'https://your-dsn@o0.ingest.sentry.io/0',
   release: 'my-uniapp@1.0.0', // 与上传 Source Map 时的 release 完全一致
   environment: 'production',
-
-  platform: 'wechat',
-  sampleRate: 1.0, // error 采样率
-  tracesSampleRate: 1.0, // 性能采样率；开启后 API 请求会作为 http.client span 上报
-
-  // 网络面包屑默认开启（自动包裹平台请求 API；uni.request 最终也走它，无需额外配置）。
-  traceNetworkBody: false,
 });
 
 Sentry.setTag('app.framework', 'uni-app');
@@ -102,9 +95,10 @@ export default Sentry;
 ## 5. 其它
 
 - **网络**：`uni.request` 最终走对应小程序端被包裹的全局请求 API，请求会自动记成 `xhr` 面包屑、随错误事件上报，无需额外配置。
-- **Source Map**：uni-app 经过编译，错误栈是编译后代码，需上传 Source Map 才能还原。配置见 [Source Map 配置](/guide/sourcemap)。
+- **性能与追踪**：需要独立性能数据时再设置采样率，见[性能与链路追踪](/guide/performance-and-tracing)。
+- **Source Map**：uni-app 经过编译，错误栈是编译后代码，需上传 Source Map 才能还原。配置见 [Source Map 上线指南](/guide/sourcemap)。
 - **验证**：`addBreadcrumb` 不会单独上报，需主动 `Sentry.captureException(new Error('test'))` 才能在 Issues 看到。详见 [快速接入](/guide/getting-started)。
 
 ## 下一步
 
-- [示例工程](/guide/examples) · [常见问题](/guide/faq) · [支持平台与能力](/guide/platforms)
+- [示例工程](/guide/examples) · [异常、日志与上下文](/guide/errors-and-context) · [常见问题](/guide/faq)

--- a/website/guide/when-to-use.md
+++ b/website/guide/when-to-use.md
@@ -32,11 +32,12 @@
 ## 为什么可以信任它
 
 - **已被收录进 [Sentry 官方文档](https://docs.sentry.io/platforms/#sdks-supported-by-our-community)** 的 community-supported SDK 列表。
-- 覆盖 **7 大平台 + Taro / uni-app**，100% 测试覆盖率，持续活跃维护。
+- 覆盖 **7 大平台 + Taro / uni-app**，通过自动化测试和 GitHub Actions 持续验证。
 - 有真实社区在用（微信交流群、GitHub fork / star）。
 
 ## 判断完了？
 
 - 适合 → 去 [快速接入](/guide/getting-started)（5 分钟跑通）。
-- 想先懂原理 → [工作原理](/guide/how-it-works)。
 - 用 Taro / uni-app → [Taro 接入](/guide/taro) / [uni-app 接入](/guide/uniapp)。
+- 做微信 / 抖音小游戏 → [小游戏接入与性能](/guide/minigame)。
+- 想先确认边界或原理 → [支持范围](/guide/platforms) / [工作原理](/guide/how-it-works)。

--- a/website/index.md
+++ b/website/index.md
@@ -3,8 +3,8 @@ layout: home
 
 hero:
   name: sentry-miniapp
-  text: 跨端小程序 Sentry SDK
-  tagline: 微信 / 支付宝 / 字节跳动 / 钉钉 / QQ / 百度 / 快手 + Taro / uni-app —— 异常、性能与网络监控开箱即用
+  text: 小程序监控 SDK
+  tagline: 一个基于 @sentry/core 构建的小程序监控 SDK，覆盖异常、性能、日志、离线缓存与链路追踪；支持微信、支付宝、字节跳动、百度、QQ、钉钉、快手等小程序，以及微信 / 抖音小游戏，并兼容 Taro / uni-app。
   image:
     src: /logo.png
     alt: sentry-miniapp
@@ -13,36 +13,27 @@ hero:
       text: 开始接入
       link: /guide/getting-started
     - theme: alt
-      text: 生产配置
-      link: /guide/configuration
+      text: 先确认是否适用
+      link: /guide/when-to-use
     - theme: alt
-      text: Source Map
-      link: /guide/sourcemap
+      text: 查看支持范围
+      link: /guide/platforms
 
 features:
-  - icon: 🌐
-    title: 全平台覆盖
-    details: 微信、支付宝、字节跳动、钉钉、QQ、百度、快手七大平台，及 Taro / uni-app 跨端框架，统一 API，自动适配平台差异。
   - icon: 🛡️
-    title: 自动异常捕获
-    details: 自动劫持平台全局错误监听，未处理异常 / Promise rejection 开箱即采，配合 Source Map 还原源码堆栈。
+    title: 发现并还原线上问题
+    details: 自动捕获未处理异常、Promise rejection 和内存告警，结合用户操作、页面与网络上下文定位问题。
   - icon: 📊
-    title: 性能、日志与追踪
-    details: 冷启动、页面渲染、网络请求耗时；支持 Sentry Logs，并可将请求作为 http.client span 串联前后端调用链。
-  - icon: 🍞
-    title: 丰富上下文面包屑
-    details: 设备信息、用户点击 / 触摸、网络请求、页面生命周期，出错时还原用户操作现场。
+    title: 看懂性能与请求链路
+    details: 采集启动、渲染、资源和请求耗时，可通过 http.client span 与追踪头串联服务端调用链。
   - icon: 📡
-    title: 可靠上报与合规门禁
-    details: 断网 / 发送失败自动缓存，恢复后静默重试；隐私合规场景可在用户同意前只采集入缓冲、不发 Sentry 网络。
-  - icon: 🎮
-    title: 小游戏支持
-    details: 微信 / 抖音小游戏冷启动首帧耗时、帧率 / 卡顿（FPS / jank）监控，性能独立上报进 Performance 页。
+    title: 面对弱网与隐私要求
+    details: 发送失败后写入本地缓存并自动重试；需要用户授权时，可在同意前采集但不发送网络请求。
 ---
 
-<div class="sm-trust-strip" aria-label="项目可信度">
+<div class="sm-trust-strip" aria-label="项目支持范围与维护状态">
   <a href="https://docs.sentry.io/platforms/#sdks-supported-by-our-community" target="_blank" rel="noreferrer">
-    <strong>官方 Community SDK</strong>
+    <strong>Sentry Community SDK</strong>
     <span>已收录进 Sentry 官方文档索引</span>
   </a>
   <span>
@@ -50,108 +41,57 @@ features:
     <span>微信 / 支付宝 / 字节 / 钉钉 / QQ / 百度 / 快手</span>
   </span>
   <span>
-    <strong>Taro / uni-app</strong>
-    <span>小程序端直接接入，H5 端使用 @sentry/browser</span>
+    <strong>微信 / 抖音小游戏</strong>
+    <span>异常、冷启动、帧率与卡顿监控</span>
   </span>
   <span>
-    <strong>100% 测试覆盖</strong>
-    <span>GitHub Actions 持续验证 Node 20 / 22</span>
+    <strong>持续自动化验证</strong>
+    <span>GitHub Actions 覆盖多 Node.js 版本</span>
   </span>
 </div>
 
 <section class="sm-home-section">
   <div class="sm-section-heading">
-    <p class="sm-eyebrow">近期能力</p>
-    <h2>上线前最常查的四件事</h2>
-    <p>把合规、日志、追踪和 Source Map 的入口放到首页，不用在长文档里翻。</p>
-  </div>
-  <div class="sm-card-grid">
-    <a class="sm-card" href="/guide/configuration#隐私合规-同意后上报">
-      <span class="sm-kicker">合规</span>
-      <h3>隐私同意门禁</h3>
-      <p>用户同意前只写本地缓冲，不发 Sentry 网络；同意后补发并恢复上报。</p>
-      <span class="sm-link">查看配置</span>
-    </a>
-    <a class="sm-card" href="/guide/configuration#logs">
-      <span class="sm-kicker">日志</span>
-      <h3>Sentry Logs</h3>
-      <p>把业务日志作为独立 log 查询、聚合和告警，避免只依赖错误事件上下文。</p>
-      <span class="sm-link">查看配置</span>
-    </a>
-    <a class="sm-card" data-tone="trace" href="/guide/configuration#分布式追踪">
-      <span class="sm-kicker">追踪</span>
-      <h3>W3C traceparent</h3>
-      <p>后端接 OpenTelemetry 或 W3C Trace Context 时，可串联小程序到服务端调用链。</p>
-      <span class="sm-link">查看配置</span>
-    </a>
-    <a class="sm-card" data-tone="source" href="/guide/sourcemap#debug-id-与自定义-stackparser">
-      <span class="sm-kicker">还原</span>
-      <h3>Debug ID / stackParser</h3>
-      <p>适配小游戏、Cocos、私有引擎或特殊堆栈格式，提升线上源码还原稳定性。</p>
-      <span class="sm-link">查看指南</span>
-    </a>
-  </div>
-</section>
-
-<section class="sm-home-section">
-  <div class="sm-section-heading">
-    <p class="sm-eyebrow">接入路径</p>
-    <h2>按你的工程类型进入</h2>
-    <p>原生、Taro、uni-app 和选型判断分开走，减少接入时来回切文档。</p>
+    <p class="sm-eyebrow">选择接入方式</p>
+    <h2>从你的工程类型开始</h2>
+    <p>先进入对应框架的接入页，再完成初始化和测试事件验证。框架组件错误、入口位置和条件编译会在各自指南中说明。</p>
   </div>
   <div class="sm-route-grid">
     <a class="sm-card" href="/guide/getting-started">
       <span class="sm-kicker">Native</span>
       <h3>原生小程序</h3>
-      <p>微信、支付宝、字节跳动、钉钉、QQ、百度、快手等平台的基础接入。</p>
+      <p>微信、支付宝、字节跳动、钉钉、QQ、百度和快手原生工程。</p>
       <span class="sm-link">快速接入</span>
     </a>
     <a class="sm-card" href="/guide/taro">
       <span class="sm-kicker">React</span>
       <h3>Taro</h3>
-      <p>覆盖入口初始化、组件错误边界、请求链路与平台差异处理。</p>
-      <span class="sm-link">查看指南</span>
+      <p>处理入口初始化、React 错误边界以及小程序 / H5 分端接入。</p>
+      <span class="sm-link">查看 Taro 指南</span>
     </a>
     <a class="sm-card" href="/guide/uniapp">
       <span class="sm-kicker">Vue</span>
       <h3>uni-app</h3>
-      <p>说明 main.js、Vue errorHandler、条件编译和 H5 端 SDK 分流。</p>
-      <span class="sm-link">查看指南</span>
+      <p>处理 main.js 初始化、Vue errorHandler 与条件编译。</p>
+      <span class="sm-link">查看 uni-app 指南</span>
     </a>
-    <a class="sm-card" data-tone="source" href="/guide/when-to-use">
-      <span class="sm-kicker">Decision</span>
-      <h3>选型与限制</h3>
-      <p>确认当前端形态是否适合 sentry-miniapp，以及哪些场景应使用官方 Web SDK。</p>
-      <span class="sm-link">先判断</span>
+    <a class="sm-card" data-tone="source" href="/guide/minigame">
+      <span class="sm-kicker">Game</span>
+      <h3>微信 / 抖音小游戏</h3>
+      <p>接入异常监控，并采集冷启动首帧、FPS 和卡顿汇总。</p>
+      <span class="sm-link">查看小游戏指南</span>
     </a>
   </div>
 </section>
 
-<section class="sm-home-section sm-check-panel">
-  <div>
-    <p class="sm-eyebrow">发布检查</p>
-    <h2>生产接入前别漏这几项</h2>
-    <p>这些问题通常不是 SDK 代码错误，却会直接影响是否能在 Sentry 看到事件、日志和源码堆栈。</p>
-  </div>
-  <ol class="sm-check-list">
-    <li><span>1</span><p><code>Sentry.init</code> 放在入口文件最顶部、<code>App()</code> 之前。</p></li>
-    <li><span>2</span><p>小程序后台把 Sentry 上报域名加入 <code>request</code> 合法域名。</p></li>
-    <li><span>3</span><p><code>release</code> 与 Source Map 上传时的 release 完全一致。</p></li>
-    <li><span>4</span><p>Taro / uni-app 的组件错误按框架指南接入错误边界或 <code>errorHandler</code>。</p></li>
-    <li><span>5</span><p>H5 端使用官方 <code>@sentry/browser</code>，小程序端使用 <code>sentry-miniapp</code>。</p></li>
-  </ol>
-</section>
+## 安装并验证
 
-## 安装
+第一次接入只做两件事：尽早初始化，然后主动发送一个测试错误。确认 Sentry Issues 中能看到事件后，再继续配置生产环境能力。
 
 ```bash
 npm install sentry-miniapp --save
 # 或 yarn add sentry-miniapp
 ```
-
-<p class="sm-install-note">首次接入建议先跑通异常上报，再补 release、Source Map、Logs 与 Trace 配置。</p>
-
-## 一分钟接入
 
 ```js
 import * as Sentry from 'sentry-miniapp';
@@ -162,8 +102,55 @@ Sentry.init({
   environment: 'production',
 });
 
-// 之后未处理异常会自动上报；也可手动：
-Sentry.captureException(new Error('test'));
+Sentry.captureException(new Error('sentry-miniapp test'));
 ```
 
-> 自托管 / 真机调试时，把 Sentry 域名加入小程序后台「合法域名」。详见 [快速接入](/guide/getting-started)。
+> 原生小程序应在入口文件顶部、`App()` 之前初始化。真机没有事件时，先检查 Sentry 上报域名是否已加入小程序后台的 `request` 合法域名。完整步骤见[快速接入](/guide/getting-started)。
+
+<section class="sm-home-section sm-check-panel">
+  <div>
+    <p class="sm-eyebrow">生产上线</p>
+    <h2>基础上报打通后，再完成四项检查</h2>
+    <p>把生产配置放在验证之后，可以更快区分“接入链路没通”和“高级能力配置不完整”。</p>
+  </div>
+  <ol class="sm-check-list">
+    <li><span>1</span><p>设置稳定的 <code>release</code> 与 <code>environment</code>，并规划错误和性能采样率。</p></li>
+    <li><span>2</span><p>上传与当前构建匹配的 <code>.js</code> 和 <code>.map</code>，在真机验证源码堆栈。</p></li>
+    <li><span>3</span><p>确认框架组件错误、小游戏性能或链路追踪等项目实际需要的能力已经启用。</p></li>
+    <li><span>4</span><p>需要隐私授权时开启同意门禁，并验证同意前不发网络、同意后能够补发。</p></li>
+  </ol>
+</section>
+
+<section class="sm-home-section">
+  <div class="sm-section-heading">
+    <p class="sm-eyebrow">继续配置</p>
+    <h2>按当前任务进入文档</h2>
+    <p>能力指南讲使用场景与验证方法；API 和配置页负责查参数；排障页从现象出发定位问题。</p>
+  </div>
+  <div class="sm-card-grid">
+    <a class="sm-card" href="/guide/errors-and-context">
+      <span class="sm-kicker">能力</span>
+      <h3>异常、日志与上下文</h3>
+      <p>确认自动捕获范围，并补充用户、标签、面包屑和独立 Logs。</p>
+      <span class="sm-link">查看能力指南</span>
+    </a>
+    <a class="sm-card" data-tone="trace" href="/guide/performance-and-tracing">
+      <span class="sm-kicker">性能</span>
+      <h3>性能与链路追踪</h3>
+      <p>配置采样、请求 span、追踪目标和 W3C traceparent。</p>
+      <span class="sm-link">配置追踪</span>
+    </a>
+    <a class="sm-card" data-tone="source" href="/guide/sourcemap">
+      <span class="sm-kicker">上线</span>
+      <h3>Source Map</h3>
+      <p>让 Sentry 把压缩后的线上堆栈还原到原始源码位置。</p>
+      <span class="sm-link">完成上传</span>
+    </a>
+    <a class="sm-card" href="/guide/faq">
+      <span class="sm-kicker">排障</span>
+      <h3>没有数据或堆栈不对</h3>
+      <p>按 DSN、合法域名、初始化时机、采样和诊断信息逐项确认。</p>
+      <span class="sm-link">开始排查</span>
+    </a>
+  </div>
+</section>


### PR DESCRIPTION
## 改动说明

- 按“开始使用、能力指南、生产上线、参考与排障”重构官网导航与侧栏，首页改为先选工程类型、再验证、最后完成生产配置
- 新增常用 API、异常与上下文、性能与链路追踪、可靠上报与隐私同意、小游戏接入五类任务型指南
- 将 700 多行 Source Map 长页拆为上线主线和进阶排障，保留旧锚点兼容入口，并明确同时上传同次构建的 JS 与 map
- 精简快速接入、FAQ、平台页和框架指南中的重复内容，同步 README 文档导航与术语

## 验证

- `yarn docs:build`
- 全站 19 个页面内部路径与锚点校验通过
- `yarn lint`
- `yarn typecheck`
- `yarn test --runInBand`（43 个测试套件，566 个测试）
- 本地检查首页、常用 API、Source Map 页面与桌面侧栏呈现
