### PR TITLE
fix: 修复宿主改写堆栈后的重复上报

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -46,7 +46,7 @@ export function wrap(
     try {
       return fn.apply(this, args);
     } catch (ex) {
-      // 平台全局 onError 会在异常重新抛出后再次收到同一个错误。记录错误指纹，
+      // 平台全局 onError 会在异常重新抛出后再次收到同一个错误。记录错误特征，
       // 由 GlobalHandlers 在短时间内精确匹配并消费对应回调。
       markErrorAsCaptured(ex);
 
@@ -121,20 +121,26 @@ export function wrap(
   return sentryWrapped;
 }
 
+interface ErrorSignature {
+  message: string;
+  type?: string;
+  location?: string;
+}
+
 interface RecentCapturedError {
-  fingerprint: string;
+  signature: ErrorSignature;
   capturedAt: number;
 }
 
 // 微信小游戏真机可能在主线程卡顿后延迟触发 onError。窗口只用于匹配同一错误，
-// 还会校验消息与首个有效堆栈位置，并在命中后立即消费。
+// 优先校验首个有效堆栈位置；宿主改写堆栈时退回到错误类型与消息，并在命中后立即消费。
 const ON_ERROR_DEDUPLICATION_WINDOW_MS = 1000;
 const MAX_RECENT_CAPTURED_ERRORS = 20;
 const recentCapturedErrors: RecentCapturedError[] = [];
 const V8_STACK_LOCATION_REGEX = /^\s*at\s+(?:(.*?)\s*\((.+):(\d+):(\d+)\)|(.+):(\d+):(\d+))\s*$/;
 const SAFARI_STACK_LOCATION_REGEX = /^\s*[^@]*@(.+):(\d+):(\d+)\s*$/;
 const ERROR_TYPE_PREFIX =
-  /^(?:Uncaught\s+)?(?:Error|Exception|[A-Za-z_$][\w.$]*(?:Error|Exception)):\s*/i;
+  /^(?:Uncaught\s+)?(Error|Exception|[A-Za-z_$][\w.$]*(?:Error|Exception)):\s*/i;
 
 function normalizeErrorMessage(message: string): string {
   return message.trim().replace(ERROR_TYPE_PREFIX, '').replace(/\s+/g, ' ');
@@ -162,10 +168,26 @@ function getPlatformErrorMessage(stack: string): string {
   return message ? normalizeErrorMessage(message) : '';
 }
 
-function getErrorDetails(value: unknown): { message: string; stack: string } | undefined {
+function getPlatformErrorType(stack: string): string | undefined {
+  for (const line of stack.split('\n')) {
+    const match = ERROR_TYPE_PREFIX.exec(line.trim());
+    if (match?.[1]) {
+      return match[1].toLowerCase();
+    }
+  }
+
+  return undefined;
+}
+
+function getErrorDetails(
+  value: unknown,
+): { message: string; stack: string; type?: string } | undefined {
   try {
     if (typeof value === 'string') {
-      return { message: getPlatformErrorMessage(value), stack: value };
+      const type = getPlatformErrorType(value);
+      return type
+        ? { message: getPlatformErrorMessage(value), stack: value, type }
+        : { message: getPlatformErrorMessage(value), stack: value };
     }
     if (!value || typeof value !== 'object') {
       return undefined;
@@ -177,7 +199,11 @@ function getErrorDetails(value: unknown): { message: string; stack: string } | u
       typeof error.message === 'string'
         ? normalizeErrorMessage(error.message)
         : getPlatformErrorMessage(stack);
-    return { message, stack };
+    const type =
+      'name' in error && typeof error.name === 'string' && error.name
+        ? error.name.toLowerCase()
+        : getPlatformErrorType(stack);
+    return type ? { message, stack, type } : { message, stack };
   } catch (_error) {
     return undefined;
   }
@@ -209,15 +235,17 @@ function getFirstStackLocation(
   return undefined;
 }
 
-function getErrorFingerprint(value: unknown): string | undefined {
+function getErrorSignature(value: unknown): ErrorSignature | undefined {
   const details = getErrorDetails(value);
-  if (!details?.message || !details.stack) {
+  if (!details?.message) {
     return undefined;
   }
 
   const location = getFirstStackLocation(details.stack);
   if (!location) {
-    return undefined;
+    return details.type
+      ? { message: details.message, type: details.type }
+      : { message: details.message };
   }
 
   const filename = location.filename
@@ -225,7 +253,11 @@ function getErrorFingerprint(value: unknown): string | undefined {
     .replace(/^(?:app|file|webpack):\/+/, '')
     .replace(/^\.\//, '')
     .replace(/[?#].*$/, '');
-  return `${details.message}|${filename}:${location.lineno}:${location.colno}`;
+  return {
+    message: details.message,
+    ...(details.type ? { type: details.type } : {}),
+    location: `${filename}:${location.lineno}:${location.colno}`,
+  };
 }
 
 function removeExpiredCapturedErrors(now: number): void {
@@ -240,16 +272,26 @@ function removeExpiredCapturedErrors(now: number): void {
  * 检查并消费与近期已捕获异常匹配的 onError
  */
 export function shouldIgnoreOnError(error: unknown): boolean {
-  const fingerprint = getErrorFingerprint(error);
-  if (!fingerprint) {
+  const signature = getErrorSignature(error);
+  if (!signature || (!signature.location && !signature.type)) {
     return false;
   }
 
   const now = Date.now();
   removeExpiredCapturedErrors(now);
-  const matchIndex = recentCapturedErrors.findIndex(
-    (candidate) => candidate.fingerprint === fingerprint,
-  );
+  const matchIndex = recentCapturedErrors.findIndex((candidate) => {
+    if (candidate.signature.message !== signature.message) {
+      return false;
+    }
+
+    const sameLocation =
+      !!candidate.signature.location &&
+      !!signature.location &&
+      candidate.signature.location === signature.location;
+    const sameType =
+      !!candidate.signature.type && !!signature.type && candidate.signature.type === signature.type;
+    return sameLocation || sameType;
+  });
   if (matchIndex === -1) {
     return false;
   }
@@ -262,14 +304,14 @@ export function shouldIgnoreOnError(error: unknown): boolean {
  * 记录一次已由 TryCatch 捕获、随后可能再次进入 onError 的异常
  */
 export function markErrorAsCaptured(error: unknown): void {
-  const fingerprint = getErrorFingerprint(error);
-  if (!fingerprint) {
+  const signature = getErrorSignature(error);
+  if (!signature || (!signature.location && !signature.type)) {
     return;
   }
 
   const now = Date.now();
   removeExpiredCapturedErrors(now);
-  recentCapturedErrors.push({ fingerprint, capturedAt: now });
+  recentCapturedErrors.push({ signature, capturedAt: now });
   if (recentCapturedErrors.length > MAX_RECENT_CAPTURED_ERRORS) {
     recentCapturedErrors.splice(0, recentCapturedErrors.length - MAX_RECENT_CAPTURED_ERRORS);
   }

--- a/test/globalhandlers.test.ts
+++ b/test/globalhandlers.test.ts
@@ -135,6 +135,29 @@ describe('GlobalHandlers', () => {
       expect(captureException).not.toHaveBeenCalled();
     });
 
+    it('should ignore a delayed callback when the host replaces the business stack', () => {
+      const integration = new GlobalHandlers();
+      integration.setupOnce();
+      const handler = mockSdk.onError.mock.calls[0][0];
+      const error = new TypeError('host-wrapped platform error');
+      error.stack = [
+        'TypeError: host-wrapped platform error',
+        'at o.OnInit (engine/game.js:10555:48)',
+      ].join('\n');
+
+      markErrorAsCaptured(error);
+      handler(
+        [
+          'MiniProgramError',
+          'TypeError: host-wrapped platform error',
+          'at sentryWrapped (sentry-miniapp.js:100:20)',
+          'at dispatchError (WAGameSubContext.js:1:200000)',
+        ].join('\n'),
+      );
+
+      expect(captureException).not.toHaveBeenCalled();
+    });
+
     it('should capture Error objects', () => {
       const integration = new GlobalHandlers();
       integration.setupOnce();

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -482,14 +482,41 @@ describe('Helpers', () => {
       }
     });
 
-    it('should require the first stack location to match', () => {
-      const message = 'same message at another location';
+    it('should not match another error type at a different location', () => {
+      const message = 'same message from another error type';
       markErrorAsCaptured(createError(message));
 
       expect(
-        shouldIgnoreOnError(createPlatformError(message, 'engine/game.js:58020:2130')),
+        shouldIgnoreOnError(
+          [
+            'MiniProgramError',
+            message,
+            `RangeError: ${message}`,
+            'at o.OnInit (engine/game.js:58020:2130)',
+          ].join('\n'),
+        ),
       ).toBe(false);
       expect(shouldIgnoreOnError(createPlatformError(message))).toBe(true);
+    });
+
+    it('should match the same error type and message when host wrapping changes the stack', () => {
+      const message = 'host-wrapped error';
+      markErrorAsCaptured(createError(message));
+
+      expect(
+        shouldIgnoreOnError(
+          createPlatformError(message, 'WAGameSubContext.js:1:200000'),
+        ),
+      ).toBe(true);
+    });
+
+    it('should use the error type when neither stack has a comparable location', () => {
+      const message = 'type-only matching error';
+      const error = new TypeError(message);
+      error.stack = `TypeError: ${message}`;
+      markErrorAsCaptured(error);
+
+      expect(shouldIgnoreOnError(`MiniProgramError\nTypeError: ${message}`)).toBe(true);
     });
 
     it('should consume multiple identical captured errors one by one', () => {

--- a/test/trycatch.realcore.test.ts
+++ b/test/trycatch.realcore.test.ts
@@ -102,7 +102,7 @@ describe('TryCatch（真 @sentry/core 集成）', () => {
     expect(Array.isArray(errEvent.extra?.arguments)).toBe(true);
   });
 
-  it('requestAnimationFrame 抛错 303ms 后平台 onError 仍不会重复上报', async () => {
+  it('requestAnimationFrame 抛错 307ms 后即使宿主栈变化也不会重复上报', async () => {
     g.requestAnimationFrame = (callback: () => void) => callback();
 
     init({
@@ -135,15 +135,16 @@ describe('TryCatch（真 @sentry/core 集成）', () => {
         });
       }).toThrow('duplicate raf boom');
 
-      // 微信真机在卡顿后可能延迟到后续任务才触发 onError。
-      now += 303;
+      // 微信真机在卡顿后可能延迟到后续任务才触发 onError，并把业务首帧替换成宿主 / SDK 包装帧。
+      now += 307;
       onErrorHandler!(
         [
           'MiniProgramError',
           'duplicate raf boom',
           'TypeError: duplicate raf boom',
-          'at o.OnInit (engine/game.js:10555:48)',
-          'at s.InvokeInit (engine/game.js:58020:2130)',
+          'at sentryWrapped (sentry-miniapp.js:100:20)',
+          'at dispatchError (WAGameSubContext.js:1:200000)',
+          'at reportError (WAGame.js:1:300000)',
         ].join('\n'),
       );
     } finally {


### PR DESCRIPTION
## 背景

关联 #286。

`1.19.0-rc.1` 已将微信小游戏 `onError` 字符串解析为结构化堆栈，但真机复测发现：`TryCatch` 捕获异常约 307ms 后，微信会再次触发全局 `onError`，且宿主会把原业务堆栈替换为 `WAGame.js`、`WAGameSubContext.js` 与 SDK 包装帧。此前必须匹配首个堆栈位置，因此仍会重复上报。

## 改动

- 将近期已捕获异常保存为错误类型、标准化消息和首个堆栈位置组成的结构化签名
- 堆栈位置一致时继续精确匹配
- 宿主改写堆栈时，在 1 秒窗口内退回到错误类型与标准化消息匹配
- 命中后立即消费，队列继续限制为最多 20 条并自动清理过期项
- 不使用 propagation trace ID 关联异常，因为同一 Scope 会复用该 ID，不能作为异常唯一标识
- 无公开 API 或配置项变化，无需更新用户文档

## 验证

- `yarn lint`
- `yarn typecheck`
- `yarn test:coverage`：47 个测试文件、734 个测试通过
- `yarn build`：ESM、CJS、UMD 及构建兼容性检查通过
- 真实 `@sentry/core` 回归：模拟异常 307ms 后收到完全不同的宿主堆栈，最终只发送一条 `instrument` 事件

合并后建议先发布 `1.19.0-rc.2`，请 issue 作者使用同一台 Android 微信小游戏真机复验，再决定是否发布正式版 `1.19.0`。