### PR TITLE
chore(deps): 升级 @sentry/core 至 10.70.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "vitest": "^3.2.6"
   },
   "dependencies": {
-    "@sentry/core": "10.69.0"
+    "@sentry/core": "10.70.0"
   },
   "resolutions": {
     "js-yaml": "4.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1804,12 +1804,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/core@npm:10.69.0":
-  version: 10.69.0
-  resolution: "@sentry/core@npm:10.69.0"
+"@sentry/core@npm:10.70.0":
+  version: 10.70.0
+  resolution: "@sentry/core@npm:10.70.0"
   dependencies:
     "@sentry/conventions": "npm:^0.16.0"
-  checksum: 10c0/d6a00824a12d332063ed309c3fc263715ac1d20d253ddfce75d22b8b046da4eb2f99d843628bf365281ca625826bc6a9bdf5dec0ce24c9eb88712f7187858891
+  checksum: 10c0/4625428ed269c00375d2436968d7a24e5235a9c83c2968dc237543bba606d42326b5922e2d8d08a76a15e5f8734b940c607b1d911da8906987e1259763d36e21
   languageName: node
   linkType: hard
 
@@ -6357,7 +6357,7 @@ __metadata:
     "@babel/plugin-transform-regenerator": "npm:^7.29.8"
     "@commitlint/cli": "npm:^20.5.0"
     "@commitlint/config-conventional": "npm:^20.5.0"
-    "@sentry/core": "npm:10.69.0"
+    "@sentry/core": "npm:10.70.0"
     "@types/node": "npm:^20.19.11"
     "@typescript-eslint/eslint-plugin": "npm:^8.57.1"
     "@typescript-eslint/parser": "npm:^8.57.1"


### PR DESCRIPTION
## 改动说明

- 将 `@sentry/core` 从 `10.69.0` 精确升级至 `10.70.0`
- 同步更新 Yarn 锁文件与包完整性校验
- 未改动 SDK 业务逻辑、公开 API 或文档

## 兼容性调研

- 官方 10.70.0 release notes 未包含 breaking change
- Core 相关改动主要修复跨 realm Error 识别，以及在 `beforeSend` 后执行错误采样并保留 Session 更新
- 公共类型差异集中在新增 MCP 导出，本项目使用的 Client、transport、离线缓存、堆栈和 tracing API 未删除或改签

## 验证

- [x] `yarn lint`
- [x] `yarn typecheck`
- [x] `yarn test:coverage`（47 个测试文件、738 项测试通过）
- [x] `yarn build`
- [x] `yarn build:miniapp`

Closes #303