### PR TITLE
fix(transports): 避免上报请求占满业务并发

### DIFF
--- a/.agents/skills/sentry-miniapp-sdk/SKILL.md
+++ b/.agents/skills/sentry-miniapp-sdk/SKILL.md
@@ -256,7 +256,7 @@ Walk through features one at a time. Load the corresponding reference file:
 | `allowUrls` | `Array<string\|RegExp>` | — | Only send errors whose URL matches (others dropped) |
 | `denyUrls` | `Array<string\|RegExp>` | — | Drop errors whose URL matches |
 | `ignoreErrors` | `Array<string\|RegExp>` | — | Drop errors whose message/type matches |
-| `transportOptions` | `object` | — | Options forwarded to built-in transport; `headers` customizes envelope request headers |
+| `transportOptions` | `object` | see below | Built-in transport safeguards and headers |
 | `defaultIntegrations` | `false\|Integration[]` | built-in core integrations | Set `false` to skip core defaults; custom array replaces the core-default base |
 | `enableMinigameLifecycle` | `boolean` | minigame `true` / miniprogram `false` | Minigame cold-start + scene + show/hide breadcrumbs |
 | `enableMinigameFrameRate` | `boolean` | minigame `true` / miniprogram `false` | Minigame FPS / jank sampling (no-op in mini program) |
@@ -264,6 +264,8 @@ Walk through features one at a time. Load the corresponding reference file:
 | `beforeSendTransaction` | `function` | — | Hook to filter/modify transaction events before sending |
 | `beforeSendLog` | `function` | — | Hook to filter/modify logs before sending |
 | `beforeBreadcrumb` | `function` | — | Hook to filter/modify breadcrumbs before they are attached |
+
+The built-in transport defaults to `requestTimeout: 3000` and `maxConcurrentRequests: 2` so Sentry cannot occupy all mini program network slots when the service is unavailable. Additional envelopes wait in the bounded `@sentry/core` buffer. A timed-out request is aborted when the host returns an abortable request task, then handed to offline caching. Keep these defaults unless real-device testing shows a need to adjust them; `transportOptions.headers` remains available for custom envelope headers.
 
 ### Privacy Consent Gate
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -16,6 +16,12 @@ import type { MiniappTransportOptions } from './transports';
 import { SDK_NAME, SDK_VERSION } from './version';
 import { syncDebugIdsToCoreGlobal } from './debugIds';
 
+const clientsWithCustomTransport = new WeakSet<MiniappClient>();
+
+export function usesCustomTransport(client: MiniappClient): boolean {
+  return clientsWithCustomTransport.has(client);
+}
+
 /**
  * The Sentry Miniapp SDK Client.
  *
@@ -30,6 +36,8 @@ export class MiniappClient extends Client<any> {
    * @param options Configuration options for this SDK.
    */
   public constructor(options: MiniappOptions = {}) {
+    const usesCustomTransport = typeof options.transport === 'function';
+
     // 配置隐私合规「同意门禁」。必须在 super() 之前——transport 工厂在 super() 执行期间被 core
     // 调用建立，其 shouldSend / store 需读到已就绪的 consent 状态。configureConsent 是模块函数、
     // 不触碰 this，故在 super 前调用合法。requireConsent=false 时它把门禁置为「恒放行」，行为不变。
@@ -91,6 +99,10 @@ export class MiniappClient extends Client<any> {
         return baseTransport;
       },
     });
+
+    if (usesCustomTransport) {
+      clientsWithCustomTransport.add(this);
+    }
   }
 
   /**

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,8 +1,9 @@
 import { getClient, isEnabled } from '@sentry/core';
 import { isConsentGranted, isConsentRequired } from './consent';
 import { appName, isMiniappEnvironment, isMinigame } from './crossPlatform';
-import { MiniappClient } from './client';
+import { MiniappClient, usesCustomTransport } from './client';
 import { miniappStackParser } from './stacktrace';
+import { normalizeMaxConcurrentRequests, normalizeRequestTimeout } from './transports/xhr';
 import type {
   MiniappDiagnostics,
   MiniappDiagnosticsOptions,
@@ -17,8 +18,9 @@ export function getDiagnostics(): MiniappDiagnostics {
   const client = getClient();
   const isMiniappClient = client instanceof MiniappClient;
   const options = isMiniappClient ? (client.getOptions() as MiniappOptions) : null;
-  const transport = options ? buildTransportDiagnostics(options) : null;
-  const diagnosticsOptions = options ? buildOptionsDiagnostics(options) : null;
+  const customTransport = isMiniappClient ? usesCustomTransport(client) : false;
+  const transport = options ? buildTransportDiagnostics(options, customTransport) : null;
+  const diagnosticsOptions = options ? buildOptionsDiagnostics(options, customTransport) : null;
   const diagnostics: MiniappDiagnostics = {
     sdk: {
       name: SDK_NAME,
@@ -45,9 +47,11 @@ export function getDiagnostics(): MiniappDiagnostics {
   return diagnostics;
 }
 
-function buildOptionsDiagnostics(options: MiniappOptions): MiniappDiagnosticsOptions {
+function buildOptionsDiagnostics(
+  options: MiniappOptions,
+  customTransport: boolean,
+): MiniappDiagnosticsOptions {
   const dsn = normalizeDsn(options.dsn);
-  const customTransport = typeof options.transport === 'function';
   return {
     dsn,
     release: options.release ?? null,
@@ -83,13 +87,21 @@ function buildOptionsDiagnostics(options: MiniappOptions): MiniappDiagnosticsOpt
   };
 }
 
-function buildTransportDiagnostics(options: MiniappOptions): MiniappDiagnosticsTransport {
-  const customTransport = typeof options.transport === 'function';
+function buildTransportDiagnostics(
+  options: MiniappOptions,
+  customTransport: boolean,
+): MiniappDiagnosticsTransport {
   return {
     custom: customTransport,
     offlineCache:
       options.requireConsent === true || (!customTransport && options.enableOfflineCache !== false),
     consentGate: options.requireConsent === true,
+    requestTimeout: customTransport
+      ? null
+      : normalizeRequestTimeout(options.transportOptions?.requestTimeout),
+    maxConcurrentRequests: customTransport
+      ? null
+      : normalizeMaxConcurrentRequests(options.transportOptions?.maxConcurrentRequests),
   };
 }
 

--- a/src/transports/index.ts
+++ b/src/transports/index.ts
@@ -1,4 +1,8 @@
-export { createMiniappTransport } from './xhr';
+export {
+  createMiniappTransport,
+  DEFAULT_TRANSPORT_MAX_CONCURRENT_REQUESTS,
+  DEFAULT_TRANSPORT_REQUEST_TIMEOUT,
+} from './xhr';
 export type { MiniappTransportOptions } from './xhr';
 export { createMiniappOfflineStore } from './offlineStore';
 export type { MiniappOfflineStoreOptions, EvictionMode, DropReason } from './offlineStore';

--- a/src/transports/xhr.ts
+++ b/src/transports/xhr.ts
@@ -4,10 +4,47 @@ import { createTransport } from '@sentry/core';
 import { sdk } from '../crossPlatform';
 
 const SENTRY_ENVELOPE_CONTENT_TYPE = 'application/x-sentry-envelope';
+export const DEFAULT_TRANSPORT_REQUEST_TIMEOUT = 3000;
+export const DEFAULT_TRANSPORT_MAX_CONCURRENT_REQUESTS = 2;
 
 export interface MiniappTransportOptions extends BaseTransportOptions {
   /** Custom headers for the request */
   headers?: Record<string, string>;
+  /** Sentry envelope request timeout in milliseconds. Defaults to 3000. */
+  requestTimeout?: number;
+  /** Maximum number of Sentry requests using host network slots at once. Defaults to 2. */
+  maxConcurrentRequests?: number;
+}
+
+interface MiniappTransportRequest {
+  body: string | Uint8Array;
+  headers?: Record<string, string>;
+}
+
+interface MiniappRequestTask {
+  abort?: () => void;
+}
+
+export function normalizeRequestTimeout(timeout: number | undefined): number {
+  return typeof timeout === 'number' && isFinite(timeout) && timeout > 0
+    ? Math.max(1, Math.floor(timeout))
+    : DEFAULT_TRANSPORT_REQUEST_TIMEOUT;
+}
+
+export function normalizeMaxConcurrentRequests(maxConcurrentRequests: number | undefined): number {
+  return typeof maxConcurrentRequests === 'number' &&
+    isFinite(maxConcurrentRequests) &&
+    maxConcurrentRequests > 0
+    ? Math.max(1, Math.floor(maxConcurrentRequests))
+    : DEFAULT_TRANSPORT_MAX_CONCURRENT_REQUESTS;
+}
+
+function networkError(error: any): Error {
+  const message =
+    typeof error === 'string'
+      ? error
+      : error?.errMsg || error?.errorMessage || error?.message || 'Unknown error';
+  return new Error(`Network request failed: ${message}`);
 }
 
 /**
@@ -17,15 +54,41 @@ export function createMiniappTransport(options: MiniappTransportOptions): Transp
   // 保存 URL 到局部变量
   const transportUrl = options.url;
   const transportHeaders = options.headers || {};
+  const requestTimeout = normalizeRequestTimeout(options.requestTimeout);
+  const maxConcurrentRequests = normalizeMaxConcurrentRequests(options.maxConcurrentRequests);
+  const requestQueue: Array<{
+    request: MiniappTransportRequest;
+    resolve: (response: TransportMakeRequestResponse) => void;
+    reject: (error: unknown) => void;
+  }> = [];
+  let activeRequests = 0;
 
   /**
-   * Make a request using miniapp request API
+   * Execute a request using the miniapp request API.
    */
-  function makeRequest(request: {
-    body: string | Uint8Array;
-    headers?: Record<string, string>;
-  }): Promise<TransportMakeRequestResponse> {
+  function executeRequest(request: MiniappTransportRequest): Promise<TransportMakeRequestResponse> {
     return new Promise((resolve, reject) => {
+      let settled = false;
+      let requestTask: MiniappRequestTask | undefined;
+
+      const settle = (callback: () => void): void => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeoutTimer);
+        callback();
+      };
+
+      const timeoutTimer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        try {
+          requestTask?.abort?.();
+        } catch (_error) {
+          // 某些宿主的 RequestTask.abort 可能抛错；超时仍需立即释放 SDK Promise。
+        }
+        reject(new Error(`Sentry request timed out after ${requestTimeout}ms`));
+      }, requestTimeout);
+
       const requestOptions = {
         url: transportUrl,
         method: 'POST' as const,
@@ -41,37 +104,74 @@ export function createMiniappTransport(options: MiniappTransportOptions): Transp
           ...transportHeaders,
           ...request.headers,
         },
-        timeout: 10000,
+        timeout: requestTimeout,
         success: (res: any) => {
-          // Alipay uses `status` instead of `statusCode`, and `headers` instead of `header`
-          const status = res.statusCode || res.status;
-          const resHeaders = res.header || res.headers || {};
+          settle(() => {
+            // Alipay uses `status` instead of `statusCode`, and `headers` instead of `header`
+            const status = res.statusCode ?? res.status;
+            const resHeaders = res.header || res.headers || {};
 
-          resolve({
-            statusCode: status,
-            headers: {
-              'x-sentry-rate-limits': resHeaders['x-sentry-rate-limits'],
-              'retry-after': resHeaders['retry-after'],
-            },
+            resolve({
+              statusCode: status,
+              headers: {
+                'x-sentry-rate-limits': resHeaders['x-sentry-rate-limits'],
+                'retry-after': resHeaders['retry-after'],
+              },
+            });
           });
         },
         fail: (error: any) => {
-          reject(
-            new Error(
-              `Network request failed: ${error.errMsg || error.errorMessage || error.message || 'Unknown error'}`,
-            ),
-          );
+          settle(() => reject(networkError(error)));
         },
       };
 
       // Use the appropriate request method based on the platform
-      if (sdk().request) {
-        sdk().request?.(requestOptions);
-      } else if (sdk().httpRequest) {
-        sdk().httpRequest?.(requestOptions);
-      } else {
-        reject(new Error('No request method available in current miniapp environment'));
+      try {
+        const currentSdk = sdk();
+        if (currentSdk.request) {
+          requestTask = currentSdk.request(requestOptions) as MiniappRequestTask | undefined;
+        } else if (currentSdk.httpRequest) {
+          requestTask = currentSdk.httpRequest(requestOptions) as MiniappRequestTask | undefined;
+        } else {
+          settle(() =>
+            reject(new Error('No request method available in current miniapp environment')),
+          );
+        }
+      } catch (error) {
+        settle(() => reject(networkError(error)));
       }
+    });
+  }
+
+  function drainRequestQueue(): void {
+    while (activeRequests < maxConcurrentRequests && requestQueue.length > 0) {
+      const pending = requestQueue.shift();
+      if (!pending) return;
+
+      activeRequests += 1;
+      void executeRequest(pending.request).then(
+        (response) => {
+          activeRequests -= 1;
+          drainRequestQueue();
+          pending.resolve(response);
+        },
+        (error) => {
+          activeRequests -= 1;
+          drainRequestQueue();
+          pending.reject(error);
+        },
+      );
+    }
+  }
+
+  /**
+   * @sentry/core keeps a bounded envelope buffer, while this queue separately limits how many
+   * requests can occupy scarce miniapp network slots at the same time.
+   */
+  function makeRequest(request: MiniappTransportRequest): Promise<TransportMakeRequestResponse> {
+    return new Promise((resolve, reject) => {
+      requestQueue.push({ request, resolve, reject });
+      drainRequestQueue();
     });
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,7 +110,10 @@ export interface MiniappOptions {
   /** Transport function */
   transport?: (transportOptions: MiniappTransportOptions) => Transport;
 
-  /** Transport options forwarded to the miniapp transport factory */
+  /**
+   * Built-in transport options, including custom headers, request timeout (default 3000 ms),
+   * and maximum concurrent host requests (maxConcurrentRequests, default 2).
+   */
   transportOptions?: Partial<MiniappTransportOptions>;
 
   /** Before send hook */
@@ -289,6 +292,10 @@ export interface MiniappDiagnosticsTransport {
   custom: boolean;
   offlineCache: boolean;
   consentGate: boolean;
+  /** 内置 transport 的单次请求超时；自定义 transport 时为 null。 */
+  requestTimeout: number | null;
+  /** 内置 transport 允许同时占用宿主网络槽位的最大请求数；自定义 transport 时为 null。 */
+  maxConcurrentRequests: number | null;
 }
 
 /** `Sentry.getDiagnostics()` 识别出的潜在接入问题。 */

--- a/test/diagnostics.test.ts
+++ b/test/diagnostics.test.ts
@@ -45,9 +45,46 @@ describe('getDiagnostics', () => {
       propagateTraceparent: true,
       tracePropagationTargetsCount: 1,
     });
+    expect(diagnostics.transport).toMatchObject({
+      custom: false,
+      requestTimeout: 3000,
+      maxConcurrentRequests: 2,
+    });
     expect(JSON.stringify(diagnostics)).not.toContain('public@example');
     expect(diagnostics.integrations).toContain('NetworkBreadcrumbs');
     expect(diagnostics.warnings.map((warning) => warning.code)).not.toContain('missing_release');
+  });
+
+  it('reports custom built-in transport safeguards', () => {
+    init({
+      dsn: 'https://public@example.ingest.sentry.io/123',
+      transportOptions: {
+        requestTimeout: 1500,
+        maxConcurrentRequests: 1,
+      },
+    });
+
+    expect(getDiagnostics().transport).toMatchObject({
+      custom: false,
+      requestTimeout: 1500,
+      maxConcurrentRequests: 1,
+    });
+  });
+
+  it('does not report built-in safeguards for a custom transport', () => {
+    init({
+      dsn: 'https://public@example.ingest.sentry.io/123',
+      transport: () => ({
+        send: async () => ({}),
+        flush: async () => true,
+      }),
+    });
+
+    expect(getDiagnostics().transport).toMatchObject({
+      custom: true,
+      requestTimeout: null,
+      maxConcurrentRequests: null,
+    });
   });
 
   it('reports consent gate blocking and clears it after setConsent(true)', () => {
@@ -70,9 +107,7 @@ describe('getDiagnostics', () => {
 
     const afterConsent = getDiagnostics();
     expect(afterConsent.options?.consentGranted).toBe(true);
-    expect(afterConsent.warnings.map((warning) => warning.code)).not.toContain(
-      'consent_blocking',
-    );
+    expect(afterConsent.warnings.map((warning) => warning.code)).not.toContain('consent_blocking');
   });
 
   it('surfaces missing production options as warnings', () => {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -150,6 +150,7 @@ describe('Integration（真 @sentry/core 端到端）', () => {
       enableOfflineCache: false,
       integrations: [],
       transportOptions: {
+        requestTimeout: 1500,
         headers: {
           'Content-Type': 'application/x-sentry-envelope; charset=utf-8',
           'X-Gateway-Token': 'miniapp-token',
@@ -162,6 +163,7 @@ describe('Integration（真 @sentry/core 端到端）', () => {
 
     expect(mockRequest).toHaveBeenCalled();
     const callArgs = mockRequest.mock.calls[0]![0] as any;
+    expect(callArgs.timeout).toBe(1500);
     expect(callArgs.header).toMatchObject({
       'Content-Type': 'application/x-sentry-envelope; charset=utf-8',
       'X-Gateway-Token': 'miniapp-token',

--- a/test/offline.realcore.test.ts
+++ b/test/offline.realcore.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, jest, beforeEach, afterEach } from '@jest/globals';
 import { makeOfflineTransport } from '@sentry/core';
 import { createMiniappOfflineStore } from '../src/transports/offlineStore';
+import { createMiniappTransport } from '../src/transports/xhr';
 import { resetPlatformCache } from '../src/crossPlatform';
 
 /**
@@ -61,9 +62,32 @@ describe('离线缓存（真 makeOfflineTransport + 小程序 store）', () => {
     expect(mem[OFFLINE_KEY]).toContain('off-1');
   });
 
+  it('内置请求超时并 abort 后，envelope 落入小程序 storage', async () => {
+    const abort = jest.fn();
+    g.wx.request = jest.fn(() => ({ abort }));
+    resetPlatformCache();
+
+    const offline = makeOfflineTransport((options: any) =>
+      createMiniappTransport({ ...options, requestTimeout: 10 }),
+    )({
+      url: 'https://o0.ingest.sentry.io/api/0/envelope/',
+      recordDroppedEvent: () => {},
+      createStore: (o: any) => createMiniappOfflineStore(o),
+      flushAtStartup: false,
+    } as any);
+
+    await offline.send(makeEnvelope('timeout-1') as any);
+
+    expect(abort).toHaveBeenCalledTimes(1);
+    expect(mem[OFFLINE_KEY]).toBeDefined();
+    expect(mem[OFFLINE_KEY]).toContain('timeout-1');
+  });
+
   it('storage 中已有积压 → 恢复后经 makeOfflineTransport 取回重发', async () => {
     // 预置一条积压（新格式：{envelope, timestamp}[]）
-    mem[OFFLINE_KEY] = JSON.stringify([{ envelope: makeEnvelope('queued-1'), timestamp: 1640995200000 }]);
+    mem[OFFLINE_KEY] = JSON.stringify([
+      { envelope: makeEnvelope('queued-1'), timestamp: 1640995200000 },
+    ]);
 
     const sent: any[] = [];
     const baseSend = jest.fn((env: any) => {

--- a/test/transport.test.ts
+++ b/test/transport.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, beforeEach, jest } from '@jest/globals';
-import { createMiniappTransport } from '../src/transports/xhr';
+import {
+  createMiniappTransport,
+  DEFAULT_TRANSPORT_MAX_CONCURRENT_REQUESTS,
+  DEFAULT_TRANSPORT_REQUEST_TIMEOUT,
+} from '../src/transports/xhr';
 import { Envelope } from '@sentry/core';
 import { resetPlatformCache } from '../src/crossPlatform';
 
@@ -45,13 +49,161 @@ describe('Transport', () => {
         headers: {
           'Content-Type': SENTRY_ENVELOPE_CONTENT_TYPE,
         },
-        timeout: 10000,
+        timeout: DEFAULT_TRANSPORT_REQUEST_TIMEOUT,
         success: expect.any(Function),
         fail: expect.any(Function),
       });
 
       expect(response.statusCode).toBe(200);
       expect(response.headers).toBeDefined();
+    });
+
+    it('aborts a hanging request at the default timeout to release the network slot', async () => {
+      jest.useFakeTimers();
+      const abort = jest.fn();
+      const mockRequest = jest.fn(() => ({ abort }));
+      (global as any).wx = { request: mockRequest };
+      resetPlatformCache();
+
+      try {
+        const transport = createMiniappTransport({
+          url: 'https://sentry.io/api/123/envelope/',
+          recordDroppedEvent: () => {},
+        });
+        const envelope: Envelope = [
+          { event_id: 'timeout', sent_at: '2022-01-01T00:00:00.000Z' },
+          [[{ type: 'event' }, { message: 'timeout', event_id: 'timeout' }]],
+        ];
+
+        const rejection = expect(transport.send(envelope as any)).rejects.toThrow(
+          `Sentry request timed out after ${DEFAULT_TRANSPORT_REQUEST_TIMEOUT}ms`,
+        );
+        await jest.advanceTimersByTimeAsync(DEFAULT_TRANSPORT_REQUEST_TIMEOUT);
+
+        await rejection;
+        expect(abort).toHaveBeenCalledTimes(1);
+      } finally {
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
+      }
+    });
+
+    it('uses a custom request timeout and ignores the fail callback triggered by abort', async () => {
+      jest.useFakeTimers();
+      let requestOptions: any;
+      const abort = jest.fn(() => requestOptions.fail({ errMsg: 'request:fail abort' }));
+      const mockRequest = jest.fn((options) => {
+        requestOptions = options;
+        return { abort };
+      });
+      (global as any).wx = { request: mockRequest };
+      resetPlatformCache();
+
+      try {
+        const transport = createMiniappTransport({
+          url: 'https://sentry.io/api/123/envelope/',
+          recordDroppedEvent: () => {},
+          requestTimeout: 1200,
+        });
+        const envelope: Envelope = [
+          { event_id: 'custom-timeout', sent_at: '2022-01-01T00:00:00.000Z' },
+          [[{ type: 'event' }, { message: 'timeout', event_id: 'custom-timeout' }]],
+        ];
+
+        const rejection = expect(transport.send(envelope as any)).rejects.toThrow(
+          'Sentry request timed out after 1200ms',
+        );
+        expect(requestOptions.timeout).toBe(1200);
+        await jest.advanceTimersByTimeAsync(1200);
+
+        await rejection;
+        expect(abort).toHaveBeenCalledTimes(1);
+      } finally {
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
+      }
+    });
+
+    it('falls back to safe transport limits for invalid values', async () => {
+      const pendingRequests: any[] = [];
+      const mockRequest = jest.fn((options) => {
+        pendingRequests.push(options);
+        return { abort: jest.fn() };
+      });
+      (global as any).wx = { request: mockRequest };
+      resetPlatformCache();
+
+      const transport = createMiniappTransport({
+        url: 'https://sentry.io/api/123/envelope/',
+        recordDroppedEvent: () => {},
+        requestTimeout: 0,
+        maxConcurrentRequests: 0,
+      });
+      const makeEnvelope = (id: string): Envelope => [
+        { event_id: id, sent_at: '2022-01-01T00:00:00.000Z' },
+        [[{ type: 'event' }, { message: id, event_id: id }]],
+      ];
+
+      const active = Array.from({ length: DEFAULT_TRANSPORT_MAX_CONCURRENT_REQUESTS }, (_, index) =>
+        transport.send(makeEnvelope(`invalid-${index}`) as any),
+      );
+      const queued = transport.send(makeEnvelope('invalid-queued') as any);
+
+      expect(mockRequest).toHaveBeenCalledTimes(DEFAULT_TRANSPORT_MAX_CONCURRENT_REQUESTS);
+      expect(pendingRequests[0].timeout).toBe(DEFAULT_TRANSPORT_REQUEST_TIMEOUT);
+
+      pendingRequests[0].success({ statusCode: 200, header: {} });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(mockRequest).toHaveBeenCalledTimes(DEFAULT_TRANSPORT_MAX_CONCURRENT_REQUESTS + 1);
+
+      pendingRequests[1].success({ statusCode: 200, header: {} });
+      pendingRequests[2].success({ statusCode: 200, header: {} });
+      await Promise.all(active);
+      await queued;
+    });
+
+    it('queues envelopes while limiting requests that occupy host network slots', async () => {
+      const pendingRequests: any[] = [];
+      const mockRequest = jest.fn((options) => {
+        pendingRequests.push(options);
+        return { abort: jest.fn() };
+      });
+      (global as any).wx = { request: mockRequest };
+      resetPlatformCache();
+
+      const transport = createMiniappTransport({
+        url: 'https://sentry.io/api/123/envelope/',
+        recordDroppedEvent: () => {},
+      });
+      const makeEnvelope = (id: string): Envelope => [
+        { event_id: id, sent_at: '2022-01-01T00:00:00.000Z' },
+        [[{ type: 'event' }, { message: id, event_id: id }]],
+      ];
+
+      const active = Array.from({ length: DEFAULT_TRANSPORT_MAX_CONCURRENT_REQUESTS }, (_, index) =>
+        transport.send(makeEnvelope(`active-${index}`) as any),
+      );
+      let queuedSettled = false;
+      const queued = transport.send(makeEnvelope('queued') as any).then((response) => {
+        queuedSettled = true;
+        return response;
+      });
+
+      await Promise.resolve();
+      expect(mockRequest).toHaveBeenCalledTimes(DEFAULT_TRANSPORT_MAX_CONCURRENT_REQUESTS);
+      expect(queuedSettled).toBe(false);
+
+      pendingRequests[0].success({ statusCode: 200, header: {} });
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(mockRequest).toHaveBeenCalledTimes(DEFAULT_TRANSPORT_MAX_CONCURRENT_REQUESTS + 1);
+
+      pendingRequests[1].success({ statusCode: 200, header: {} });
+      pendingRequests[2].success({ statusCode: 200, header: {} });
+      await Promise.all(active);
+      await queued;
+      expect(queuedSettled).toBe(true);
     });
 
     it('should send envelope as newline-delimited text with Sentry envelope content type', async () => {
@@ -75,7 +227,10 @@ describe('Transport', () => {
         [
           [
             { type: 'event' },
-            { message: 'Windows WeChat should not JSON stringify this envelope', event_id: 'test-envelope-type' },
+            {
+              message: 'Windows WeChat should not JSON stringify this envelope',
+              event_id: 'test-envelope-type',
+            },
           ],
         ],
       ];
@@ -196,6 +351,12 @@ describe('Transport', () => {
     });
 
     it('should send envelope successfully', async () => {
+      const mockRequest = jest.fn((requestOptions: any) => {
+        requestOptions.success({ statusCode: 200, header: {} });
+      });
+      (global as any).wx = { request: mockRequest };
+      resetPlatformCache();
+
       const options = {
         url: 'https://sentry.io/api/123/store/',
         recordDroppedEvent: jest.fn(),
@@ -209,8 +370,8 @@ describe('Transport', () => {
         [[{ type: 'event' }, { message: 'test message', event_id: 'test-id' }]],
       ];
 
-      // Just test that the transport can be called without throwing
-      expect(() => transport.send(envelope)).not.toThrow();
+      await expect(transport.send(envelope)).resolves.toMatchObject({ statusCode: 200 });
+      expect(mockRequest).toHaveBeenCalledTimes(1);
     });
 
     it('should handle transport configuration', async () => {
@@ -310,6 +471,38 @@ describe('Transport', () => {
 
       expect(mockHttpRequest).toHaveBeenCalled();
       expect(response.statusCode).toBe(200);
+    });
+
+    it('aborts a hanging httpRequest after the configured timeout', async () => {
+      jest.useFakeTimers();
+      const abort = jest.fn();
+      const mockHttpRequest = jest.fn(() => ({ abort }));
+      (global as any).dd = { httpRequest: mockHttpRequest };
+      resetPlatformCache();
+
+      try {
+        const transport = createMiniappTransport({
+          url: 'https://sentry.io/api/123/store/',
+          recordDroppedEvent: () => {},
+          requestTimeout: 800,
+        });
+        const envelope: Envelope = [
+          { event_id: 'dingtalk-timeout', sent_at: '2022-01-01T00:00:00.000Z' },
+          [[{ type: 'event' }, { message: 'timeout', event_id: 'dingtalk-timeout' }]],
+        ];
+
+        const rejection = expect(transport.send(envelope as any)).rejects.toThrow(
+          'Sentry request timed out after 800ms',
+        );
+        await jest.advanceTimersByTimeAsync(800);
+
+        await rejection;
+        expect(mockHttpRequest).toHaveBeenCalledTimes(1);
+        expect(abort).toHaveBeenCalledTimes(1);
+      } finally {
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
+      }
     });
 
     it('should handle response with status instead of statusCode (Alipay style)', async () => {

--- a/website/guide/configuration.md
+++ b/website/guide/configuration.md
@@ -85,7 +85,7 @@ console.log(diagnostics.warnings);
 | `platform` | 当前检测到的平台、是否小程序环境、是否小游戏 |
 | `client` | 是否已初始化、当前 client 是否为 `MiniappClient` |
 | `options` | `release`、`environment`、采样、Source Map、Logs、consent、trace header 等配置摘要 |
-| `transport` | 是否自定义 transport、是否启用离线缓存、是否处于 consent 门禁 |
+| `transport` | 是否自定义 transport、离线缓存与 consent 门禁状态，以及内置上报超时 / 网络并发上限 |
 | `integrations` | 已装配的 integration 名称列表 |
 | `warnings` | SDK 识别出的潜在接入问题，如缺 `release`、tracing 未开启、consent 正在阻断上报 |
 
@@ -178,7 +178,7 @@ Sentry.setConsent(false);
 | `beforeSend` | `function` | — | 事件发送前的钩子，可修改或返回 `null` 丢弃 |
 | `beforeSendTransaction` | `function` | — | Transaction 事件发送前的钩子，可修改或返回 `null` 丢弃 |
 | `beforeBreadcrumb` | `function` | — | 面包屑记录前的钩子 |
-| `transportOptions` | `object` | — | 传给内置 transport 的选项；可用 `headers` 自定义 envelope 请求头 |
+| `transportOptions` | `object` | 见下 | 内置上报通道选项：请求头、超时和 Sentry 网络并发上限 |
 | `transport` | `function` | 内置 | 自定义传输层（高级用法） |
 
 > `allowUrls` / `denyUrls` / `ignoreErrors` 由内置的 `EventFilters` 集成实现，`init` 时自动装配（若你在 `integrations` 里已自带 `EventFilters` / `InboundFilters`，则不重复追加）。
@@ -187,12 +187,20 @@ Sentry.setConsent(false);
 Sentry.init({
   dsn: 'https://<key>@sentry.io/<project>',
   transportOptions: {
+    requestTimeout: 3000,
+    maxConcurrentRequests: 2,
     headers: {
       'Content-Type': 'application/x-sentry-envelope; charset=utf-8',
     },
   },
 });
 ```
+
+- `requestTimeout`：单次 Sentry 上报的超时时间（ms），默认 `3000`。超时后 SDK 会在宿主支持时调用 `RequestTask.abort()`，并把发送失败交给离线缓存处理。
+- `maxConcurrentRequests`：最多同时占用宿主网络槽位的 Sentry 请求数，默认 `2`。更多事件会先在 `@sentry/core` 的有界缓冲中等待，避免监控请求占满小程序网络并发、影响业务接口。
+- `headers`：附加到 envelope 请求的自定义请求头。
+
+通常不建议调大 `requestTimeout` 或 `maxConcurrentRequests`。自建 Sentry 服务响应较慢时，应先检查服务和网络链路；确需调整时，也要在真机上确认业务请求不受影响。
 
 ## 集成
 

--- a/website/guide/reliability-and-privacy.md
+++ b/website/guide/reliability-and-privacy.md
@@ -11,6 +11,24 @@
 
 它们复用平台 Storage 和离线 transport，但策略与上限可以分别配置。
 
+## 不让监控请求占满业务并发
+
+小程序宿主会限制同时进行的网络请求数。内置 transport 默认只允许最多 `2` 个 Sentry 请求同时在途，并把单次上报超时设为 `3000ms`：
+
+```js
+Sentry.init({
+  dsn: 'YOUR_DSN',
+  transportOptions: {
+    requestTimeout: 3000,
+    maxConcurrentRequests: 2,
+  },
+});
+```
+
+Sentry 服务不可达或长时间无响应时，SDK 除了把超时传给平台请求 API，还会启动自己的计时器；到时会主动调用宿主 `RequestTask.abort()`（宿主提供该能力时），尽快释放网络槽位。发送失败的事件随后进入离线缓存，等待网络恢复后重试。
+
+当已有 `2` 个 Sentry 请求未结束时，新事件会先在 `@sentry/core` 的有界缓冲中等待；只有缓冲也达到上限时才会记为 `queue_overflow` 并丢弃。这样既优先保障正常业务请求，也能承接短时间的 Sentry 上报峰值。可以通过 `transportOptions` 调整超时和网络并发，但通常应保持较短超时和较小并发。
+
 ## 弱网离线缓存
 
 默认配置已经适合大多数项目：


### PR DESCRIPTION
## 背景

小程序宿主的网络请求并发数有限。此前内置 transport 将 Sentry 上报超时固定为 10 秒；当 Sentry 服务不可达或长时间无响应时，监控请求可能持续占用网络槽位，影响正常业务请求。

## 改动

- 将内置 Sentry 请求默认超时缩短为 3 秒，并支持通过 `transportOptions.requestTimeout` 调整
- 同时使用宿主请求超时和 SDK 计时器；超时后在宿主支持时主动调用 `RequestTask.abort()`
- 新增独立网络调度队列，默认最多只让 2 个 Sentry 请求占用宿主网络槽位；其余 envelope 继续在 `@sentry/core` 有界缓冲中等待
- 支持通过 `transportOptions.maxConcurrentRequests` 调整网络并发
- 超时失败继续进入现有离线缓存，网络恢复后重试
- 在 `getDiagnostics()` 中展示生效的超时和网络并发配置，并修正内置 transport 被误判为自定义 transport 的诊断问题
- 更新官网配置、可靠上报说明和 SDK skill

## 验证

- `yarn lint`
- `yarn typecheck`
- `yarn test --runInBand`（44 suites / 590 tests）
- `yarn build`
- `yarn docs:build`

新增测试覆盖微信 `request`、钉钉 `httpRequest`、默认及自定义超时、主动 abort、网络并发排队、非法配置回退、离线缓存落盘和端到端配置透传。