### PR TITLE
chore(release): 发布 1.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-miniapp",
-  "version": "1.17.4",
+  "version": "1.18.0",
   "description": "Sentry SDK for Mini Programs (WeChat, Alipay, ByteDance, Baidu, QQ, DingTalk, Kuaishou) & Taro / uni-app | 小程序监控 SDK，支持异常监控、性能监控、错误收集",
   "repository": {
     "type": "git",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
 // 版本号应该与 package.json 中的版本保持同步
-export const SDK_VERSION = '1.17.4';
+export const SDK_VERSION = '1.18.0';
 export const SDK_NAME = 'sentry.javascript.miniapp';


### PR DESCRIPTION
## 版本

发布 `sentry-miniapp@1.18.0`。

## 本次内容

- 修复多平台对象共存时固定优先命中 `wx` 的问题，结合宿主名称、数据路径和 AppID 自动识别，并支持 `platform` 正确覆盖 `contexts.miniapp.platform`
- 修复微信小游戏中 TryCatch 捕获后又触发平台 `onError` 导致的重复上报，同时解析平台字符串中的原始堆栈
- Source Map doctor / merge 工具支持按需诊断微信小游戏 `game.js` 两层映射，并避免把普通 Cocos 本地 map 误判为微信外层 map
- 补充小游戏平台识别与 Cocos Source Map 进阶排障文档

## 验证

- `yarn lint`
- `yarn typecheck`
- `yarn test --runInBand`（44 suites / 583 tests）
- `yarn build`
- `yarn docs:build`
- `npm pack --dry-run --json --ignore-scripts`（80 files）
- 版本一致性测试：`package.json` 与 `SDK_VERSION` 均为 `1.18.0`

## 兼容性

无 breaking change。普通单平台接入保持原有行为；新增自动消歧失败时仍按历史平台顺序回退。
