### PR TITLE
chore(release): 发布 1.19.0-rc.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-miniapp",
-  "version": "1.19.0-rc.1",
+  "version": "1.19.0-rc.2",
   "description": "Sentry SDK for Mini Programs (WeChat, Alipay, ByteDance, Baidu, QQ, DingTalk, Kuaishou) & Taro / uni-app | 小程序监控 SDK，支持异常监控、性能监控、错误收集",
   "repository": {
     "type": "git",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
 // 版本号应该与 package.json 中的版本保持同步
-export const SDK_VERSION = '1.19.0-rc.1';
+export const SDK_VERSION = '1.19.0-rc.2';
 export const SDK_NAME = 'sentry.javascript.miniapp';


### PR DESCRIPTION
## 发布版本

`1.19.0-rc.2`

## 发布内容

- 包含 #306：修复微信小游戏宿主改写异常堆栈后，同一次异常仍被 `TryCatch` 和全局 `onError` 重复上报的问题
- 堆栈位置一致时继续精确匹配；宿主替换业务堆栈时，在 1 秒窗口内使用错误类型与标准化消息匹配
- 命中后立即消费，保留过期淘汰和最多 20 条的队列限制
- 不使用 propagation trace ID 关联异常，避免将同一 Scope 复用的 trace ID 误当成异常唯一标识

本版本继续发布到 npm `next`，用于 #286 作者在同一台 Android 微信小游戏真机上复验；验证通过后再发布正式版 `1.19.0`。

## 版本文件

- `package.json`：`1.19.0-rc.2`
- `src/version.ts`：`1.19.0-rc.2`
- 本地 tag：`v1.19.0-rc.2`，待本 PR 使用 merge commit 合入后推送

## 验证

- `yarn lint`
- `yarn typecheck`
- `yarn test`：47 个测试文件、734 个测试通过
- `yarn build`：ESM / CJS / UMD 构建及兼容性检查通过

合并方式：**merge commit**，不要 squash，确保 release commit 和 tag 进入 `master` 历史。