### PR TITLE
fix(cross-platform): 修复小游戏平台识别与覆盖

### DIFF
--- a/.agents/skills/sentry-miniapp-sdk/SKILL.md
+++ b/.agents/skills/sentry-miniapp-sdk/SKILL.md
@@ -163,17 +163,19 @@ Sentry.init({
 
 ### Step 3: Configure Platform (if needed)
 
-The SDK auto-detects the platform at runtime. No explicit `platform` option is required in most cases.
+The SDK auto-detects the platform at runtime. No explicit `platform` option is required in most cases. Game engine adapters such as Cocos may expose a cross-platform compatibility global; set `platform` when the event label is detected incorrectly.
 
-If you need to force a specific platform:
+If you need to override the event's miniapp platform label:
 
 ```javascript
 Sentry.init({
   dsn: '...',
-  platform: 'wechat', // 'wechat' | 'alipay' | 'bytedance' | 'qq' | 'swan' | 'dingtalk' | 'kuaishou'
+  platform: 'bytedance', // 'wechat' | 'alipay' | 'bytedance' | 'qq' | 'swan' | 'dingtalk' | 'kuaishou'
   // Note: Baidu's global object is `swan`, so use 'swan' (there is no 'baidu' value).
 });
 ```
+
+The configured value is written to both the top-level event `platform` and `contexts.miniapp.platform`. It does not switch the underlying runtime API: error handlers, requests, and storage continue using the compatible global detected automatically. If Source Map processing requires top-level `event.platform = 'javascript'`, set that in `beforeSend`; the miniapp context keeps the configured platform.
 
 ### Step 4: Add User Context
 

--- a/.agents/skills/sentry-miniapp-sdk/SKILL.md
+++ b/.agents/skills/sentry-miniapp-sdk/SKILL.md
@@ -163,7 +163,7 @@ Sentry.init({
 
 ### Step 3: Configure Platform (if needed)
 
-The SDK auto-detects the platform at runtime. No explicit `platform` option is required in most cases. Set `platform` when multiple platform globals are present or the detected event label does not match the actual release target.
+The SDK auto-detects the platform at runtime. When multiple platform globals are present, it uses platform-specific host names, data paths, and App IDs to disambiguate them. Set `platform` only when those runtime signals are unavailable or the detected event label still does not match the release target.
 
 If you need to override the event's miniapp platform label:
 

--- a/.agents/skills/sentry-miniapp-sdk/SKILL.md
+++ b/.agents/skills/sentry-miniapp-sdk/SKILL.md
@@ -163,7 +163,7 @@ Sentry.init({
 
 ### Step 3: Configure Platform (if needed)
 
-The SDK auto-detects the platform at runtime. No explicit `platform` option is required in most cases. Game engine adapters such as Cocos may expose a cross-platform compatibility global; set `platform` when the event label is detected incorrectly.
+The SDK auto-detects the platform at runtime. No explicit `platform` option is required in most cases. Set `platform` when multiple platform globals are present or the detected event label does not match the actual release target.
 
 If you need to override the event's miniapp platform label:
 

--- a/.agents/skills/sentry-miniapp-sdk/SKILL.md
+++ b/.agents/skills/sentry-miniapp-sdk/SKILL.md
@@ -163,7 +163,7 @@ Sentry.init({
 
 ### Step 3: Configure Platform (if needed)
 
-The SDK auto-detects the platform at runtime. When multiple platform globals are present, it uses platform-specific host names, data paths, and App IDs to disambiguate them. Set `platform` only when those runtime signals are unavailable or the detected event label still does not match the release target.
+The SDK auto-detects the platform at runtime. When multiple platform globals are present, it uses platform-specific host names, data paths, and App IDs to disambiguate them. Set `platform` only when those runtime signals are unavailable, conflicting, or the detected event label still does not match the release target.
 
 If you need to override the event's miniapp platform label:
 
@@ -175,7 +175,7 @@ Sentry.init({
 });
 ```
 
-The configured value is written to both the top-level event `platform` and `contexts.miniapp.platform`. It does not switch the underlying runtime API: error handlers, requests, and storage continue using the compatible global detected automatically. If Source Map processing requires top-level `event.platform = 'javascript'`, set that in `beforeSend`; the miniapp context keeps the configured platform.
+The configured value is used as the default top-level event `platform` and is written to `contexts.miniapp.platform`. It does not switch the underlying runtime API: error handlers, requests, and storage continue using the compatible global detected automatically. If Source Map processing requires top-level `event.platform = 'javascript'`, set that in `beforeSend`; the miniapp context keeps the configured platform.
 
 ### Step 4: Add User Context
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -154,7 +154,7 @@ export class MiniappClient extends Client<any> {
       event.contexts = {};
     }
     event.contexts['miniapp'] = {
-      platform: appName(),
+      platform: this.getOptions().platform || appName(),
       sdk_version: SDK_VERSION,
     };
 

--- a/src/crossPlatform.ts
+++ b/src/crossPlatform.ts
@@ -24,6 +24,7 @@ interface SDK {
   offShow?: Function;
   offHide?: Function;
   getLaunchOptionsSync?: Function;
+  getEnvInfoSync?: Function;
   getAccountInfoSync?: Function;
   getUpdateManager?: Function;
   showModal?: Function;
@@ -144,8 +145,8 @@ const isBrowserRuntime = (): boolean => {
  */
 /**
  * 平台描述表：全局对象名 → 平台标识。平台检测的唯一来源，getSDK() / getAppName() /
- * isMiniappEnvironment() 均基于此。数组顺序即 first-match 优先级（多个平台全局对象
- * 共存时取靠前者），新增平台或调整优先级只需改这一处。
+ * isMiniappEnvironment() 均基于此。数组顺序只作为宿主信号无法消除多对象歧义时的兼容回退，
+ * 新增平台只需改这一处。
  */
 const PLATFORMS: ReadonlyArray<{ global: string; name: AppName }> = [
   { global: 'wx', name: 'wechat' },
@@ -157,22 +158,108 @@ const PLATFORMS: ReadonlyArray<{ global: string; name: AppName }> = [
   { global: 'ks', name: 'kuaishou' },
 ];
 
-/**
- * 检测当前平台：返回首个命中的平台全局对象与标识，未命中返回 null。
- */
-export const detectPlatform = (): { sdk: SDK; name: AppName } | null => {
-  const g = globalThis as Record<string, unknown>;
-  for (const platform of PLATFORMS) {
-    const candidate = g[platform.global];
-    if (typeof candidate === 'object' && candidate !== null) {
-      return { sdk: candidate as SDK, name: platform.name };
-    }
+type DetectedPlatform = { sdk: SDK; name: AppName };
+
+const BYTEDANCE_HOST_NAMES = new Set([
+  'toutiao',
+  'douyin',
+  'douyin_lite',
+  'news_article_lite',
+  'aweme_hotsoon',
+  'xigua',
+  'douyin_web',
+]);
+
+const callPlatformInfo = (platformSdk: SDK, method: keyof SDK): Record<string, any> | null => {
+  const fn = platformSdk[method];
+  if (typeof fn !== 'function') return null;
+
+  try {
+    const result = fn.call(platformSdk);
+    return result && typeof result === 'object' ? result : null;
+  } catch (_error) {
+    return null;
   }
+};
+
+const inferPlatformFromAppId = (appId: unknown): AppName | null => {
+  if (typeof appId !== 'string') return null;
+  if (appId.startsWith('tt')) return 'bytedance';
+  if (appId.startsWith('wx')) return 'wechat';
   return null;
 };
 
+/**
+ * 从宿主 API 返回值推断真实平台，仅识别有稳定、平台专属格式的信号。
+ * 该推断只在多个平台全局对象共存时使用，失败时由 detectPlatform 保留历史 first-match。
+ */
+const inferPlatformFromRuntime = (platformSdk: SDK): AppName | null => {
+  const envInfo = callPlatformInfo(platformSdk, 'getEnvInfoSync');
+  const envPlatform = inferPlatformFromAppId(envInfo?.['microapp']?.['appId']);
+  if (envPlatform) return envPlatform;
+
+  const userDataPath = envInfo?.['common']?.['USER_DATA_PATH'];
+  if (typeof userDataPath === 'string') {
+    if (userDataPath.startsWith('ttfile://')) return 'bytedance';
+    if (userDataPath.startsWith('wxfile://')) return 'wechat';
+  }
+
+  const systemInfo = callPlatformInfo(platformSdk, 'getSystemInfoSync');
+  const hostName = systemInfo?.['appName'] ?? systemInfo?.['hostName'];
+  if (typeof hostName === 'string' && BYTEDANCE_HOST_NAMES.has(hostName.toLowerCase())) {
+    return 'bytedance';
+  }
+
+  const accountInfo = callPlatformInfo(platformSdk, 'getAccountInfoSync');
+  const accountPlatform = inferPlatformFromAppId(accountInfo?.['miniProgram']?.['appId']);
+  if (accountPlatform) return accountPlatform;
+
+  const launchOptions = callPlatformInfo(platformSdk, 'getLaunchOptionsSync');
+  const launchPlatform = inferPlatformFromAppId(launchOptions?.['extra']?.['appId']);
+  if (launchPlatform) return launchPlatform;
+
+  return null;
+};
+
+/**
+ * 检测当前平台。单一命中直接返回；多个平台对象共存时优先采用宿主 API 的明确证据，
+ * 无法判定才回退历史 first-match 顺序，未命中返回 null。
+ */
+export const detectPlatform = (): DetectedPlatform | null => {
+  const g = globalThis as Record<string, unknown>;
+  const candidates: DetectedPlatform[] = [];
+  for (const platform of PLATFORMS) {
+    const platformSdk = g[platform.global];
+    if (typeof platformSdk === 'object' && platformSdk !== null) {
+      candidates.push({ sdk: platformSdk as SDK, name: platform.name });
+    }
+  }
+
+  if (candidates.length <= 1) {
+    return candidates[0] ?? null;
+  }
+
+  for (const candidate of candidates) {
+    const inferredPlatform = inferPlatformFromRuntime(candidate.sdk);
+    if (inferredPlatform) {
+      return { sdk: candidate.sdk, name: inferredPlatform };
+    }
+  }
+
+  return candidates[0] ?? null;
+};
+
+let _detectedPlatform: DetectedPlatform | null | undefined;
+
+const resolvePlatform = (): DetectedPlatform | null => {
+  if (_detectedPlatform === undefined) {
+    _detectedPlatform = detectPlatform();
+  }
+  return _detectedPlatform;
+};
+
 const getSDK = (): SDK => {
-  const detected = detectPlatform();
+  const detected = resolvePlatform();
 
   if (!detected) {
     if (isBrowserRuntime()) {
@@ -240,7 +327,7 @@ const getSDK = (): SDK => {
  * 获取平台名称
  */
 const getAppName = (): AppName => {
-  return detectPlatform()?.name ?? 'unknown';
+  return resolvePlatform()?.name ?? 'unknown';
 };
 
 /**
@@ -416,8 +503,9 @@ export const isMinigame = (): boolean => {
   return _isMinigame;
 };
 
-/** 统一重置平台检测相关缓存（_sdk / _appName / _isMinigame），仅供测试使用。 */
+/** 统一重置平台解析及其派生缓存，仅供测试使用。 */
 export const resetPlatformCache = (): void => {
+  _detectedPlatform = undefined;
   _sdk = null;
   _appName = null;
   _isMinigame = null;

--- a/src/crossPlatform.ts
+++ b/src/crossPlatform.ts
@@ -171,10 +171,10 @@ const BYTEDANCE_HOST_NAMES = new Set([
 ]);
 
 const callPlatformInfo = (platformSdk: SDK, method: keyof SDK): Record<string, any> | null => {
-  const fn = platformSdk[method];
-  if (typeof fn !== 'function') return null;
-
   try {
+    const fn = platformSdk[method];
+    if (typeof fn !== 'function') return null;
+
     const result = fn.call(platformSdk);
     return result && typeof result === 'object' ? result : null;
   } catch (_error) {
@@ -239,11 +239,19 @@ export const detectPlatform = (): DetectedPlatform | null => {
     return candidates[0] ?? null;
   }
 
+  const inferredPlatforms = new Set<AppName>();
   for (const candidate of candidates) {
     const inferredPlatform = inferPlatformFromRuntime(candidate.sdk);
-    if (inferredPlatform) {
-      return { sdk: candidate.sdk, name: inferredPlatform };
+    if (inferredPlatform && candidates.some((item) => item.name === inferredPlatform)) {
+      inferredPlatforms.add(inferredPlatform);
     }
+  }
+
+  if (inferredPlatforms.size === 1) {
+    const [inferredPlatform] = inferredPlatforms;
+    // 宿主证据只用于选择同名候选对象，不能把 A 平台 SDK 与 B 平台名称拼在一起；
+    // getSDK() 后续会按 name 执行支付宝/钉钉等平台适配，二者错配会破坏请求和 Storage。
+    return candidates.find((item) => item.name === inferredPlatform) ?? candidates[0] ?? null;
   }
 
   return candidates[0] ?? null;

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -180,7 +180,7 @@ export function init(options: MiniappOptions = {}): MiniappClient | undefined {
   // 平台标记。device / os / app context 由 MiniappClient._prepareEvent 在每个事件上统一写入
   // （唯一权威），此处不再重复设置，避免字段不一致与覆盖歧义（见架构 review P2-b）。
   setContext('miniapp', {
-    platform: appName(),
+    platform: opts.platform || appName(),
     environment: 'miniapp',
   });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -133,7 +133,7 @@ export interface MiniappOptions {
 
   /**
    * 事件的小程序平台标记，写入顶层 `platform` 与 `contexts.miniapp.platform`。
-   * 默认按宿主全局对象自动识别；当运行时存在多个平台对象或识别结果不准确时可显式指定。
+   * 默认按宿主全局对象及平台专属宿主信息自动识别；无法消除多对象歧义时可显式指定。
    * 此选项不切换底层运行时 API。百度小程序使用 `swan`，没有单独的 `baidu`。
    */
   platform?: 'wechat' | 'alipay' | 'bytedance' | 'qq' | 'swan' | 'dingtalk' | 'kuaishou';

--- a/src/types.ts
+++ b/src/types.ts
@@ -133,7 +133,7 @@ export interface MiniappOptions {
 
   /**
    * 事件的小程序平台标记，写入顶层 `platform` 与 `contexts.miniapp.platform`。
-   * 默认按宿主全局对象自动识别；可在 Cocos 等引擎适配层导致识别歧义时显式指定。
+   * 默认按宿主全局对象自动识别；当运行时存在多个平台对象或识别结果不准确时可显式指定。
    * 此选项不切换底层运行时 API。百度小程序使用 `swan`，没有单独的 `baidu`。
    */
   platform?: 'wechat' | 'alipay' | 'bytedance' | 'qq' | 'swan' | 'dingtalk' | 'kuaishou';

--- a/src/types.ts
+++ b/src/types.ts
@@ -132,8 +132,9 @@ export interface MiniappOptions {
   beforeSendLog?: (log: Log) => Log | null;
 
   /**
-   * Miniapp platform label stored on events. Runtime platform detection is automatic.
-   * 取值与运行时 `AppName` 对齐（百度小程序的全局对象是 `swan`，故用 `swan` 表示，无独立 `baidu`）。
+   * 事件的小程序平台标记，写入顶层 `platform` 与 `contexts.miniapp.platform`。
+   * 默认按宿主全局对象自动识别；可在 Cocos 等引擎适配层导致识别歧义时显式指定。
+   * 此选项不切换底层运行时 API。百度小程序使用 `swan`，没有单独的 `baidu`。
    */
   platform?: 'wechat' | 'alipay' | 'bytedance' | 'qq' | 'swan' | 'dingtalk' | 'kuaishou';
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -132,7 +132,7 @@ export interface MiniappOptions {
   beforeSendLog?: (log: Log) => Log | null;
 
   /**
-   * 事件的小程序平台标记，写入顶层 `platform` 与 `contexts.miniapp.platform`。
+   * 事件的小程序平台标记，作为顶层 `platform` 的默认值并写入 `contexts.miniapp.platform`。
    * 默认按宿主全局对象及平台专属宿主信息自动识别；无法消除多对象歧义时可显式指定。
    * 此选项不切换底层运行时 API。百度小程序使用 `swan`，没有单独的 `baidu`。
    */

--- a/test/crossPlatform.test.ts
+++ b/test/crossPlatform.test.ts
@@ -67,6 +67,81 @@ describe('CrossPlatform', () => {
       expect(detectPlatform()?.name).toBe('wechat');
     });
 
+    it('wx / tt 共存时根据抖音宿主 appName 自动识别为 bytedance', async () => {
+      const mockWx = { request: jest.fn(), getSystemInfoSync: jest.fn(() => ({})) };
+      const mockTt = {
+        request: jest.fn(),
+        getSystemInfoSync: jest.fn(() => ({ appName: 'Douyin' })),
+      };
+      (global as any).wx = mockWx;
+      (global as any).tt = mockTt;
+
+      const { getSDK, appName, detectPlatform } = await import('../src/crossPlatform');
+      expect(getSDK()).toBe(mockTt);
+      expect(appName()).toBe('bytedance');
+      expect(detectPlatform()).toEqual({ sdk: mockTt, name: 'bytedance' });
+    });
+
+    it('兼容对象返回抖音 hostName 时保留该对象作为 SDK，并纠正平台标记', async () => {
+      const compatibleWx = {
+        request: jest.fn(),
+        getSystemInfoSync: jest.fn(() => ({ hostName: 'Douyin' })),
+      };
+      (global as any).wx = compatibleWx;
+      (global as any).tt = { request: jest.fn() };
+
+      const { getSDK, appName } = await import('../src/crossPlatform');
+      expect(getSDK()).toBe(compatibleWx);
+      expect(appName()).toBe('bytedance');
+    });
+
+    it('通过抖音环境路径和 AppID 识别 bytedance', async () => {
+      (global as any).wx = { request: jest.fn() };
+      const mockTt = {
+        request: jest.fn(),
+        getEnvInfoSync: jest.fn(() => ({
+          microapp: { appId: 'tt1234567890' },
+          common: { USER_DATA_PATH: 'ttfile://user' },
+        })),
+      };
+      (global as any).tt = mockTt;
+
+      const { detectPlatform } = await import('../src/crossPlatform');
+      expect(detectPlatform()).toEqual({ sdk: mockTt, name: 'bytedance' });
+    });
+
+    it('宿主信息 API 抛错或没有明确证据时保留历史 first-match', async () => {
+      const mockWx = {
+        request: jest.fn(),
+        getSystemInfoSync: jest.fn(() => {
+          throw new Error('not ready');
+        }),
+      };
+      (global as any).wx = mockWx;
+      (global as any).tt = { request: jest.fn(), getSystemInfoSync: jest.fn(() => ({})) };
+
+      const { getSDK, appName } = await import('../src/crossPlatform');
+      expect(getSDK()).toBe(mockWx);
+      expect(appName()).toBe('wechat');
+    });
+
+    it('sdk 与 appName 共享同一次平台解析结果', async () => {
+      (global as any).wx = { request: jest.fn() };
+      const getSystemInfoSync = jest
+        .fn<() => Record<string, string>>()
+        .mockReturnValueOnce({ appName: 'Douyin' })
+        .mockImplementation(() => {
+          throw new Error('transient failure');
+        });
+      const mockTt = { request: jest.fn(), getSystemInfoSync };
+      (global as any).tt = mockTt;
+
+      const { getSDK, appName } = await import('../src/crossPlatform');
+      expect(getSDK()).toBe(mockTt);
+      expect(appName()).toBe('bytedance');
+      expect(getSystemInfoSync).toHaveBeenCalledTimes(1);
+    });
+
     it('should return my SDK when wx not available but my is', async () => {
       const mockMy = {
         request: jest.fn(),

--- a/test/crossPlatform.test.ts
+++ b/test/crossPlatform.test.ts
@@ -82,28 +82,41 @@ describe('CrossPlatform', () => {
       expect(detectPlatform()).toEqual({ sdk: mockTt, name: 'bytedance' });
     });
 
-    it('兼容对象返回抖音 hostName 时保留该对象作为 SDK，并纠正平台标记', async () => {
+    it('兼容对象返回抖音 hostName 时选择同名 tt 对象，避免 SDK 与平台名称错配', async () => {
       const compatibleWx = {
         request: jest.fn(),
         getSystemInfoSync: jest.fn(() => ({ hostName: 'Douyin' })),
       };
       (global as any).wx = compatibleWx;
-      (global as any).tt = { request: jest.fn() };
+      const mockTt = { request: jest.fn() };
+      (global as any).tt = mockTt;
 
       const { getSDK, appName } = await import('../src/crossPlatform');
-      expect(getSDK()).toBe(compatibleWx);
+      expect(getSDK()).toBe(mockTt);
       expect(appName()).toBe('bytedance');
     });
 
-    it('通过抖音环境路径和 AppID 识别 bytedance', async () => {
+    it('通过抖音环境数据路径识别 bytedance', async () => {
       (global as any).wx = { request: jest.fn() };
       const mockTt = {
         request: jest.fn(),
         getEnvInfoSync: jest.fn(() => ({
-          microapp: { appId: 'tt1234567890' },
           common: { USER_DATA_PATH: 'ttfile://user' },
         })),
       };
+      (global as any).tt = mockTt;
+
+      const { detectPlatform } = await import('../src/crossPlatform');
+      expect(detectPlatform()).toEqual({ sdk: mockTt, name: 'bytedance' });
+    });
+
+    it.each([
+      ['getEnvInfoSync', () => ({ microapp: { appId: 'tt1234567890' } })],
+      ['getAccountInfoSync', () => ({ miniProgram: { appId: 'tt1234567890' } })],
+      ['getLaunchOptionsSync', () => ({ extra: { appId: 'tt1234567890' } })],
+    ])('通过 %s 返回的抖音 AppID 识别 bytedance', async (method, getInfo) => {
+      (global as any).wx = { request: jest.fn() };
+      const mockTt = { request: jest.fn(), [method]: jest.fn(getInfo) };
       (global as any).tt = mockTt;
 
       const { detectPlatform } = await import('../src/crossPlatform');
@@ -119,6 +132,37 @@ describe('CrossPlatform', () => {
       };
       (global as any).wx = mockWx;
       (global as any).tt = { request: jest.fn(), getSystemInfoSync: jest.fn(() => ({})) };
+
+      const { getSDK, appName } = await import('../src/crossPlatform');
+      expect(getSDK()).toBe(mockWx);
+      expect(appName()).toBe('wechat');
+    });
+
+    it('宿主信息 API getter 抛错时保留历史 first-match', async () => {
+      const mockWx = { request: jest.fn() };
+      Object.defineProperty(mockWx, 'getSystemInfoSync', {
+        get: () => {
+          throw new Error('unsupported getter');
+        },
+      });
+      (global as any).wx = mockWx;
+      (global as any).tt = { request: jest.fn() };
+
+      const { getSDK, appName } = await import('../src/crossPlatform');
+      expect(getSDK()).toBe(mockWx);
+      expect(appName()).toBe('wechat');
+    });
+
+    it('不同候选对象返回冲突平台信号时保留历史 first-match', async () => {
+      const mockWx = {
+        request: jest.fn(),
+        getEnvInfoSync: jest.fn(() => ({ common: { USER_DATA_PATH: 'wxfile://user' } })),
+      };
+      (global as any).wx = mockWx;
+      (global as any).tt = {
+        request: jest.fn(),
+        getSystemInfoSync: jest.fn(() => ({ appName: 'Douyin' })),
+      };
 
       const { getSDK, appName } = await import('../src/crossPlatform');
       expect(getSDK()).toBe(mockWx);

--- a/test/nonwx.realcore.test.ts
+++ b/test/nonwx.realcore.test.ts
@@ -33,8 +33,8 @@ describe('支付宝 my 平台（真 @sentry/core 集成）', () => {
     resetPlatformCache();
     _resetAppLifecycle();
     installedIntegrations.length = 0;
-    // test/setup.ts 全局注入了 global.wx，detectPlatform 会优先命中 wx → 恒为 wechat。
-    // 要真正走支付宝分支，必须先清掉 wx，只留 my。（这也正是非 wx 路径长期被遮蔽的原因。）
+    // test/setup.ts 全局注入了 global.wx；mock 没有可消除歧义的宿主信息时会回退到 wx。
+    // 要隔离验证支付宝分支，必须先清掉 wx，只留 my。
     savedWx = g.wx;
     delete g.wx;
     g.my = {

--- a/test/platform-detection.realcore.test.ts
+++ b/test/platform-detection.realcore.test.ts
@@ -16,7 +16,7 @@ function collectEvents(captured: any[]): any[] {
   return events;
 }
 
-describe('显式平台覆盖（真 @sentry/core 集成）', () => {
+describe('平台识别与显式覆盖（真 @sentry/core 集成）', () => {
   const g = global as any;
   let captured: any[];
   let tt: any;
@@ -34,6 +34,7 @@ describe('显式平台覆盖（真 @sentry/core 集成）', () => {
         brand: 'ByteDance',
         model: 'Douyin Device',
         system: 'iOS 18',
+        appName: 'Douyin',
         SDKVersion: '3.0.0',
       })),
       onError: jest.fn(),
@@ -51,13 +52,50 @@ describe('显式平台覆盖（真 @sentry/core 集成）', () => {
     delete g.tt;
   });
 
-  it('platform=bytedance 覆盖事件标记，但保留自动检测到的兼容运行时 API', async () => {
+  it('wx / tt 共存时自动识别抖音宿主，并兼容 beforeSend 顶层 platform', async () => {
+    const wxOnError = g.wx.onError;
+    const client = init({
+      dsn: 'https://test@o0.ingest.sentry.io/0',
+      enableAutoSessionTracking: false,
+      beforeSend: (event) => ({ ...event, platform: 'javascript' }),
+      transport: () => ({
+        send: (envelope: any) => {
+          captured.push(envelope);
+          return Promise.resolve({ statusCode: 200 });
+        },
+        flush: () => Promise.resolve(true),
+      }),
+    });
+    expect(client).toBeDefined();
+    expect(tt.onError).toHaveBeenCalledTimes(1);
+    expect(wxOnError).not.toHaveBeenCalled();
+
+    captureException(new Error('bytedance auto detection'));
+    await flush(2000);
+
+    const event = collectEvents(captured).find((item) =>
+      item.exception?.values?.some((value: any) =>
+        value.value?.includes('bytedance auto detection'),
+      ),
+    );
+    expect(event).toBeDefined();
+    expect(event.platform).toBe('javascript');
+    expect(event.contexts?.miniapp?.platform).toBe('bytedance');
+    expect(event.contexts?.device?.brand).toBe('ByteDance');
+  });
+
+  it('宿主信号不足时允许 platform=bytedance 覆盖事件标记', async () => {
+    tt.getSystemInfoSync.mockReturnValue({
+      brand: 'Unknown Adapter',
+      model: 'Unknown Device',
+      system: 'iOS 18',
+      SDKVersion: '3.0.0',
+    });
     const wxOnError = g.wx.onError;
     const client = init({
       dsn: 'https://test@o0.ingest.sentry.io/0',
       platform: 'bytedance',
       enableAutoSessionTracking: false,
-      beforeSend: (event) => ({ ...event, platform: 'javascript' }),
       transport: () => ({
         send: (envelope: any) => {
           captured.push(envelope);
@@ -70,17 +108,16 @@ describe('显式平台覆盖（真 @sentry/core 集成）', () => {
     expect(wxOnError).toHaveBeenCalledTimes(1);
     expect(tt.onError).not.toHaveBeenCalled();
 
-    captureException(new Error('bytedance platform override'));
+    captureException(new Error('bytedance explicit fallback'));
     await flush(2000);
 
     const event = collectEvents(captured).find((item) =>
       item.exception?.values?.some((value: any) =>
-        value.value?.includes('bytedance platform override'),
+        value.value?.includes('bytedance explicit fallback'),
       ),
     );
     expect(event).toBeDefined();
-    expect(event.platform).toBe('javascript');
+    expect(event.platform).toBe('bytedance');
     expect(event.contexts?.miniapp?.platform).toBe('bytedance');
-    expect(event.contexts?.device?.brand).toBe('Apple');
   });
 });

--- a/test/platform-override.realcore.test.ts
+++ b/test/platform-override.realcore.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { captureException, flush, getClient, installedIntegrations } from '@sentry/core';
+import { _resetAppLifecycle } from '../src/appLifecycle';
+import { resetPlatformCache } from '../src/crossPlatform';
+import { init } from '../src/index';
+
+function collectEvents(captured: any[]): any[] {
+  const events: any[] = [];
+  for (const envelope of captured) {
+    const items = envelope[1];
+    if (!Array.isArray(items)) continue;
+    for (const item of items) {
+      if (item[0]?.type === 'event') events.push(item[1]);
+    }
+  }
+  return events;
+}
+
+describe('显式平台覆盖（真 @sentry/core 集成）', () => {
+  const g = global as any;
+  let captured: any[];
+  let tt: any;
+
+  beforeEach(() => {
+    captured = [];
+    resetPlatformCache();
+    _resetAppLifecycle();
+    installedIntegrations.length = 0;
+
+    // 模拟 Cocos 抖音小游戏：适配层暴露 wx 兼容对象，真实宿主同时提供 tt。
+    tt = {
+      request: jest.fn(),
+      getSystemInfoSync: jest.fn(() => ({
+        brand: 'ByteDance',
+        model: 'Douyin Device',
+        system: 'iOS 18',
+        SDKVersion: '3.0.0',
+      })),
+      onError: jest.fn(),
+      onUnhandledRejection: jest.fn(),
+    };
+    g.tt = tt;
+  });
+
+  afterEach(async () => {
+    const client = getClient();
+    if (client) await client.close(0);
+    installedIntegrations.length = 0;
+    _resetAppLifecycle();
+    resetPlatformCache();
+    delete g.tt;
+  });
+
+  it('platform=bytedance 覆盖事件标记，但保留自动检测到的兼容运行时 API', async () => {
+    const wxOnError = g.wx.onError;
+    const client = init({
+      dsn: 'https://test@o0.ingest.sentry.io/0',
+      platform: 'bytedance',
+      enableAutoSessionTracking: false,
+      beforeSend: (event) => ({ ...event, platform: 'javascript' }),
+      transport: () => ({
+        send: (envelope: any) => {
+          captured.push(envelope);
+          return Promise.resolve({ statusCode: 200 });
+        },
+        flush: () => Promise.resolve(true),
+      }),
+    });
+    expect(client).toBeDefined();
+    expect(wxOnError).toHaveBeenCalledTimes(1);
+    expect(tt.onError).not.toHaveBeenCalled();
+
+    captureException(new Error('bytedance platform override'));
+    await flush(2000);
+
+    const event = collectEvents(captured).find((item) =>
+      item.exception?.values?.some((value: any) =>
+        value.value?.includes('bytedance platform override'),
+      ),
+    );
+    expect(event).toBeDefined();
+    expect(event.platform).toBe('javascript');
+    expect(event.contexts?.miniapp?.platform).toBe('bytedance');
+    expect(event.contexts?.device?.brand).toBe('Apple');
+  });
+});

--- a/test/platform-override.realcore.test.ts
+++ b/test/platform-override.realcore.test.ts
@@ -27,7 +27,7 @@ describe('显式平台覆盖（真 @sentry/core 集成）', () => {
     _resetAppLifecycle();
     installedIntegrations.length = 0;
 
-    // 模拟 Cocos 抖音小游戏：适配层暴露 wx 兼容对象，真实宿主同时提供 tt。
+    // 复现 issue #288 的可观测状态：wx / tt 同时存在，默认顺序先命中 wx。
     tt = {
       request: jest.fn(),
       getSystemInfoSync: jest.fn(() => ({

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -4,10 +4,8 @@ import { resetPlatformCache } from '../src/crossPlatform';
 // 所有平台全局：每个用例前后统一清理，杜绝跨用例残留导致 detectPlatform 串味。
 const PLATFORM_GLOBALS = ['wx', 'my', 'tt', 'dd', 'qq', 'swan', 'ks'];
 
-// 默认 wx（微信）平台 mock。注意：detectPlatform 按 PLATFORMS 顺序、wx 优先命中，
-// 因此只要 global.wx 存在，平台恒为 wechat。要测非 wx 平台（支付宝 my / 字节 tt 等），
-// 用例需在自己的 beforeEach 里 `delete (global as any).wx` 再注入目标平台全局——
-// 本文件的 beforeEach 先执行、用例的 beforeEach 后执行覆盖，故清除生效。
+// 默认 wx（微信）平台 mock。多平台对象共存但没有平台专属宿主信息时，detectPlatform
+// 会按 PLATFORMS 顺序回退到 wx。要隔离验证非 wx 路径，测试仍应清掉默认 wx。
 function makeDefaultWx(): any {
   return {
     request: jest.fn(),

--- a/website/guide/configuration.md
+++ b/website/guide/configuration.md
@@ -12,7 +12,7 @@
 | `release` | `string` | — | 版本号；**Source Map 解析的关键**，需与上传时的 release 完全一致 |
 | `environment` | `string` | — | 环境标识，如 `production` / `staging` |
 | `debug` | `boolean` | `false` | 开启 SDK 调试日志 |
-| `platform` | `'wechat'｜'alipay'｜'bytedance'｜'qq'｜'swan'｜'dingtalk'｜'kuaishou'` | 自动识别 | 事件的平台标记，同时写入顶层 `platform` 与 `contexts.miniapp.platform`。SDK 会结合平台对象、宿主名称、数据路径和 AppID 自动消除多对象歧义；仅在宿主未提供有效信息时需要手动指定。该选项不切换底层运行时 API。百度小程序使用 `swan`，没有单独的 `baidu` |
+| `platform` | `'wechat'｜'alipay'｜'bytedance'｜'qq'｜'swan'｜'dingtalk'｜'kuaishou'` | 自动识别 | 事件的平台标记，作为顶层 `platform` 的默认值并写入 `contexts.miniapp.platform`。SDK 会结合平台对象、宿主名称、数据路径和 AppID 尽量消除 `wx` / `tt` 等多对象歧义；仅在宿主信息缺失或冲突时需要手动指定。该选项不切换底层运行时 API。百度小程序使用 `swan`，没有单独的 `baidu` |
 
 ## 采样
 

--- a/website/guide/configuration.md
+++ b/website/guide/configuration.md
@@ -12,7 +12,7 @@
 | `release` | `string` | — | 版本号；**Source Map 解析的关键**，需与上传时的 release 完全一致 |
 | `environment` | `string` | — | 环境标识，如 `production` / `staging` |
 | `debug` | `boolean` | `false` | 开启 SDK 调试日志 |
-| `platform` | `'wechat'｜'alipay'｜'bytedance'｜'qq'｜'swan'｜'dingtalk'｜'kuaishou'` | 自动识别 | 事件的平台标记，同时写入顶层 `platform` 与 `contexts.miniapp.platform`。通常无需设置；当运行时存在多个平台对象或识别结果不准确时再指定。该选项不切换底层运行时 API。百度小程序使用 `swan`，没有单独的 `baidu` |
+| `platform` | `'wechat'｜'alipay'｜'bytedance'｜'qq'｜'swan'｜'dingtalk'｜'kuaishou'` | 自动识别 | 事件的平台标记，同时写入顶层 `platform` 与 `contexts.miniapp.platform`。SDK 会结合平台对象、宿主名称、数据路径和 AppID 自动消除多对象歧义；仅在宿主未提供有效信息时需要手动指定。该选项不切换底层运行时 API。百度小程序使用 `swan`，没有单独的 `baidu` |
 
 ## 采样
 

--- a/website/guide/configuration.md
+++ b/website/guide/configuration.md
@@ -12,7 +12,7 @@
 | `release` | `string` | — | 版本号；**Source Map 解析的关键**，需与上传时的 release 完全一致 |
 | `environment` | `string` | — | 环境标识，如 `production` / `staging` |
 | `debug` | `boolean` | `false` | 开启 SDK 调试日志 |
-| `platform` | `'wechat'｜'alipay'｜'bytedance'｜'qq'｜'swan'｜'dingtalk'｜'kuaishou'` | 自动识别 | 事件上标注的平台；运行时平台 SDK 会自动检测，一般无需手动设。百度小程序的全局对象是 `swan`，因此平台标识使用 `swan`，没有单独的 `baidu` |
+| `platform` | `'wechat'｜'alipay'｜'bytedance'｜'qq'｜'swan'｜'dingtalk'｜'kuaishou'` | 自动识别 | 事件的平台标记，同时写入顶层 `platform` 与 `contexts.miniapp.platform`。通常无需设置；当 Cocos 等引擎适配层导致自动识别错误时再指定。该选项不切换底层运行时 API。百度小程序使用 `swan`，没有单独的 `baidu` |
 
 ## 采样
 

--- a/website/guide/configuration.md
+++ b/website/guide/configuration.md
@@ -12,7 +12,7 @@
 | `release` | `string` | — | 版本号；**Source Map 解析的关键**，需与上传时的 release 完全一致 |
 | `environment` | `string` | — | 环境标识，如 `production` / `staging` |
 | `debug` | `boolean` | `false` | 开启 SDK 调试日志 |
-| `platform` | `'wechat'｜'alipay'｜'bytedance'｜'qq'｜'swan'｜'dingtalk'｜'kuaishou'` | 自动识别 | 事件的平台标记，同时写入顶层 `platform` 与 `contexts.miniapp.platform`。通常无需设置；当 Cocos 等引擎适配层导致自动识别错误时再指定。该选项不切换底层运行时 API。百度小程序使用 `swan`，没有单独的 `baidu` |
+| `platform` | `'wechat'｜'alipay'｜'bytedance'｜'qq'｜'swan'｜'dingtalk'｜'kuaishou'` | 自动识别 | 事件的平台标记，同时写入顶层 `platform` 与 `contexts.miniapp.platform`。通常无需设置；当运行时存在多个平台对象或识别结果不准确时再指定。该选项不切换底层运行时 API。百度小程序使用 `swan`，没有单独的 `baidu` |
 
 ## 采样
 

--- a/website/guide/minigame.md
+++ b/website/guide/minigame.md
@@ -23,7 +23,7 @@ Sentry.captureException(new Error('minigame sentry test'));
 
 ## 平台识别与游戏引擎
 
-SDK 默认通过 `wx`、`tt` 等宿主对象自动识别平台。如果抖音小游戏事件被识别为 `wechat`，可显式传入 `platform: 'bytedance'`，将事件的 `contexts.miniapp.platform` 标为 `bytedance`。底层异常监听和网络请求仍使用自动检测到的平台 API；详见[跨平台差异与降级](/guide/platform-compatibility#sdk-如何处理平台差异)。
+SDK 默认通过 `wx`、`tt` 等平台对象识别平台。多个对象共存时，还会结合宿主名称、`ttfile://` 数据路径和 `tt...` AppID 等平台专属信息自动判定抖音环境。如果宿主 API 不可用或未返回有效信息，仍可显式传入 `platform: 'bytedance'` 作为事件标记兜底；详见[跨平台差异与降级](/guide/platform-compatibility#sdk-如何处理平台差异)。
 
 ## 能捕获什么
 

--- a/website/guide/minigame.md
+++ b/website/guide/minigame.md
@@ -21,6 +21,10 @@ Sentry.captureException(new Error('minigame sentry test'));
 
 小游戏运行时会自动启用生命周期和帧率集成；普通小程序中默认关闭。通常不需要手动传 `integrations`。
 
+## 平台识别与游戏引擎
+
+SDK 默认通过 `wx`、`tt` 等宿主对象自动识别平台。Cocos 等引擎适配层可能让抖音小游戏首先被识别为 `wechat`；此时可显式传入 `platform: 'bytedance'`，将事件的 `contexts.miniapp.platform` 标为 `bytedance`。底层异常监听和网络请求仍沿用适配层提供的可用 API；详见[跨平台差异与降级](/guide/platform-compatibility#sdk-如何处理平台差异)。
+
 ## 能捕获什么
 
 | 能力 | 微信小游戏 | 抖音小游戏 | 说明 |

--- a/website/guide/minigame.md
+++ b/website/guide/minigame.md
@@ -23,7 +23,7 @@ Sentry.captureException(new Error('minigame sentry test'));
 
 ## 平台识别与游戏引擎
 
-SDK 默认通过 `wx`、`tt` 等宿主对象自动识别平台。Cocos 等引擎适配层可能让抖音小游戏首先被识别为 `wechat`；此时可显式传入 `platform: 'bytedance'`，将事件的 `contexts.miniapp.platform` 标为 `bytedance`。底层异常监听和网络请求仍沿用适配层提供的可用 API；详见[跨平台差异与降级](/guide/platform-compatibility#sdk-如何处理平台差异)。
+SDK 默认通过 `wx`、`tt` 等宿主对象自动识别平台。如果抖音小游戏事件被识别为 `wechat`，可显式传入 `platform: 'bytedance'`，将事件的 `contexts.miniapp.platform` 标为 `bytedance`。底层异常监听和网络请求仍使用自动检测到的平台 API；详见[跨平台差异与降级](/guide/platform-compatibility#sdk-如何处理平台差异)。
 
 ## 能捕获什么
 

--- a/website/guide/platform-compatibility.md
+++ b/website/guide/platform-compatibility.md
@@ -18,7 +18,18 @@ SDK 初始化时按当前运行时的全局对象识别平台，业务代码不�
 | 百度智能小程序 | `swan` | `swan` | `swan.request` |
 | 快手小程序 | `ks` | `kuaishou` | `ks.request` |
 
-识别完成后，SDK 的异常捕获、面包屑、transport、离线缓存等上层能力只面对统一接口。通常不应手动设置 `platform`；该选项只影响事件上的平台标记，不能把当前运行时转换成另一个平台。
+识别完成后，SDK 的异常捕获、面包屑、transport、离线缓存等上层能力只面对统一接口。通常无需手动设置 `platform`。
+
+Cocos 等游戏引擎的适配层可能暴露跨平台兼容对象，例如抖音小游戏运行时首先被识别为 `wx`。如果事件的平台标记不正确，可显式指定：
+
+```js
+Sentry.init({
+  dsn: 'YOUR_DSN',
+  platform: 'bytedance',
+});
+```
+
+显式配置会覆盖事件顶层 `platform` 与 `contexts.miniapp.platform`，但不会切换底层宿主对象。异常监听、网络和 Storage 等能力仍使用自动检测到的兼容 API，避免破坏引擎适配层原本可用的上报链路。如果需要让 Sentry 按 JavaScript 事件处理 Source Map，可继续在 `beforeSend` 中将顶层 `event.platform` 改为 `javascript`；`contexts.miniapp.platform` 仍会保留真实小游戏平台。
 
 ## 网络请求差异
 

--- a/website/guide/platform-compatibility.md
+++ b/website/guide/platform-compatibility.md
@@ -26,7 +26,7 @@ SDK 初始化时按当前运行时的全局对象识别平台，业务代码不�
 - `getEnvInfoSync()` 返回的 `ttfile://` 数据路径和 `tt...` AppID；
 - `getAccountInfoSync()` 或 `getLaunchOptionsSync()` 返回的平台 AppID。
 
-这些 API 不存在、调用失败或未返回明确平台信息时，SDK 才按上表顺序兼容回退。此时可显式指定事件的平台标记：
+这些 API 不存在、调用失败、未返回明确信息或不同对象的信号互相冲突时，SDK 会按上表顺序兼容回退。此时可显式指定事件的平台标记：
 
 ```js
 Sentry.init({
@@ -35,7 +35,7 @@ Sentry.init({
 });
 ```
 
-显式配置会覆盖事件顶层 `platform` 与 `contexts.miniapp.platform`，但不会切换底层宿主对象。异常监听、网络和 Storage 等能力仍使用自动检测到的平台 API，避免改变原本可用的上报链路。如果需要让 Sentry 按 JavaScript 事件处理 Source Map，可继续在 `beforeSend` 中将顶层 `event.platform` 改为 `javascript`；`contexts.miniapp.platform` 仍会保留真实小游戏平台。
+显式配置会作为事件顶层 `platform` 的默认值，并覆盖 `contexts.miniapp.platform`，但不会切换底层宿主对象。异常监听、网络和 Storage 等能力仍使用自动检测到的平台 API，避免改变原本可用的上报链路。如果需要让 Sentry 按 JavaScript 事件处理 Source Map，可继续在 `beforeSend` 中将顶层 `event.platform` 改为 `javascript`；`contexts.miniapp.platform` 仍会保留真实小游戏平台。
 
 ## 网络请求差异
 

--- a/website/guide/platform-compatibility.md
+++ b/website/guide/platform-compatibility.md
@@ -20,7 +20,13 @@ SDK 初始化时按当前运行时的全局对象识别平台，业务代码不�
 
 识别完成后，SDK 的异常捕获、面包屑、transport、离线缓存等上层能力只面对统一接口。通常无需手动设置 `platform`。
 
-SDK 按上表顺序使用首个检测到的平台对象。如果运行时同时存在多个平台对象，或者外部代码注入了其它平台对象，自动识别结果可能与实际发布平台不一致。此时可显式指定事件的平台标记：
+只有一个平台对象时，SDK 直接使用它。运行时同时存在多个平台对象时，SDK 会进一步读取同步宿主信息，以平台专属信号消除歧义：
+
+- 抖音 `getSystemInfoSync()` 返回的 `appName` / `hostName`；
+- `getEnvInfoSync()` 返回的 `ttfile://` 数据路径和 `tt...` AppID；
+- `getAccountInfoSync()` 或 `getLaunchOptionsSync()` 返回的平台 AppID。
+
+这些 API 不存在、调用失败或未返回明确平台信息时，SDK 才按上表顺序兼容回退。此时可显式指定事件的平台标记：
 
 ```js
 Sentry.init({

--- a/website/guide/platform-compatibility.md
+++ b/website/guide/platform-compatibility.md
@@ -20,7 +20,7 @@ SDK 初始化时按当前运行时的全局对象识别平台，业务代码不�
 
 识别完成后，SDK 的异常捕获、面包屑、transport、离线缓存等上层能力只面对统一接口。通常无需手动设置 `platform`。
 
-Cocos 等游戏引擎的适配层可能暴露跨平台兼容对象，例如抖音小游戏运行时首先被识别为 `wx`。如果事件的平台标记不正确，可显式指定：
+SDK 按上表顺序使用首个检测到的平台对象。如果运行时同时存在多个平台对象，或者外部代码注入了其它平台对象，自动识别结果可能与实际发布平台不一致。此时可显式指定事件的平台标记：
 
 ```js
 Sentry.init({
@@ -29,7 +29,7 @@ Sentry.init({
 });
 ```
 
-显式配置会覆盖事件顶层 `platform` 与 `contexts.miniapp.platform`，但不会切换底层宿主对象。异常监听、网络和 Storage 等能力仍使用自动检测到的兼容 API，避免破坏引擎适配层原本可用的上报链路。如果需要让 Sentry 按 JavaScript 事件处理 Source Map，可继续在 `beforeSend` 中将顶层 `event.platform` 改为 `javascript`；`contexts.miniapp.platform` 仍会保留真实小游戏平台。
+显式配置会覆盖事件顶层 `platform` 与 `contexts.miniapp.platform`，但不会切换底层宿主对象。异常监听、网络和 Storage 等能力仍使用自动检测到的平台 API，避免改变原本可用的上报链路。如果需要让 Sentry 按 JavaScript 事件处理 Source Map，可继续在 `beforeSend` 中将顶层 `event.platform` 改为 `javascript`；`contexts.miniapp.platform` 仍会保留真实小游戏平台。
 
 ## 网络请求差异
 


### PR DESCRIPTION
## 背景

平台检测此前采用固定 first-match 顺序：`wx → my → tt → ...`。当运行时同时存在多个平台对象时，只要 `wx` 存在就会直接识别为 `wechat`，不会再检查真实宿主信号；同时，显式传入的 `platform: "bytedance"` 也没有写入 `contexts.miniapp.platform`。

抖音官方文档明确：小游戏 API 由 `tt` 承载，`getSystemInfoSync()` 会返回宿主名称，`getEnvInfoSync()` 会返回环境 AppID 和 `ttfile://` 数据路径。PR 不再对 #288 中 `wx` 的具体注入来源作未经验证的归因。

## 修改内容

- 单一平台对象保持原有直接识别，避免增加普通接入成本
- 多个平台对象共存时，汇总宿主名称、平台数据路径和 AppID 等明确证据，仅在证据一致时自动选择同名平台对象
- 宿主 API 缺失、getter / 调用抛错、信息不足或信号冲突时保留历史顺序作为兼容回退
- 一次初始化共享同一份平台解析结果，保证 SDK 对象与平台标识始终配对
- 让显式 `platform` 作为事件顶层 `platform` 的默认值，并写入 `contexts.miniapp.platform`，作为无法自动消歧时的事件标记兜底
- 保留 `beforeSend` 将顶层平台改为 `javascript` 的 Source Map 使用方式
- 更新配置参考、小游戏指南、跨平台说明和 SDK Agent skill

## 验证

- `yarn run lint`
- `yarn run typecheck`
- `yarn run test --runInBand`（44 suites / 578 tests）
- `yarn run build`
- `yarn run docs:build`

Fixes #288