### PR TITLE
chore(release): 发布 1.19.0-rc.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-miniapp",
-  "version": "1.19.0-rc.2",
+  "version": "1.19.0-rc.3",
   "description": "Sentry SDK for Mini Programs (WeChat, Alipay, ByteDance, Baidu, QQ, DingTalk, Kuaishou) & Taro / uni-app | 小程序监控 SDK，支持异常监控、性能监控、错误收集",
   "repository": {
     "type": "git",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
 // 版本号应该与 package.json 中的版本保持同步
-export const SDK_VERSION = '1.19.0-rc.2';
+export const SDK_VERSION = '1.19.0-rc.3';
 export const SDK_NAME = 'sentry.javascript.miniapp';


### PR DESCRIPTION
## 发布内容

- 发布 `sentry-miniapp@1.19.0-rc.3`，npm 使用 `next` 标签。
- 包含 #308：兼容微信小游戏 Android 真机中 `{ message, stack: "" }` 形式的 `wx.onError` 载荷。
- 修复对象载荷下错误类型、核心消息与堆栈提取，确保与 `TryCatch` 捕获结果使用同一去重签名。
- 发布后请 #286 提问者在同一 Android 真机复测重复上报与 Source Map 还原。

## 版本文件

- `package.json`
- `src/version.ts`

本地已创建 `v1.19.0-rc.3` 候选标签；待本 PR 以 merge commit 合并后，再确认标签提交属于 `master` 并推送触发发布。

## 验证

- `yarn lint`
- `yarn typecheck`
- `yarn test`（47 个测试文件、738 个测试通过）
- `yarn build`

关联：#286