### PR TITLE
chore(release): 准备 1.19.0-rc.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-miniapp",
-  "version": "1.19.0-rc.5",
+  "version": "1.19.0-rc.6",
   "description": "Sentry SDK for Mini Programs (WeChat, Alipay, ByteDance, Baidu, QQ, DingTalk, Kuaishou) & Taro / uni-app | 小程序监控 SDK，支持异常监控、性能监控、错误收集",
   "repository": {
     "type": "git",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
 // 版本号应该与 package.json 中的版本保持同步
-export const SDK_VERSION = '1.19.0-rc.5';
+export const SDK_VERSION = '1.19.0-rc.6';
 export const SDK_NAME = 'sentry.javascript.miniapp';


### PR DESCRIPTION
## 发布目标

准备发布 `sentry-miniapp@1.19.0-rc.6` 到 npm `next`。

## 相比 rc.5

- 修复 #286 中 Android 微信小游戏真机同一异常仍产生 `instrument` 与 `onerror` 两条事件的问题（#315）
- 将兜底去重从原始 Error 指纹迁移到 Sentry Core 完成构建后的事件层
- 仅匹配 1 秒内最终 `exception.type + exception.value` 完全相同的 `instrument -> onerror`，并一次性消费
- 保留独立 `onerror`、不同类型或消息、过期事件以及 client 隔离和 cleanup 清理

## 版本变更

- `package.json`: `1.19.0-rc.5` → `1.19.0-rc.6`
- `src/version.ts`: `1.19.0-rc.5` → `1.19.0-rc.6`

## 验证

- [x] `yarn lint`
- [x] `yarn typecheck`
- [x] `yarn test`（47 个测试文件、730 项测试通过）
- [x] `yarn build`
- [x] `npm pack --dry-run --json --ignore-scripts`（82 个文件，版本与发布内容正确）

发布后继续保持 #286 打开，等待同一台 Android 微信小游戏真机复测；通过前不发布正式版 `1.19.0`。