### PR TITLE
chore(release): 发布 1.19.0-rc.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-miniapp",
-  "version": "1.19.0-rc.0",
+  "version": "1.19.0-rc.1",
   "description": "Sentry SDK for Mini Programs (WeChat, Alipay, ByteDance, Baidu, QQ, DingTalk, Kuaishou) & Taro / uni-app | 小程序监控 SDK，支持异常监控、性能监控、错误收集",
   "repository": {
     "type": "git",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
 // 版本号应该与 package.json 中的版本保持同步
-export const SDK_VERSION = '1.19.0-rc.0';
+export const SDK_VERSION = '1.19.0-rc.1';
 export const SDK_NAME = 'sentry.javascript.miniapp';


### PR DESCRIPTION
## 发布版本

`1.19.0-rc.1`

## 发布内容

- 包含 #304：修复微信小游戏真机延迟触发 `wx.onError` 时，同一异常重复上报的问题
- 使用短时间错误指纹匹配，避免扩大通用 Dedupe 规则或误吞独立异常
- 验证 Cocos 带函数名的微信小游戏堆栈可生成结构化 frames

本版本继续发布到 npm `next`，用于 #286 作者在 Android 真机上复验；验证通过后再发布正式版 `1.19.0`。

## 版本文件

- `package.json`：`1.19.0-rc.1`
- `src/version.ts`：`1.19.0-rc.1`
- 本地 tag：`v1.19.0-rc.1`，待本 PR 使用 merge commit 合入后推送

## 验证

- `yarn lint`
- `yarn typecheck`
- `yarn test`：47 个测试文件、731 个测试通过
- `yarn build`：ESM / CJS / UMD 构建及兼容性检查通过

合并方式：**merge commit**，不要 squash，确保 release commit 和 tag 进入 `master` 历史。
