### PR TITLE
chore(release): 1.18.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-miniapp",
-  "version": "1.18.0",
+  "version": "1.18.1",
   "description": "Sentry SDK for Mini Programs (WeChat, Alipay, ByteDance, Baidu, QQ, DingTalk, Kuaishou) & Taro / uni-app | 小程序监控 SDK，支持异常监控、性能监控、错误收集",
   "repository": {
     "type": "git",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
 // 版本号应该与 package.json 中的版本保持同步
-export const SDK_VERSION = '1.18.0';
+export const SDK_VERSION = '1.18.1';
 export const SDK_NAME = 'sentry.javascript.miniapp';


### PR DESCRIPTION
## 发布内容

发布 `sentry-miniapp@1.18.1`，包含 #295 的上报请求超时与网络并发保护：

- Sentry 请求默认超时由 10 秒缩短为 3 秒
- 超时后在宿主支持时主动 `abort()`，尽快释放网络槽位
- 默认最多 2 个 Sentry 请求同时占用宿主网络，其余事件在 `@sentry/core` 有界缓冲中等待
- 超时失败继续进入离线缓存，网络恢复后重试
- 新增 `requestTimeout`、`maxConcurrentRequests` 配置与诊断信息

## 发布前验证

- `yarn lint`
- `yarn typecheck`
- `yarn test --runInBand`（44 suites / 591 tests）
- `yarn build`
- `npm pack --dry-run --json`（80 files，约 813 KiB）

PR 合并后将创建并推送 `v1.18.1` tag，由发布 workflow 自动发布 npm 包并创建 GitHub Release。