### PR TITLE
fix(integrations): 对齐全局错误去重类型识别

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -189,6 +189,28 @@ function getPlatformErrorType(stack: string): string | undefined {
   return undefined;
 }
 
+function getObjectErrorType(error: { name?: unknown; constructor?: unknown }): string | undefined {
+  try {
+    if (typeof error.name === 'string' && error.name) {
+      return error.name;
+    }
+  } catch (_error) {
+    // 某些宿主对象不允许读取 name，继续尝试构造器名称。
+  }
+
+  try {
+    const constructorName =
+      typeof error.constructor === 'function' ? error.constructor.name : undefined;
+    // 与 core 的 error.name || error.constructor.name 语义对齐，但不把普通 Object
+    // 等构造器误当成异常类型。
+    return constructorName && ERROR_TYPE_PREFIX.test(`${constructorName}: `)
+      ? constructorName
+      : undefined;
+  } catch (_error) {
+    return undefined;
+  }
+}
+
 export interface ErrorDetails {
   message: string;
   stack: string;
@@ -218,9 +240,7 @@ export function getErrorDetails(value: unknown): ErrorDetails | undefined {
     const message =
       platformMessage ||
       (rawMessage ? normalizeErrorMessage(rawMessage) : getPlatformErrorMessage(stack));
-    const type =
-      getPlatformErrorType(stack) ||
-      (typeof error.name === 'string' && error.name ? error.name : undefined);
+    const type = getPlatformErrorType(stack) || getObjectErrorType(error);
     return type ? { message, stack, type } : { message, stack };
   } catch (_error) {
     return undefined;

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -4,6 +4,7 @@ import {
   fill,
   shouldIgnoreOnError,
   markErrorAsCaptured,
+  getErrorDetails,
   getFunctionName,
 } from '../src/helpers';
 
@@ -552,6 +553,53 @@ describe('Helpers', () => {
       markErrorAsCaptured(error);
 
       expect(shouldIgnoreOnError(`MiniProgramError\nTypeError: ${message}`)).toBe(true);
+    });
+
+    it('should fall back to the constructor type when the runtime omits error.name', () => {
+      const message = "Cannot read properties of null (reading 'TryChangeDataUserBySystemInit')";
+      const error = new TypeError(message);
+      error.name = '';
+      error.stack = [message, 'at gameTick (subpackages/engine/game.js:12000:20)'].join('\n');
+      markErrorAsCaptured(error);
+
+      expect(
+        shouldIgnoreOnError({
+          message: [
+            'MiniProgramError',
+            message,
+            `TypeError: ${message}`,
+            'at sentryWrapped (sdk/sentry-miniapp.js:18:15817)',
+            'at Function.<anonymous> (WAGameSubContext.js:1:216128)',
+          ].join('\n'),
+          stack: '',
+        }),
+      ).toBe(true);
+    });
+
+    it('should tolerate a throwing name getter and still use the constructor type', () => {
+      const value = {
+        message: 'host error',
+        stack: '',
+        constructor: TypeError,
+      } as Record<string, unknown>;
+      Object.defineProperty(value, 'name', {
+        get() {
+          throw new Error('name is unavailable');
+        },
+      });
+
+      expect(getErrorDetails(value)?.type).toBe('TypeError');
+    });
+
+    it('should tolerate a throwing constructor getter without inventing an error type', () => {
+      const value = { message: 'host error', stack: '', name: '' } as Record<string, unknown>;
+      Object.defineProperty(value, 'constructor', {
+        get() {
+          throw new Error('constructor is unavailable');
+        },
+      });
+
+      expect(getErrorDetails(value)).toEqual({ message: 'host error', stack: '' });
     });
 
     it('should consume multiple identical captured errors one by one', () => {

--- a/test/trycatch.realcore.test.ts
+++ b/test/trycatch.realcore.test.ts
@@ -102,7 +102,7 @@ describe('TryCatch（真 @sentry/core 集成）', () => {
     expect(Array.isArray(errEvent.extra?.arguments)).toBe(true);
   });
 
-  it('requestAnimationFrame 抛错 307ms 后即使宿主栈变化也不会重复上报', async () => {
+  it('requestAnimationFrame 抛错 401ms 后即使宿主栈变化也不会重复上报', async () => {
     g.requestAnimationFrame = (callback: () => void) => callback();
 
     init({
@@ -122,8 +122,11 @@ describe('TryCatch（真 @sentry/core 集成）', () => {
     let now = Date.now();
     const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now);
     const error = new TypeError('duplicate raf boom');
+    // 部分 Cocos / 微信运行时 Error 最终会被 core 通过 constructor.name 识别为
+    // TypeError，但捕获瞬间的 name 和 stack 首行并不携带类型。
+    error.name = '';
     error.stack = [
-      'TypeError: duplicate raf boom',
+      'duplicate raf boom',
       'at o.OnInit (engine/game.js:10555:48)',
       'at s.InvokeInit (engine/game.js:58020:2130)',
     ].join('\n');
@@ -136,7 +139,7 @@ describe('TryCatch（真 @sentry/core 集成）', () => {
       }).toThrow('duplicate raf boom');
 
       // 微信真机在卡顿后可能延迟到后续任务才触发 onError，并把业务首帧替换成宿主 / SDK 包装帧。
-      now += 307;
+      now += 401;
       onErrorHandler!({
         message: [
           'MiniProgramError',
@@ -157,6 +160,7 @@ describe('TryCatch（真 @sentry/core 集成）', () => {
       event.exception?.values?.some((value: any) => value.value?.includes('duplicate raf boom')),
     );
     expect(events).toHaveLength(1);
+    expect(events[0].exception.values[0].type).toBe('TypeError');
     expect(events[0].exception.values[0].mechanism).toMatchObject({
       type: 'instrument',
       handled: false,


### PR DESCRIPTION
## 问题

`1.19.0-rc.4` 已能正确解析 Android 微信小游戏对象形式的 `wx.onError` 载荷，但 #286 真机复测仍会同时生成 `instrument` 和 `onerror` 两条事件。

进一步核对发现，`@sentry/core` 构建异常事件时会使用 `error.name || error.constructor.name` 识别类型；现有去重签名只读取堆栈中的类型或 `error.name`。当 Cocos / 微信运行时错误的 `name` 为空、堆栈首行也不携带类型时，Sentry 最终事件仍显示为 `TypeError`，但去重队列中记录的签名没有类型。宿主随后改写堆栈位置后，两边既无法按位置匹配，也无法按类型回退。

## 修改

- 去重签名在 `error.name` 缺失时安全回退到 `error.constructor.name`
- 仅接受 `Error` / `Exception` 类型名称，避免把普通 `Object` 等构造器误当成异常类型
- 宿主对象的 `name` / `constructor` getter 抛错时保守降级
- 用 #286 最新消息与不同宿主堆栈构造回归测试
- 真实 Core 集成测试验证最终事件仍为 `TypeError`，且只发送一条 `instrument` 事件

## 验证

- [x] `yarn lint`
- [x] `yarn typecheck`
- [x] `yarn test:coverage`（47 个测试文件、741 项测试通过）
- [x] `yarn build`
- [x] `yarn build:miniapp`

Refs #286