### PR TITLE
chore(release): 发布 1.17.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-miniapp",
-  "version": "1.17.3",
+  "version": "1.17.4",
   "description": "Sentry SDK for Mini Programs (WeChat, Alipay, ByteDance, Baidu, QQ, DingTalk, Kuaishou) & Taro / uni-app | 小程序监控 SDK，支持异常监控、性能监控、错误收集",
   "repository": {
     "type": "git",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
 // 版本号应该与 package.json 中的版本保持同步
-export const SDK_VERSION = '1.17.3';
+export const SDK_VERSION = '1.17.4';
 export const SDK_NAME = 'sentry.javascript.miniapp';


### PR DESCRIPTION
## 版本

发布 `sentry-miniapp@1.17.4`。

## 本次内容

- 修复性能集成误调用微信宿主 `reportPerformance`，消除 `SDK 暂不支持此API` 控制台报错，同时保留 Sentry 性能数据上报
- 重构官网文档信息架构，按用户任务组织接入、配置、平台能力与排障内容
- 解耦 npm 标准构建与微信示例产物，移除仓库中的生成文件
- 新增微信示例 bundle 独立加载检查及 `dev:miniapp` 工作流
- GitHub Release 开始附带可直接下载的 UMD 文件与 Source Map

## 验证

- `yarn run lint`
- `yarn run typecheck`
- `yarn run test --runInBand`（43 suites / 566 tests）
- `yarn run build`
- `yarn run build:miniapp`

## 兼容性

无 breaking change。SDK 对外 API 保持不变。