### PR TITLE
ci(release): 迁移到 npm Trusted Publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,17 +18,22 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # 发布成功后创建 / 更新 GitHub Release
-      id-token: write # 这使得工作流能够通过 OIDC 从 GitHub 获取凭证
+      id-token: write # npm Trusted Publishing 通过 OIDC 获取短期发布凭证
 
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
-        node-version: '22.x'
+        node-version: '24.x'
         registry-url: 'https://registry.npmjs.org'
+        package-manager-cache: false
+
+    # npm Trusted Publishing 要求 npm >= 11.5.1；固定版本避免 runner 镜像变化影响发版。
+    - name: Setup npm for Trusted Publishing
+      run: npm install --global npm@11.19.0
 
     - name: Enable Corepack
       run: corepack enable
@@ -50,7 +55,6 @@ jobs:
 
     - name: Publish to NPM
       env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         TAG_NAME: ${{ github.ref_name }}
       run: |
         VERSION="${TAG_NAME#v}"
@@ -70,7 +74,7 @@ jobs:
           echo "sentry-miniapp@$VERSION is already published; skipping npm publish."
         else
           echo "Publishing sentry-miniapp@$VERSION with dist-tag $PUBLISH_TAG"
-          npm publish --access public --provenance --tag "$PUBLISH_TAG"
+          npm publish --access public --tag "$PUBLISH_TAG"
         fi
 
     - name: Create GitHub Release

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -103,6 +103,21 @@ yarn lint && yarn test
    git push origin vX.Y.Z
    ```
 
-6. GitHub Actions 将自动接管构建、发布到 NPM，并在发布成功后通过 `softprops/action-gh-release@v3` 创建对应的 GitHub Release。Release notes 由 GitHub 根据 tag 之间的 PR 自动生成，同时附带可直接下载的 `sentry-miniapp.umd.js` 与 Source Map。
+6. GitHub Actions 将自动接管构建、通过 npm Trusted Publishing（OIDC）发布到 NPM，并在发布成功后通过 `softprops/action-gh-release@v3` 创建对应的 GitHub Release。Release notes 由 GitHub 根据 tag 之间的 PR 自动生成，同时附带可直接下载的 `sentry-miniapp.umd.js` 与 Source Map。
+
+### npm Trusted Publishing
+
+发布工作流不使用长期 `NPM_TOKEN`。npm 包设置中的 Trusted Publisher 必须与仓库配置精确匹配：
+
+- Provider：GitHub Actions
+- Organization or user：`lizhiyao`
+- Repository：`sentry-miniapp`
+- Workflow filename：`publish.yml`
+- Allowed actions：`npm publish`
+- Environment：不设置
+
+`.github/workflows/publish.yml` 使用 GitHub 托管 runner，并授予 `id-token: write`。npm CLI 会用 GitHub OIDC 身份换取仅对当前 workflow 有效的短期发布凭证，并自动生成 provenance；不要重新添加 `NODE_AUTH_TOKEN` 或发布权限 token。
+
+首次 OIDC 发版验证成功后，应在 npm 的 Publishing access 中选择 **Require two-factor authentication and disallow tokens**，删除仓库中的 `NPM_TOKEN` Secret，并撤销 npm 账户里不再使用的发布 token。若发布报 `ENEEDAUTH`，优先检查 npm Trusted Publisher 的仓库名、workflow 文件名和可执行 action 是否完全一致。
 
 仓库不再保留单独的 `CHANGELOG.md`。PR title / description 是发版说明的唯一信息源，包含 BREAKING CHANGE、迁移方式或兼容性注意事项的改动必须在 PR 描述里写清楚。


### PR DESCRIPTION
## 改造内容

- 将 npm 发布认证从长期 `NPM_TOKEN` 迁移到 GitHub OIDC Trusted Publishing。
- 发布 runner 升级到 Node 24，并固定使用支持 Trusted Publishing 的 npm 11.19.0。
- 升级 `actions/checkout` / `actions/setup-node` 到 v6，移除旧的 Node 20 action runtime 警告。
- 移除 workflow 中的 `NODE_AUTH_TOKEN` 与显式 `--provenance`；OIDC 发布会自动生成 provenance。
- 在 `DEVELOPMENT.md` 补充 npm 端绑定字段、迁移顺序和排障说明。

## npm 端配置

Trusted Publisher 应配置为：

- GitHub user：`lizhiyao`
- Repository：`sentry-miniapp`
- Workflow：`publish.yml`
- Allowed action：`npm publish`
- Environment：不设置

首次 OIDC 发布成功前暂时保留仓库 `NPM_TOKEN` Secret，但 workflow 已不再读取；验证成功后再删除 Secret 并在 npm 禁用 token 发布。

## 验证

- workflow YAML 解析通过
- `yarn lint`
- `yarn test`（47 个测试文件、738 个测试通过）
- `yarn build`