### PR TITLE
chore(release): 准备 1.19.0-rc.0

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,6 +55,11 @@ jobs:
       run: |
         VERSION="${TAG_NAME#v}"
         PACKAGE_VERSION="$(node -p "require('./package.json').version")"
+        PUBLISH_TAG="latest"
+
+        if [[ "$VERSION" == *-* ]]; then
+          PUBLISH_TAG="next"
+        fi
 
         if [ "$PACKAGE_VERSION" != "$VERSION" ]; then
           echo "package.json version ($PACKAGE_VERSION) does not match tag ($TAG_NAME)"
@@ -64,13 +69,15 @@ jobs:
         if npm view "sentry-miniapp@$VERSION" version >/dev/null 2>&1; then
           echo "sentry-miniapp@$VERSION is already published; skipping npm publish."
         else
-          npm publish --access public --provenance
+          echo "Publishing sentry-miniapp@$VERSION with dist-tag $PUBLISH_TAG"
+          npm publish --access public --provenance --tag "$PUBLISH_TAG"
         fi
 
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v3
       with:
         generate_release_notes: true
+        prerelease: ${{ contains(github.ref_name, '-') }}
         fail_on_unmatched_files: true
         files: |
           dist/sentry-miniapp.umd.js

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-miniapp",
-  "version": "1.18.1",
+  "version": "1.19.0-rc.0",
   "description": "Sentry SDK for Mini Programs (WeChat, Alipay, ByteDance, Baidu, QQ, DingTalk, Kuaishou) & Taro / uni-app | 小程序监控 SDK，支持异常监控、性能监控、错误收集",
   "repository": {
     "type": "git",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
 // 版本号应该与 package.json 中的版本保持同步
-export const SDK_VERSION = '1.18.1';
+export const SDK_VERSION = '1.19.0-rc.0';
 export const SDK_NAME = 'sentry.javascript.miniapp';


### PR DESCRIPTION
## 变更

- 将 `package.json` 与运行时 `SDK_VERSION` 更新为 `1.19.0-rc.0`
- 预发布版本通过 npm `next` dist-tag 发布，稳定版本继续使用 `latest`
- 带连字符的版本 tag 自动创建为 GitHub prerelease
- 复用已经合入的 [1.19 升级指南](./docs/migration-1.19.md)

## 原因

1.19 对齐了 Sentry JavaScript SDK 的默认集成装配、事件字段、异常构建和追踪语义。先发布 RC 可以在正式版前验证真实小程序宿主；同时避免 RC 覆盖 npm `latest` 或被 GitHub 标记为稳定版本。

本 PR 只准备发版元数据和发布保护，不创建 tag，不发布 npm，也不创建 GitHub Release。

## 验证

- `yarn run lint`
- `yarn run typecheck`
- `yarn run test:coverage`（47 个测试文件、725 个测试）
- 覆盖率：Statements/Lines 98.81%，Branches 95.63%，Functions 99.15%
- `yarn run build`
- `yarn run build:miniapp`
- `yarn run docs:build`
- `npm pack --dry-run --ignore-scripts`（82 个文件，约 904 KB）
- 发布标签逻辑：`1.19.0-rc.0 → next`，`1.19.0 → latest`
