### PR TITLE
fix(errors): 避免微信小游戏异常重复上报

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -46,6 +46,10 @@ export function wrap(
     try {
       return fn.apply(this, args);
     } catch (ex) {
+      // 平台全局 onError 会在异常重新抛出后再次收到同一个错误。短暂屏蔽该回调，
+      // 与 Sentry Browser 的 TryCatch / GlobalHandlers 去重策略保持一致。
+      ignoreNextOnErrorCall();
+
       // 用 withScope 临时 fork 一个 scope：事件处理器只作用于本次 captureException，用完即弃。
       // 绝不能用 getCurrentScope().addEventProcessor——那会把处理器永久挂在当前 scope 上，给之后
       // 每个 unrelated 事件都盖上本次的 mechanism/arguments（尤其把未处理错误误标成 handled:true，

--- a/src/integrations/globalhandlers.ts
+++ b/src/integrations/globalhandlers.ts
@@ -2,6 +2,19 @@ import { captureException, getCurrentScope } from '@sentry/core';
 import type { Integration, IntegrationFn } from '@sentry/core';
 
 import { sdk } from '../crossPlatform';
+import { shouldIgnoreOnError } from '../helpers';
+
+function errorFromPlatformValue(value: string | Error): Error {
+  if (typeof value !== 'string') {
+    return value;
+  }
+
+  const error = new Error(value);
+  // 小程序 / 小游戏 onError 只给字符串时，堆栈也包含在该字符串中。覆盖本地构造
+  // Error 产生的无关 stack，让 MiniappClient 使用用户配置的 stackParser 解析宿主帧。
+  error.stack = value;
+  return error;
+}
 
 /** JSDoc */
 interface GlobalHandlersIntegrations {
@@ -82,7 +95,11 @@ export class GlobalHandlers implements Integration {
 
     if (sdk().onError) {
       this._errorHandler = (err: string | Error) => {
-        const error = typeof err === 'string' ? new Error(err) : err;
+        if (shouldIgnoreOnError()) {
+          return;
+        }
+
+        const error = errorFromPlatformValue(err);
         captureException(error, {
           mechanism: {
             type: 'onerror',

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -13,6 +13,7 @@ export { getDiagnostics } from './diagnostics';
 
 import { MiniappClient } from './client';
 import { appName, isMiniappEnvironment, isMinigame } from './crossPlatform';
+import { ignoreNextOnErrorCall } from './helpers';
 import {
   GlobalHandlers,
   TryCatch,
@@ -215,6 +216,7 @@ export function wrap<T extends (...args: any[]) => any>(fn: T): T {
       try {
         return fn.apply(this, args);
       } catch (error) {
+        ignoreNextOnErrorCall();
         getCurrentScope().captureException(error);
         throw error;
       }

--- a/test/globalhandlers.realcore.test.ts
+++ b/test/globalhandlers.realcore.test.ts
@@ -81,4 +81,42 @@ describe('GlobalHandlers（真 @sentry/core 集成）', () => {
     expect(val.value).toContain('boom from platform');
     expect(val.mechanism).toEqual({ type: 'onerror', handled: false });
   });
+
+  it('wx.onError 字符串中的小游戏堆栈会转为结构化 frames', async () => {
+    init({
+      dsn: 'https://test@o0.ingest.sentry.io/0',
+      enableAutoSessionTracking: false,
+      transport: () => ({
+        send: (env: any) => {
+          captured.push(env);
+          return Promise.resolve({ statusCode: 200 });
+        },
+        flush: () => Promise.resolve(true),
+      }),
+    } as any);
+
+    onErrorHandler!(
+      [
+        'MiniProgramError',
+        "undefined is not an object (evaluating 'object.someProperty')",
+        "TypeError: undefined is not an object (evaluating 'object.someProperty')",
+        'at (subpackages/engine/game.js:12000:20)',
+        'at (WAGameSubContext.js:1:200000)',
+      ].join('\n'),
+    );
+    await flush(2000);
+
+    const events = collectEvents(captured);
+    const value = events[0]?.exception?.values?.[0];
+    expect(value.mechanism).toEqual({ type: 'onerror', handled: false });
+    expect(value.stacktrace?.frames).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          filename: 'app:///subpackages/engine/game.js',
+          lineno: 12000,
+          colno: 20,
+        }),
+      ]),
+    );
+  });
 });

--- a/test/globalhandlers.test.ts
+++ b/test/globalhandlers.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import { captureException, getCurrentScope } from '@sentry/core';
 import { GlobalHandlers } from '../src/integrations/globalhandlers';
+import { ignoreNextOnErrorCall } from '../src/helpers';
 
 // Mock @sentry/core
 jest.mock('@sentry/core', () => ({
@@ -92,11 +93,32 @@ describe('GlobalHandlers', () => {
       handler('Something went wrong');
 
       expect(captureException).toHaveBeenCalledWith(
-        expect.any(Error),
+        expect.objectContaining({
+          message: 'Something went wrong',
+          stack: 'Something went wrong',
+        }),
         expect.objectContaining({
           mechanism: { type: 'onerror', handled: false },
         }),
       );
+    });
+
+    it('should ignore the global callback after a wrapped handler captured the error', () => {
+      jest.useFakeTimers();
+
+      try {
+        const integration = new GlobalHandlers();
+        integration.setupOnce();
+        const handler = mockSdk.onError.mock.calls[0][0];
+
+        ignoreNextOnErrorCall();
+        handler('duplicate platform error');
+
+        expect(captureException).not.toHaveBeenCalled();
+      } finally {
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
+      }
     });
 
     it('should capture Error objects', () => {

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -28,6 +28,7 @@ describe('Helpers', () => {
     });
 
     it('should handle function that throws error', () => {
+      jest.useFakeTimers();
       const mockCaptureException = jest.fn();
       const mockGetClient = jest.fn(() => ({
         captureException: mockCaptureException,
@@ -46,8 +47,13 @@ describe('Helpers', () => {
 
       const wrappedFn = wrap(errorFn);
 
-      expect(() => wrappedFn()).toThrow('Test error');
-      expect(errorFn).toHaveBeenCalled();
+      try {
+        expect(() => wrappedFn()).toThrow('Test error');
+        expect(errorFn).toHaveBeenCalled();
+      } finally {
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
+      }
     });
 
     it('should preserve function properties', () => {
@@ -267,8 +273,15 @@ describe('Helpers', () => {
     });
 
     it('should return true after ignoreNextOnErrorCall', () => {
-      ignoreNextOnErrorCall();
-      expect(shouldIgnoreOnError()).toBe(true);
+      jest.useFakeTimers();
+
+      try {
+        ignoreNextOnErrorCall();
+        expect(shouldIgnoreOnError()).toBe(true);
+      } finally {
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
+      }
     });
 
     it('should return false after timeout', (done) => {
@@ -282,9 +295,16 @@ describe('Helpers', () => {
     });
 
     it('should handle multiple calls', () => {
-      ignoreNextOnErrorCall();
-      ignoreNextOnErrorCall();
-      expect(shouldIgnoreOnError()).toBe(true);
+      jest.useFakeTimers();
+
+      try {
+        ignoreNextOnErrorCall();
+        ignoreNextOnErrorCall();
+        expect(shouldIgnoreOnError()).toBe(true);
+      } finally {
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
+      }
     });
   });
 

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -16,6 +16,7 @@ import type { StackParser } from '@sentry/core';
 import { MiniappClient } from '../src/client';
 import { MiniappOptions } from '../src/types';
 import { MinigameFrameRateIntegration } from '../src/integrations/minigame-framerate';
+import { shouldIgnoreOnError } from '../src/helpers';
 
 describe('SDK', () => {
   beforeEach(() => {
@@ -424,14 +425,24 @@ describe('SDK', () => {
     });
 
     it('should capture exceptions and re-throw', () => {
-      init({ dsn: 'https://test@sentry.io/123' });
-      const error = new Error('Test wrap error');
-      const fn = () => {
-        throw error;
-      };
-      const wrapped = wrap(fn);
+      jest.useFakeTimers();
 
-      expect(() => wrapped()).toThrow('Test wrap error');
+      try {
+        init({ dsn: 'https://test@sentry.io/123' });
+        const error = new Error('Test wrap error');
+        const fn = () => {
+          throw error;
+        };
+        const wrapped = wrap(fn);
+
+        expect(() => wrapped()).toThrow('Test wrap error');
+        expect(shouldIgnoreOnError()).toBe(true);
+      } finally {
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
+      }
+
+      expect(shouldIgnoreOnError()).toBe(false);
     });
 
     it('should preserve this context', () => {

--- a/test/trycatch.realcore.test.ts
+++ b/test/trycatch.realcore.test.ts
@@ -21,6 +21,8 @@ describe('TryCatch（真 @sentry/core 集成）', () => {
   const g = global as any;
   let captured: any[];
   let realSetTimeout: any;
+  let realRequestAnimationFrame: any;
+  let onErrorHandler: ((e: string | Error) => void) | undefined;
 
   beforeEach(() => {
     captured = [];
@@ -28,16 +30,25 @@ describe('TryCatch（真 @sentry/core 集成）', () => {
     _resetAppLifecycle();
     installedIntegrations.length = 0;
     realSetTimeout = g.setTimeout;
+    realRequestAnimationFrame = g.requestAnimationFrame;
+    onErrorHandler = undefined;
     g.wx = {
       request: jest.fn(),
       getSystemInfoSync: () => ({ brand: 'Apple', SDKVersion: '3' }),
-      onError: jest.fn(),
+      onError: jest.fn((h: (e: string | Error) => void) => {
+        onErrorHandler = h;
+      }),
       onUnhandledRejection: jest.fn(),
     };
   });
 
   afterEach(async () => {
     g.setTimeout = realSetTimeout;
+    if (realRequestAnimationFrame === undefined) {
+      delete g.requestAnimationFrame;
+    } else {
+      g.requestAnimationFrame = realRequestAnimationFrame;
+    }
     const c = getClient();
     if (c) await c.close(0);
     installedIntegrations.length = 0;
@@ -89,6 +100,47 @@ describe('TryCatch（真 @sentry/core 集成）', () => {
     expect(val.mechanism?.handled).toBe(true);
     expect((errEvent.exception as any).mechanism).toBeUndefined(); // 不再误挂容器级
     expect(Array.isArray(errEvent.extra?.arguments)).toBe(true);
+  });
+
+  it('requestAnimationFrame 抛错后平台 onError 不会重复上报', async () => {
+    g.requestAnimationFrame = (callback: () => void) => callback();
+
+    init({
+      dsn: 'https://test@o0.ingest.sentry.io/0',
+      enableAutoSessionTracking: false,
+      enableOfflineCache: false,
+      enableMinigameFrameRate: false,
+      transport: () => ({
+        send: (env: any) => {
+          captured.push(env);
+          return Promise.resolve({ statusCode: 200 });
+        },
+        flush: () => Promise.resolve(true),
+      }),
+    } as any);
+
+    expect(() => {
+      g.requestAnimationFrame(() => {
+        throw new TypeError('duplicate raf boom');
+      });
+    }).toThrow('duplicate raf boom');
+
+    // 微信会在重新抛出后以字符串形式触发 onError；这条回调应被短暂屏蔽。
+    onErrorHandler!(
+      ['MiniProgramError', 'TypeError: duplicate raf boom', 'at (engine/game.js:12000:20)'].join(
+        '\n',
+      ),
+    );
+    await flush(2000);
+
+    const events = collectEvents(captured).filter((event) =>
+      event.exception?.values?.some((value: any) => value.value?.includes('duplicate raf boom')),
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0].exception.values[0].mechanism).toMatchObject({
+      type: 'instrument',
+      handled: true,
+    });
   });
 
   it('Error.cause 链存在时，instrument mechanism 标在原始抛错而非 cause', async () => {


### PR DESCRIPTION
## 背景

微信小游戏中，被 `TryCatch` 包装的 `requestAnimationFrame` 回调抛错后会先由 instrumentation 捕获，重新抛出时又触发 `wx.onError`。第二次回调只有字符串，既形成重复 Issue，也无法被 Source Map 还原。

Fixes #286

## 根因

仓库已有 `ignoreNextOnErrorCall` / `shouldIgnoreOnError` 计数器，但没有接入 `wrap()` 和 `GlobalHandlers`，去重链路实际上未生效；同时 `wx.onError` 字符串被直接传给 `new Error(message)`，宿主堆栈停留在 message 中，未交给 `stackParser`。

## 修复

- `TryCatch` 捕获并重新抛出异常前，短暂屏蔽随后到来的平台 `onError`
- `GlobalHandlers.onerror` 消费屏蔽标记，避免同一异常二次上报
- 将平台字符串写入 `Error.stack`，由现有 `miniappStackParser` 生成结构化 frames
- 公开的 `Sentry.wrap()` 同步使用相同去重机制
- 不放宽 Dedupe 规则，避免误合并两个独立业务异常

该策略与 Sentry Browser 的 `TryCatch` / `GlobalHandlers` 处理方式一致。

## 验证

- 真 `@sentry/core` 用例：RAF 异常加 `wx.onError` 回调最终只发送 1 条 `instrument` 事件
- 真 `@sentry/core` 用例：微信小游戏字符串堆栈生成 `app:///subpackages/engine/game.js:12000:20` frame
- `yarn lint`
- `yarn typecheck`
- `yarn test --runInBand`（43 suites / 569 tests）
- `yarn build`
- `yarn build:miniapp`

## 兼容性

不改变公开 API 或配置。未经过 TryCatch 的顶层、引擎和第三方 SDK 异常仍由 GlobalHandlers 正常兜底上报。