### PR TITLE
chore(release): 准备 1.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-miniapp",
-  "version": "1.19.0-rc.6",
+  "version": "1.19.0",
   "description": "Sentry SDK for Mini Programs (WeChat, Alipay, ByteDance, Baidu, QQ, DingTalk, Kuaishou) & Taro / uni-app | 小程序监控 SDK，支持异常监控、性能监控、错误收集",
   "repository": {
     "type": "git",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
 // 版本号应该与 package.json 中的版本保持同步
-export const SDK_VERSION = '1.19.0-rc.6';
+export const SDK_VERSION = '1.19.0';
 export const SDK_NAME = 'sentry.javascript.miniapp';


### PR DESCRIPTION
## 发布目标

将已经过 `1.19.0-rc.1` 至 `rc.6` 验证的版本发布为正式版 `sentry-miniapp@1.19.0`，并更新 npm `latest`。

## 版本亮点

- SDK 初始化、默认集成装配和事件构建进一步对齐 `@sentry/core` 官方语义
- 测试框架迁移至 Vitest，并补齐七个平台宿主契约和真实 Core 集成测试
- 修复 TryCatch 重新抛出后与微信小游戏全局 `onError` 重复上报的问题
- 兼容 Android 微信小游戏 `{ message, stack: "" }` 形式的全局错误载荷及结构化堆栈
- 去重迁移到 Core 构建完成后的事件层，同时保留独立 `onerror` 兜底事件
- `@sentry/core` 升级至 `10.70.0`
- npm 发布已迁移到 OIDC Trusted Publishing，并自动创建 GitHub Release

## 真机验证

#286 作者已使用 `1.19.0-rc.6` 在同一台 Android 微信真机验证通过：

- `requestAnimationFrame` 中同一异常只保留一条 `instrument` 事件
- 不经过 TryCatch 包装的触摸回调错误仍能以单独 `onerror` 事件正常上报

验证记录：https://github.com/lizhiyao/sentry-miniapp/issues/286#issuecomment-5406479092

## 版本变更

- `package.json`: `1.19.0-rc.6` → `1.19.0`
- `src/version.ts`: `1.19.0-rc.6` → `1.19.0`
- 与已通过真机验证的 `v1.19.0-rc.6` 相比无功能代码变化

## 发布校验

- [x] `yarn lint`
- [x] `yarn typecheck`
- [x] `yarn test`（47 个测试文件、730 项测试通过）
- [x] `yarn build`
- [x] `npm pack --dry-run --json --ignore-scripts`（82 个文件，版本与发布内容正确）