### PR TITLE
fix: 兼容微信真机对象形式的全局错误载荷

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -151,6 +151,16 @@ function getPlatformErrorMessage(stack: string): string {
     .split('\n')
     .map((line) => line.trim())
     .filter(Boolean);
+  const markerIndex = lines.indexOf('MiniProgramError');
+  const markerMessage = markerIndex >= 0 ? lines[markerIndex + 1] : undefined;
+  if (
+    markerMessage &&
+    !markerMessage.startsWith('at ') &&
+    !/^\s*[^@]*@.+:\d+(?::\d+)?\s*$/.test(markerMessage)
+  ) {
+    return normalizeErrorMessage(markerMessage);
+  }
+
   const typedMessage = lines.find(
     (line) => ERROR_TYPE_PREFIX.test(line) && normalizeErrorMessage(line).length > 0,
   );
@@ -172,16 +182,20 @@ function getPlatformErrorType(stack: string): string | undefined {
   for (const line of stack.split('\n')) {
     const match = ERROR_TYPE_PREFIX.exec(line.trim());
     if (match?.[1]) {
-      return match[1].toLowerCase();
+      return match[1];
     }
   }
 
   return undefined;
 }
 
-function getErrorDetails(
-  value: unknown,
-): { message: string; stack: string; type?: string } | undefined {
+export interface ErrorDetails {
+  message: string;
+  stack: string;
+  type?: string;
+}
+
+export function getErrorDetails(value: unknown): ErrorDetails | undefined {
   try {
     if (typeof value === 'string') {
       const type = getPlatformErrorType(value);
@@ -193,16 +207,20 @@ function getErrorDetails(
       return undefined;
     }
 
-    const error = value as { message?: unknown; stack?: unknown };
-    const stack = typeof error.stack === 'string' ? error.stack : '';
+    const error = value as { message?: unknown; name?: unknown; stack?: unknown };
+    const rawMessage = typeof error.message === 'string' ? error.message : '';
+    const rawStack = typeof error.stack === 'string' ? error.stack : '';
+    // 微信小游戏 Android 真机可能传入 { message: "MiniProgramError\n...\nat ...", stack: "" }。
+    // stack 为空时，message 本身就是完整宿主堆栈，必须沿字符串路径解析。
+    const embeddedStack = rawMessage.includes('\n') ? rawMessage : '';
+    const stack = rawStack.trim() ? rawStack : embeddedStack;
+    const platformMessage = embeddedStack ? getPlatformErrorMessage(embeddedStack) : '';
     const message =
-      typeof error.message === 'string'
-        ? normalizeErrorMessage(error.message)
-        : getPlatformErrorMessage(stack);
+      platformMessage ||
+      (rawMessage ? normalizeErrorMessage(rawMessage) : getPlatformErrorMessage(stack));
     const type =
-      'name' in error && typeof error.name === 'string' && error.name
-        ? error.name.toLowerCase()
-        : getPlatformErrorType(stack);
+      getPlatformErrorType(stack) ||
+      (typeof error.name === 'string' && error.name ? error.name : undefined);
     return type ? { message, stack, type } : { message, stack };
   } catch (_error) {
     return undefined;
@@ -244,7 +262,7 @@ function getErrorSignature(value: unknown): ErrorSignature | undefined {
   const location = getFirstStackLocation(details.stack);
   if (!location) {
     return details.type
-      ? { message: details.message, type: details.type }
+      ? { message: details.message, type: details.type.toLowerCase() }
       : { message: details.message };
   }
 
@@ -255,7 +273,7 @@ function getErrorSignature(value: unknown): ErrorSignature | undefined {
     .replace(/[?#].*$/, '');
   return {
     message: details.message,
-    ...(details.type ? { type: details.type } : {}),
+    ...(details.type ? { type: details.type.toLowerCase() } : {}),
     location: `${filename}:${location.lineno}:${location.colno}`,
   };
 }

--- a/src/integrations/globalhandlers.ts
+++ b/src/integrations/globalhandlers.ts
@@ -2,17 +2,32 @@ import { captureException, getClient, withScope } from '@sentry/core';
 import type { Client, Integration, IntegrationFn } from '@sentry/core';
 
 import { sdk } from '../crossPlatform';
-import { shouldIgnoreOnError } from '../helpers';
+import { getErrorDetails, shouldIgnoreOnError } from '../helpers';
 
-function errorFromPlatformValue(value: string | Error): Error {
-  if (typeof value !== 'string') {
+interface PlatformErrorPayload {
+  message?: unknown;
+  name?: unknown;
+  stack?: unknown;
+}
+
+type PlatformErrorValue = string | Error | PlatformErrorPayload;
+
+function errorFromPlatformValue(value: PlatformErrorValue): Error {
+  if (value instanceof Error) {
     return value;
   }
 
-  const error = new Error(value);
-  // 小程序 / 小游戏 onError 只给字符串时，堆栈也包含在该字符串中。覆盖本地构造
-  // Error 产生的无关 stack，让 MiniappClient 使用用户配置的 stackParser 解析宿主帧。
-  error.stack = value;
+  const details = getErrorDetails(value);
+  const error = new Error(details?.message || 'Unknown platform error');
+  if (details?.type) {
+    error.name = details.type;
+  }
+  // 小程序 / 小游戏 onError 可能直接给字符串，也可能给
+  // { message: "MiniProgramError\n...\nat ...", stack: "" }。覆盖本地构造 Error
+  // 产生的无关 stack，让 MiniappClient 使用用户配置的 stackParser 解析宿主帧。
+  if (details) {
+    error.stack = details.stack || details.message;
+  }
   return error;
 }
 
@@ -44,7 +59,7 @@ export class GlobalHandlers implements Integration {
   private _onPageNotFoundHandlerInstalled: boolean = false;
   private _onMemoryWarningHandlerInstalled: boolean = false;
 
-  private _errorHandler: ((err: string | Error) => void) | null = null;
+  private _errorHandler: ((err: PlatformErrorValue) => void) | null = null;
   private _rejectionHandler:
     | ((res: { reason: string | Error; promise: Promise<any> }) => void)
     | null = null;
@@ -106,7 +121,7 @@ export class GlobalHandlers implements Integration {
     }
 
     if (sdk().onError) {
-      this._errorHandler = (err: string | Error) => {
+      this._errorHandler = (err: PlatformErrorValue) => {
         if (this._client && getClient() !== this._client) return;
         if (shouldIgnoreOnError(err)) {
           return;

--- a/test/globalhandlers.realcore.test.ts
+++ b/test/globalhandlers.realcore.test.ts
@@ -27,7 +27,7 @@ function collectEvents(captured: any[]): any[] {
 describe('GlobalHandlers（真 @sentry/core 集成）', () => {
   const g = global as any;
   let captured: any[];
-  let onErrorHandler: ((e: string | Error) => void) | undefined;
+  let onErrorHandler: ((e: unknown) => void) | undefined;
   let onPageNotFoundHandler:
     | ((event: { path: string; query: Record<string, unknown>; isEntryPage: boolean }) => void)
     | undefined;
@@ -42,7 +42,7 @@ describe('GlobalHandlers（真 @sentry/core 集成）', () => {
     g.wx = {
       request: vi.fn(),
       getSystemInfoSync: () => ({ brand: 'Apple', SDKVersion: '3' }),
-      onError: vi.fn((h: (e: string | Error) => void) => {
+      onError: vi.fn((h: (e: unknown) => void) => {
         onErrorHandler = h;
       }),
       onUnhandledRejection: vi.fn(),
@@ -124,6 +124,47 @@ describe('GlobalHandlers（真 @sentry/core 集成）', () => {
           function: 'o.OnInit',
           lineno: 10555,
           colno: 48,
+        }),
+      ]),
+    );
+  });
+
+  it('wx.onError 对象 message 中的小游戏堆栈会转为结构化 frames', async () => {
+    init({
+      dsn: 'https://test@o0.ingest.sentry.io/0',
+      enableAutoSessionTracking: false,
+      transport: () => ({
+        send: (env: any) => {
+          captured.push(env);
+          return Promise.resolve({ statusCode: 200 });
+        },
+        flush: () => Promise.resolve(true),
+      }),
+    } as any);
+
+    onErrorHandler!({
+      message: [
+        'MiniProgramError',
+        's.Ins.OnEventGameInit is not a function',
+        'TypeError: s.Ins.OnEventGameInit is not a function',
+        'at bInit (subpackages/../file:/Project/ViewBattleDebug.ts:52:23)',
+        'at Function.<anonymous> (WAGameSubContext.js:1:216128)',
+      ].join('\n'),
+      stack: '',
+    });
+    await flush(2000);
+
+    const events = collectEvents(captured);
+    const value = events[0]?.exception?.values?.[0];
+    expect(value.type).toBe('TypeError');
+    expect(value.value).toBe('s.Ins.OnEventGameInit is not a function');
+    expect(value.mechanism).toEqual({ type: 'onerror', handled: false });
+    expect(value.stacktrace?.frames).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          function: 'bInit',
+          lineno: 52,
+          colno: 23,
         }),
       ]),
     );

--- a/test/globalhandlers.test.ts
+++ b/test/globalhandlers.test.ts
@@ -158,6 +158,31 @@ describe('GlobalHandlers', () => {
       expect(captureException).not.toHaveBeenCalled();
     });
 
+    it('should ignore an object payload whose message contains the platform stack', () => {
+      const integration = new GlobalHandlers();
+      integration.setupOnce();
+      const handler = mockSdk.onError.mock.calls[0][0];
+      const message = 's.Ins.OnEventGameInit is not a function';
+      const error = new TypeError(message);
+      error.stack = [`TypeError: ${message}`, 'at bInit (Project/ViewBattleDebug.ts:52:23)'].join(
+        '\n',
+      );
+
+      markErrorAsCaptured(error);
+      handler({
+        message: [
+          'MiniProgramError',
+          message,
+          `TypeError: ${message}`,
+          'at bInit (subpackages/../file:/Project/ViewBattleDebug.ts:52:23)',
+          'at Function.<anonymous> (WAGameSubContext.js:1:216128)',
+        ].join('\n'),
+        stack: '',
+      });
+
+      expect(captureException).not.toHaveBeenCalled();
+    });
+
     it('should capture Error objects', () => {
       const integration = new GlobalHandlers();
       integration.setupOnce();

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -510,6 +510,41 @@ describe('Helpers', () => {
       ).toBe(true);
     });
 
+    it('should read an embedded stack from an object payload with an empty stack field', () => {
+      const message = 's.Ins.OnEventGameInit is not a function';
+      markErrorAsCaptured(createError(message, 'Project/ViewBattleDebug.ts:52:23'));
+
+      expect(
+        shouldIgnoreOnError({
+          message: [
+            'MiniProgramError',
+            message,
+            `TypeError: ${message}`,
+            'at bInit (subpackages/../file:/Project/ViewBattleDebug.ts:52:23)',
+            'at Function.<anonymous> (WAGameSubContext.js:1:216128)',
+          ].join('\n'),
+          stack: '',
+        }),
+      ).toBe(true);
+    });
+
+    it('should prefer the core message immediately after MiniProgramError', () => {
+      const message = 'core platform message';
+      markErrorAsCaptured(createError(message));
+
+      expect(
+        shouldIgnoreOnError({
+          message: [
+            'MiniProgramError',
+            message,
+            `TypeError: ${message} (host suffix)`,
+            'at Function.<anonymous> (WAGameSubContext.js:1:216128)',
+          ].join('\n'),
+          stack: '   ',
+        }),
+      ).toBe(true);
+    });
+
     it('should use the error type when neither stack has a comparable location', () => {
       const message = 'type-only matching error';
       const error = new TypeError(message);

--- a/test/trycatch.realcore.test.ts
+++ b/test/trycatch.realcore.test.ts
@@ -22,7 +22,7 @@ describe('TryCatch（真 @sentry/core 集成）', () => {
   let captured: any[];
   let realSetTimeout: any;
   let realRequestAnimationFrame: any;
-  let onErrorHandler: ((e: string | Error) => void) | undefined;
+  let onErrorHandler: ((e: unknown) => void) | undefined;
 
   beforeEach(() => {
     captured = [];
@@ -35,7 +35,7 @@ describe('TryCatch（真 @sentry/core 集成）', () => {
     g.wx = {
       request: vi.fn(),
       getSystemInfoSync: () => ({ brand: 'Apple', SDKVersion: '3' }),
-      onError: vi.fn((h: (e: string | Error) => void) => {
+      onError: vi.fn((h: (e: unknown) => void) => {
         onErrorHandler = h;
       }),
       onUnhandledRejection: vi.fn(),
@@ -137,8 +137,8 @@ describe('TryCatch（真 @sentry/core 集成）', () => {
 
       // 微信真机在卡顿后可能延迟到后续任务才触发 onError，并把业务首帧替换成宿主 / SDK 包装帧。
       now += 307;
-      onErrorHandler!(
-        [
+      onErrorHandler!({
+        message: [
           'MiniProgramError',
           'duplicate raf boom',
           'TypeError: duplicate raf boom',
@@ -146,7 +146,8 @@ describe('TryCatch（真 @sentry/core 集成）', () => {
           'at dispatchError (WAGameSubContext.js:1:200000)',
           'at reportError (WAGame.js:1:300000)',
         ].join('\n'),
-      );
+        stack: '',
+      });
     } finally {
       nowSpy.mockRestore();
     }


### PR DESCRIPTION
## 背景

关联 #286。

`1.19.0-rc.2` 在 Android 微信小游戏真机上仍会重复上报。作者补充的原始日志确认，`wx.onError` 第一个参数并非字符串，而是：

```js
{
  message: "MiniProgramError\n核心消息\nTypeError: 核心消息\nat ...",
  stack: ""
}
```

此前对象分支把整个多行 `message` 当作普通消息，又只从空 `stack` 读取类型和位置，导致近期 `TryCatch` 异常签名无法匹配。

## 改动

- 对象载荷的 `stack` 为空或仅含空白时，从多行 `message` 提取内嵌宿主堆栈
- 优先读取 `MiniProgramError` 后第一行作为核心错误消息，再以带类型消息兜底
- 从内嵌堆栈恢复 `TypeError` 等异常类型并统一签名大小写
- GlobalHandlers 使用同一归一化结果构建 Error
- 对于只经过全局 `onError` 的对象载荷，保留核心消息、异常类型和结构化 frames
- 不改变正常的 onerror-only 兜底行为，也不扩大通用 Dedupe 规则

## 验证

- 新增与 #286 原始 `{ message, stack: "" }` 载荷同形的去重回归测试
- 新增真实 `@sentry/core` 对象载荷事件测试，验证 TypeError、核心消息和业务 frame
- 将 307ms 延迟重复上报真实 core 测试改为对象载荷
- `yarn lint`
- `yarn typecheck`
- `yarn test:coverage`：47 个测试文件、738 个测试通过
- `yarn build`：ESM / CJS / UMD 及构建兼容性检查通过

合并后建议继续发布 `1.19.0-rc.3` 给 #286 作者复验，不直接发布正式版。