### PR TITLE
chore(release): 准备 1.19.0-rc.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-miniapp",
-  "version": "1.19.0-rc.4",
+  "version": "1.19.0-rc.5",
   "description": "Sentry SDK for Mini Programs (WeChat, Alipay, ByteDance, Baidu, QQ, DingTalk, Kuaishou) & Taro / uni-app | 小程序监控 SDK，支持异常监控、性能监控、错误收集",
   "repository": {
     "type": "git",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
 // 版本号应该与 package.json 中的版本保持同步
-export const SDK_VERSION = '1.19.0-rc.4';
+export const SDK_VERSION = '1.19.0-rc.5';
 export const SDK_NAME = 'sentry.javascript.miniapp';


### PR DESCRIPTION
## 发布目标

准备发布 `sentry-miniapp@1.19.0-rc.5` 到 npm `next`。

## 相比 rc.4

- 修复 #286 真机链路中错误类型来源不一致导致的全局错误去重漏匹配（#313）
- 去重签名与 `@sentry/core` 的 `error.name || error.constructor.name` 语义对齐
- 升级 `@sentry/core` 至 `10.70.0`（#312）
- 保留 `rc.4` 已支持的 Android 微信小游戏对象形式 `wx.onError` 载荷解析

## 版本变更

- `package.json`: `1.19.0-rc.4` → `1.19.0-rc.5`
- `src/version.ts`: `1.19.0-rc.4` → `1.19.0-rc.5`

## 验证

- [x] `yarn lint`
- [x] `yarn typecheck`
- [x] `yarn test`（47 个测试文件、741 项测试通过）
- [x] `yarn build`
- [x] `npm pack --dry-run --json --ignore-scripts`（82 个文件，版本与发布内容正确）

发布后继续保持 #286 打开，等待同一台 Android 微信真机复测。