### PR TITLE
chore(release): 发布 1.19.0-rc.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-miniapp",
-  "version": "1.19.0-rc.3",
+  "version": "1.19.0-rc.4",
   "description": "Sentry SDK for Mini Programs (WeChat, Alipay, ByteDance, Baidu, QQ, DingTalk, Kuaishou) & Taro / uni-app | 小程序监控 SDK，支持异常监控、性能监控、错误收集",
   "repository": {
     "type": "git",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
 // 版本号应该与 package.json 中的版本保持同步
-export const SDK_VERSION = '1.19.0-rc.3';
+export const SDK_VERSION = '1.19.0-rc.4';
 export const SDK_NAME = 'sentry.javascript.miniapp';


### PR DESCRIPTION
## 发布目的

- 发布 `sentry-miniapp@1.19.0-rc.4`，npm 使用 `next` 标签。
- 首次实发验证 #310 引入的 npm Trusted Publishing（GitHub OIDC）。
- 本版本不增加 SDK 功能，运行时代码与 rc.3 一致。

## 认证验证

- workflow 不读取 `NPM_TOKEN` / `NODE_AUTH_TOKEN`。
- npm Trusted Publisher：`lizhiyao/sentry-miniapp` + `publish.yml` + `npm publish`。
- 预期由 GitHub OIDC 获取短期凭证并自动生成 provenance。
- 验证成功后删除仓库 `NPM_TOKEN`，并在 npm 禁止 token 发布。

## 版本文件

- `package.json`
- `src/version.ts`

本地已创建 `v1.19.0-rc.4` 候选标签；待本 PR 以 merge commit 合并后，再确认标签提交属于 `master` 并推送触发发布。

## 验证

- `yarn lint`
- `yarn typecheck`
- `yarn test`（47 个测试文件、738 个测试通过）
- `yarn build`