### PR TITLE
fix: 修复小游戏延迟 onError 重复上报

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -46,9 +46,9 @@ export function wrap(
     try {
       return fn.apply(this, args);
     } catch (ex) {
-      // 平台全局 onError 会在异常重新抛出后再次收到同一个错误。短暂屏蔽该回调，
-      // 与 Sentry Browser 的 TryCatch / GlobalHandlers 去重策略保持一致。
-      ignoreNextOnErrorCall();
+      // 平台全局 onError 会在异常重新抛出后再次收到同一个错误。记录错误指纹，
+      // 由 GlobalHandlers 在短时间内精确匹配并消费对应回调。
+      markErrorAsCaptured(ex);
 
       // 用 withScope 临时 fork 一个 scope：事件处理器只作用于本次 captureException，用完即弃。
       // 绝不能用 getCurrentScope().addEventProcessor——那会把处理器永久挂在当前 scope 上，给之后
@@ -121,26 +121,158 @@ export function wrap(
   return sentryWrapped;
 }
 
-/**
- * 是否忽略下一次 onError 事件
- */
-let ignoreNextOnError = 0;
+interface RecentCapturedError {
+  fingerprint: string;
+  capturedAt: number;
+}
 
-/**
- * 检查是否应忽略 onError
- */
-export function shouldIgnoreOnError(): boolean {
-  return ignoreNextOnError > 0;
+// 微信小游戏真机可能在主线程卡顿后延迟触发 onError。窗口只用于匹配同一错误，
+// 还会校验消息与首个有效堆栈位置，并在命中后立即消费。
+const ON_ERROR_DEDUPLICATION_WINDOW_MS = 1000;
+const MAX_RECENT_CAPTURED_ERRORS = 20;
+const recentCapturedErrors: RecentCapturedError[] = [];
+const V8_STACK_LOCATION_REGEX = /^\s*at\s+(?:(.*?)\s*\((.+):(\d+):(\d+)\)|(.+):(\d+):(\d+))\s*$/;
+const SAFARI_STACK_LOCATION_REGEX = /^\s*[^@]*@(.+):(\d+):(\d+)\s*$/;
+const ERROR_TYPE_PREFIX =
+  /^(?:Uncaught\s+)?(?:Error|Exception|[A-Za-z_$][\w.$]*(?:Error|Exception)):\s*/i;
+
+function normalizeErrorMessage(message: string): string {
+  return message.trim().replace(ERROR_TYPE_PREFIX, '').replace(/\s+/g, ' ');
+}
+
+function getPlatformErrorMessage(stack: string): string {
+  const lines = stack
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+  const typedMessage = lines.find(
+    (line) => ERROR_TYPE_PREFIX.test(line) && normalizeErrorMessage(line).length > 0,
+  );
+
+  if (typedMessage) {
+    return normalizeErrorMessage(typedMessage);
+  }
+
+  const message = lines.find(
+    (line) =>
+      line !== 'MiniProgramError' &&
+      !line.startsWith('at ') &&
+      !/^\s*[^@]*@.+:\d+(?::\d+)?\s*$/.test(line),
+  );
+  return message ? normalizeErrorMessage(message) : '';
+}
+
+function getErrorDetails(value: unknown): { message: string; stack: string } | undefined {
+  try {
+    if (typeof value === 'string') {
+      return { message: getPlatformErrorMessage(value), stack: value };
+    }
+    if (!value || typeof value !== 'object') {
+      return undefined;
+    }
+
+    const error = value as { message?: unknown; stack?: unknown };
+    const stack = typeof error.stack === 'string' ? error.stack : '';
+    const message =
+      typeof error.message === 'string'
+        ? normalizeErrorMessage(error.message)
+        : getPlatformErrorMessage(stack);
+    return { message, stack };
+  } catch (_error) {
+    return undefined;
+  }
+}
+
+function getFirstStackLocation(
+  stack: string,
+): { filename: string; lineno: string; colno: string } | undefined {
+  for (const line of stack.split('\n')) {
+    const v8Match = V8_STACK_LOCATION_REGEX.exec(line);
+    if (v8Match) {
+      return {
+        filename: (v8Match[2] || v8Match[5])!,
+        lineno: (v8Match[3] || v8Match[6])!,
+        colno: (v8Match[4] || v8Match[7])!,
+      };
+    }
+
+    const safariMatch = SAFARI_STACK_LOCATION_REGEX.exec(line);
+    if (safariMatch) {
+      return {
+        filename: safariMatch[1]!,
+        lineno: safariMatch[2]!,
+        colno: safariMatch[3]!,
+      };
+    }
+  }
+
+  return undefined;
+}
+
+function getErrorFingerprint(value: unknown): string | undefined {
+  const details = getErrorDetails(value);
+  if (!details?.message || !details.stack) {
+    return undefined;
+  }
+
+  const location = getFirstStackLocation(details.stack);
+  if (!location) {
+    return undefined;
+  }
+
+  const filename = location.filename
+    .replace(/\\/g, '/')
+    .replace(/^(?:app|file|webpack):\/+/, '')
+    .replace(/^\.\//, '')
+    .replace(/[?#].*$/, '');
+  return `${details.message}|${filename}:${location.lineno}:${location.colno}`;
+}
+
+function removeExpiredCapturedErrors(now: number): void {
+  for (let index = recentCapturedErrors.length - 1; index >= 0; index -= 1) {
+    if (now - recentCapturedErrors[index]!.capturedAt > ON_ERROR_DEDUPLICATION_WINDOW_MS) {
+      recentCapturedErrors.splice(index, 1);
+    }
+  }
 }
 
 /**
- * 忽略下一次 onError 调用
+ * 检查并消费与近期已捕获异常匹配的 onError
  */
-export function ignoreNextOnErrorCall(): void {
-  ignoreNextOnError += 1;
-  setTimeout(() => {
-    ignoreNextOnError -= 1;
-  });
+export function shouldIgnoreOnError(error: unknown): boolean {
+  const fingerprint = getErrorFingerprint(error);
+  if (!fingerprint) {
+    return false;
+  }
+
+  const now = Date.now();
+  removeExpiredCapturedErrors(now);
+  const matchIndex = recentCapturedErrors.findIndex(
+    (candidate) => candidate.fingerprint === fingerprint,
+  );
+  if (matchIndex === -1) {
+    return false;
+  }
+
+  recentCapturedErrors.splice(matchIndex, 1);
+  return true;
+}
+
+/**
+ * 记录一次已由 TryCatch 捕获、随后可能再次进入 onError 的异常
+ */
+export function markErrorAsCaptured(error: unknown): void {
+  const fingerprint = getErrorFingerprint(error);
+  if (!fingerprint) {
+    return;
+  }
+
+  const now = Date.now();
+  removeExpiredCapturedErrors(now);
+  recentCapturedErrors.push({ fingerprint, capturedAt: now });
+  if (recentCapturedErrors.length > MAX_RECENT_CAPTURED_ERRORS) {
+    recentCapturedErrors.splice(0, recentCapturedErrors.length - MAX_RECENT_CAPTURED_ERRORS);
+  }
 }
 
 /**

--- a/src/integrations/globalhandlers.ts
+++ b/src/integrations/globalhandlers.ts
@@ -108,7 +108,7 @@ export class GlobalHandlers implements Integration {
     if (sdk().onError) {
       this._errorHandler = (err: string | Error) => {
         if (this._client && getClient() !== this._client) return;
-        if (shouldIgnoreOnError()) {
+        if (shouldIgnoreOnError(err)) {
           return;
         }
 

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -16,7 +16,7 @@ export { getDiagnostics } from './diagnostics';
 
 import { MiniappClient, setConfiguredDefaultIntegrationsMode } from './client';
 import { appName, isMiniappEnvironment, isMinigame } from './crossPlatform';
-import { ignoreNextOnErrorCall } from './helpers';
+import { markErrorAsCaptured } from './helpers';
 import {
   GlobalHandlers,
   TryCatch,
@@ -241,7 +241,7 @@ export function wrap<T extends (...args: any[]) => any>(fn: T): T {
       try {
         return fn.apply(this, args);
       } catch (error) {
-        ignoreNextOnErrorCall();
+        markErrorAsCaptured(error);
         getCurrentScope().captureException(error);
         throw error;
       }

--- a/test/globalhandlers.realcore.test.ts
+++ b/test/globalhandlers.realcore.test.ts
@@ -105,9 +105,10 @@ describe('GlobalHandlers（真 @sentry/core 集成）', () => {
     onErrorHandler!(
       [
         'MiniProgramError',
-        "undefined is not an object (evaluating 'object.someProperty')",
-        "TypeError: undefined is not an object (evaluating 'object.someProperty')",
-        'at (subpackages/engine/game.js:12000:20)',
+        'Cannot read properties of undefined (reading someProperty)',
+        'TypeError: Cannot read properties of undefined (reading someProperty)',
+        'at o.OnInit (subpackages/engine/game.js:10555:48)',
+        'at s.InvokeInit (subpackages/engine/game.js:58020:2130)',
         'at (WAGameSubContext.js:1:200000)',
       ].join('\n'),
     );
@@ -120,8 +121,9 @@ describe('GlobalHandlers（真 @sentry/core 集成）', () => {
       expect.arrayContaining([
         expect.objectContaining({
           filename: 'app:///subpackages/engine/game.js',
-          lineno: 12000,
-          colno: 20,
+          function: 'o.OnInit',
+          lineno: 10555,
+          colno: 48,
         }),
       ]),
     );

--- a/test/globalhandlers.test.ts
+++ b/test/globalhandlers.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, vi, type Mock } from 'vitest';
 import { captureException, withScope } from '@sentry/core';
 import { GlobalHandlers, globalHandlersIntegration } from '../src/integrations/index';
-import { ignoreNextOnErrorCall } from '../src/helpers';
+import { markErrorAsCaptured } from '../src/helpers';
 
 // Mock @sentry/core
 vi.mock('@sentry/core', () => ({
@@ -113,21 +113,26 @@ describe('GlobalHandlers', () => {
     });
 
     it('should ignore the global callback after a wrapped handler captured the error', () => {
-      vi.useFakeTimers();
+      const integration = new GlobalHandlers();
+      integration.setupOnce();
+      const handler = mockSdk.onError.mock.calls[0][0];
+      const error = new TypeError('duplicate platform error');
+      error.stack = [
+        'TypeError: duplicate platform error',
+        'at o.OnInit (engine/game.js:10555:48)',
+      ].join('\n');
 
-      try {
-        const integration = new GlobalHandlers();
-        integration.setupOnce();
-        const handler = mockSdk.onError.mock.calls[0][0];
+      markErrorAsCaptured(error);
+      handler(
+        [
+          'MiniProgramError',
+          'duplicate platform error',
+          'TypeError: duplicate platform error',
+          'at o.OnInit (engine/game.js:10555:48)',
+        ].join('\n'),
+      );
 
-        ignoreNextOnErrorCall();
-        handler('duplicate platform error');
-
-        expect(captureException).not.toHaveBeenCalled();
-      } finally {
-        vi.runOnlyPendingTimers();
-        vi.useRealTimers();
-      }
+      expect(captureException).not.toHaveBeenCalled();
     });
 
     it('should capture Error objects', () => {

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -3,7 +3,7 @@ import {
   wrap,
   fill,
   shouldIgnoreOnError,
-  ignoreNextOnErrorCall,
+  markErrorAsCaptured,
   getFunctionName,
 } from '../src/helpers';
 
@@ -388,47 +388,123 @@ describe('Helpers', () => {
   });
 
   describe('shouldIgnoreOnError', () => {
+    const createError = (message: string, location = 'engine/game.js:10555:48'): Error => {
+      const error = new TypeError(message);
+      error.stack = [`TypeError: ${message}`, `at o.OnInit (${location})`].join('\n');
+      return error;
+    };
+
+    const createPlatformError = (
+      message: string,
+      location = 'engine/game.js:10555:48',
+    ): string =>
+      [
+        'MiniProgramError',
+        message,
+        `TypeError: ${message}`,
+        `at o.OnInit (${location})`,
+      ].join('\n');
+
     it('should return false by default', () => {
-      expect(shouldIgnoreOnError()).toBe(false);
+      expect(shouldIgnoreOnError(createPlatformError('not captured'))).toBe(false);
     });
 
-    it('should return true after ignoreNextOnErrorCall', () => {
-      vi.useFakeTimers();
+    it('should consume a matching platform error once', () => {
+      const message = 'matching captured error';
+      markErrorAsCaptured(createError(message));
+
+      expect(shouldIgnoreOnError(createPlatformError(message))).toBe(true);
+      expect(shouldIgnoreOnError(createPlatformError(message))).toBe(false);
+    });
+
+    it('should normalize the generic Error prefix from platform strings', () => {
+      const message = 'generic matching error';
+      const error = new Error(message);
+      error.stack = [`Error: ${message}`, 'at o.OnInit (engine/game.js:10555:48)'].join('\n');
+      markErrorAsCaptured(error);
+
+      expect(
+        shouldIgnoreOnError(
+          [
+            'MiniProgramError',
+            message,
+            `Error: ${message}`,
+            'at o.OnInit (engine/game.js:10555:48)',
+          ].join('\n'),
+        ),
+      ).toBe(true);
+    });
+
+    it('should match Safari-style stack locations', () => {
+      const message = 'safari matching error';
+      const error = new Error(message);
+      error.stack = [`Error: ${message}`, 'o.OnInit@engine/game.js:10555:48'].join('\n');
+      markErrorAsCaptured(error);
+
+      expect(
+        shouldIgnoreOnError(
+          [
+            'MiniProgramError',
+            `Error: ${message}`,
+            'o.OnInit@engine/game.js:10555:48',
+          ].join('\n'),
+        ),
+      ).toBe(true);
+    });
+
+    it('should cover a delayed platform callback within the fingerprint window', () => {
+      let now = 1000;
+      const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now);
+      const message = 'delayed captured error';
 
       try {
-        ignoreNextOnErrorCall();
-        expect(shouldIgnoreOnError()).toBe(true);
+        markErrorAsCaptured(createError(message));
+        now += 303;
+
+        expect(shouldIgnoreOnError(createPlatformError(message))).toBe(true);
       } finally {
-        vi.runOnlyPendingTimers();
-        vi.useRealTimers();
+        nowSpy.mockRestore();
       }
     });
 
-    it('should return false after timeout', async () => {
-      vi.useFakeTimers();
+    it('should not consume an expired captured error', () => {
+      let now = 1000;
+      const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now);
+      const message = 'expired captured error';
 
       try {
-        ignoreNextOnErrorCall();
-        expect(shouldIgnoreOnError()).toBe(true);
+        markErrorAsCaptured(createError(message));
+        now += 1001;
 
-        await vi.advanceTimersByTimeAsync(10);
-        expect(shouldIgnoreOnError()).toBe(false);
+        expect(shouldIgnoreOnError(createPlatformError(message))).toBe(false);
       } finally {
-        vi.useRealTimers();
+        nowSpy.mockRestore();
       }
     });
 
-    it('should handle multiple calls', () => {
-      vi.useFakeTimers();
+    it('should require the first stack location to match', () => {
+      const message = 'same message at another location';
+      markErrorAsCaptured(createError(message));
 
-      try {
-        ignoreNextOnErrorCall();
-        ignoreNextOnErrorCall();
-        expect(shouldIgnoreOnError()).toBe(true);
-      } finally {
-        vi.runOnlyPendingTimers();
-        vi.useRealTimers();
-      }
+      expect(
+        shouldIgnoreOnError(createPlatformError(message, 'engine/game.js:58020:2130')),
+      ).toBe(false);
+      expect(shouldIgnoreOnError(createPlatformError(message))).toBe(true);
+    });
+
+    it('should consume multiple identical captured errors one by one', () => {
+      const message = 'repeated captured error';
+      markErrorAsCaptured(createError(message));
+      markErrorAsCaptured(createError(message));
+
+      expect(shouldIgnoreOnError(createPlatformError(message))).toBe(true);
+      expect(shouldIgnoreOnError(createPlatformError(message))).toBe(true);
+      expect(shouldIgnoreOnError(createPlatformError(message))).toBe(false);
+    });
+
+    it('should not suppress errors without a comparable stack location', () => {
+      markErrorAsCaptured('missing platform stack');
+      expect(shouldIgnoreOnError('missing platform stack')).toBe(false);
     });
   });
 

--- a/test/sdk.test.ts
+++ b/test/sdk.test.ts
@@ -588,24 +588,16 @@ describe('SDK', () => {
     });
 
     it('should capture exceptions and re-throw', () => {
-      vi.useFakeTimers();
+      init({ dsn: 'https://test@sentry.io/123' });
+      const error = new Error('Test wrap error');
+      const fn = () => {
+        throw error;
+      };
+      const wrapped = wrap(fn);
 
-      try {
-        init({ dsn: 'https://test@sentry.io/123' });
-        const error = new Error('Test wrap error');
-        const fn = () => {
-          throw error;
-        };
-        const wrapped = wrap(fn);
-
-        expect(() => wrapped()).toThrow('Test wrap error');
-        expect(shouldIgnoreOnError()).toBe(true);
-      } finally {
-        vi.runOnlyPendingTimers();
-        vi.useRealTimers();
-      }
-
-      expect(shouldIgnoreOnError()).toBe(false);
+      expect(() => wrapped()).toThrow('Test wrap error');
+      expect(shouldIgnoreOnError(error)).toBe(true);
+      expect(shouldIgnoreOnError(error)).toBe(false);
     });
 
     it('should preserve this context', () => {

--- a/test/stacktrace.test.ts
+++ b/test/stacktrace.test.ts
@@ -52,6 +52,25 @@ describe('miniappStackParser', () => {
       expect(crashFrame!.in_app).toBe(true);
     });
 
+    it('should parse Cocos WeChat minigame frames with minified function names', () => {
+      const stack = [
+        'MiniProgramError',
+        'Cannot read properties of undefined (reading someProperty)',
+        'TypeError: Cannot read properties of undefined (reading someProperty)',
+        'at o.OnInit (engine/game.js:10555:48)',
+        'at s.InvokeInit (engine/game.js:58020:2130)',
+      ].join('\n');
+
+      const frames = miniappStackParser(stack, 0);
+      expect(frames).toHaveLength(2);
+      expect(frames[1]).toMatchObject({
+        filename: 'engine/game.js',
+        function: 'o.OnInit',
+        lineno: 10555,
+        colno: 48,
+      });
+    });
+
     it('should parse WeChat appservice frames', () => {
       const stack = [
         'Error: something went wrong',

--- a/test/trycatch.realcore.test.ts
+++ b/test/trycatch.realcore.test.ts
@@ -102,7 +102,7 @@ describe('TryCatch（真 @sentry/core 集成）', () => {
     expect(Array.isArray(errEvent.extra?.arguments)).toBe(true);
   });
 
-  it('requestAnimationFrame 抛错后平台 onError 不会重复上报', async () => {
+  it('requestAnimationFrame 抛错 303ms 后平台 onError 仍不会重复上报', async () => {
     g.requestAnimationFrame = (callback: () => void) => callback();
 
     init({
@@ -119,18 +119,36 @@ describe('TryCatch（真 @sentry/core 集成）', () => {
       }),
     } as any);
 
-    expect(() => {
-      g.requestAnimationFrame(() => {
-        throw new TypeError('duplicate raf boom');
-      });
-    }).toThrow('duplicate raf boom');
+    let now = Date.now();
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now);
+    const error = new TypeError('duplicate raf boom');
+    error.stack = [
+      'TypeError: duplicate raf boom',
+      'at o.OnInit (engine/game.js:10555:48)',
+      'at s.InvokeInit (engine/game.js:58020:2130)',
+    ].join('\n');
 
-    // 微信会在重新抛出后以字符串形式触发 onError；这条回调应被短暂屏蔽。
-    onErrorHandler!(
-      ['MiniProgramError', 'TypeError: duplicate raf boom', 'at (engine/game.js:12000:20)'].join(
-        '\n',
-      ),
-    );
+    try {
+      expect(() => {
+        g.requestAnimationFrame(() => {
+          throw error;
+        });
+      }).toThrow('duplicate raf boom');
+
+      // 微信真机在卡顿后可能延迟到后续任务才触发 onError。
+      now += 303;
+      onErrorHandler!(
+        [
+          'MiniProgramError',
+          'duplicate raf boom',
+          'TypeError: duplicate raf boom',
+          'at o.OnInit (engine/game.js:10555:48)',
+          'at s.InvokeInit (engine/game.js:58020:2130)',
+        ].join('\n'),
+      );
+    } finally {
+      nowSpy.mockRestore();
+    }
     await flush(2000);
 
     const events = collectEvents(captured).filter((event) =>


### PR DESCRIPTION
## 背景

关联 #286。

微信小游戏真机在主线程卡顿时，`TryCatch` 重新抛出的异常可能延迟约 303ms 才进入 `wx.onError`。原实现用 `setTimeout(..., 0)` 清除全局计数器，因此回调跨任务到达后会再次上报。

## 改动

- 将“下一轮 timer”计数器改为 1 秒内的近期错误指纹队列
- 指纹同时匹配标准化错误消息和首个有效文件、行号、列号
- 匹配项只消费一次；不同堆栈位置、过期回调或无法可靠比对的错误继续正常上报
- 队列最多保留 20 项，避免常驻增长
- 补充 303ms 延迟回调、单次消费、过期、不同位置、Safari 堆栈等回归测试
- 使用真实 `@sentry/core` 验证 Cocos 格式 `at o.OnInit (...)` 可生成结构化 frames

当前 `master` 已通过官方 `eventFromUnknownInput` 路径构建异常事件，因此 #286 中反馈的带函数名 Cocos 堆栈可正常结构化；本 PR 主要补齐真机延迟导致的去重缺口。

## 验证

- `yarn lint`
- `yarn typecheck`
- `yarn test:coverage`：47 个测试文件、731 个测试通过，覆盖率 98.65%
- `yarn build`：ESM / CJS / UMD 构建及兼容性检查通过
