### PR TITLE
fix: 兼容小游戏 Performance 能力差异

### DIFF
--- a/docs/README.en.md
+++ b/docs/README.en.md
@@ -30,7 +30,7 @@ Mini program runtimes do not provide browser APIs like `window`, `fetch`, or `XM
 - **Performance and tracing**: Tracks startup, page rendering, resource loading, and API timing; with tracing enabled, requests can be reported as `http.client` spans for backend correlation.
 - **Source Map friendly stacks**: Normalizes platform-specific virtual stack paths to `app:///`, supports Source Maps / Debug IDs, and exposes `stackParser` for unusual runtimes.
 - **Weak-network and privacy flows**: Failed sends go into the local offline queue and retry when the network recovers; with `requireConsent`, events are buffered locally without sending to Sentry until `Sentry.setConsent(true)` is called.
-- **Mini game support**: WeChat / Douyin mini games can report first frame, FPS, and jank to help diagnose slow startup and stutter.
+- **Mini game support**: WeChat / Douyin mini games can report first frame, FPS, and jank to help diagnose slow startup and stutter. Mini games usually expose only `performance.now()`, so mini-program-only navigation, render, and resource observers are skipped automatically.
 - **Familiar Sentry APIs**: `captureException`, `setUser`, `addBreadcrumb`, `startSpan`, `captureFeedback`, `Sentry.logger.*`, and more.
 
 ---

--- a/src/crossPlatform.ts
+++ b/src/crossPlatform.ts
@@ -617,8 +617,7 @@ export interface PerformanceManager {
   clearMarks(name?: string): void;
   clearMeasures(name?: string): void;
 
-  // 观察者
-  // 小游戏 Performance 通常仅提供 now()，PerformanceObserver 只在部分小程序宿主可用。
+  /** 创建性能观察者；小游戏等宿主可能只提供 `now()`，因此该能力可选。 */
   createObserver?(callback: PerformanceObserverCallback): PerformanceObserver;
 }
 

--- a/src/crossPlatform.ts
+++ b/src/crossPlatform.ts
@@ -618,7 +618,8 @@ export interface PerformanceManager {
   clearMeasures(name?: string): void;
 
   // 观察者
-  createObserver(callback: PerformanceObserverCallback): PerformanceObserver;
+  // 小游戏 Performance 通常仅提供 now()，PerformanceObserver 只在部分小程序宿主可用。
+  createObserver?(callback: PerformanceObserverCallback): PerformanceObserver;
 }
 
 /**

--- a/src/integrations/performance.ts
+++ b/src/integrations/performance.ts
@@ -119,7 +119,9 @@ export class PerformanceIntegration implements Integration {
     this._isSetup = true;
     this._setupEpochMilliseconds = epochNow();
     this._initializePerformanceManager();
-    this._setupPerformanceObservers();
+    if (!this._setupPerformanceObservers()) {
+      return;
+    }
     this._startAutoReporting();
     this._addPerformanceContext();
   }
@@ -131,18 +133,8 @@ export class PerformanceIntegration implements Integration {
     try {
       this._performanceManager = getPerformanceManager();
       if (!this._performanceManager) {
-        console.warn('[sentry-miniapp] Performance API not available');
         return;
       }
-
-      // 设置性能监控标签
-      const scope = getCurrentScope();
-      scope.setTag('performance.api.available', true);
-      scope.setContext('performance', {
-        api_version: 'miniapp-1.0',
-        sample_rate: this._options.sampleRate,
-        buffer_size: this._options.bufferSize,
-      });
     } catch (error) {
       console.warn('[sentry-miniapp] Failed to initialize performance manager:', error);
     }
@@ -151,12 +143,16 @@ export class PerformanceIntegration implements Integration {
   /**
    * 设置性能观察者
    */
-  private _setupPerformanceObservers(): void {
+  private _setupPerformanceObservers(): boolean {
     if (!this._performanceManager) {
-      return;
+      return false;
     }
 
     try {
+      if (typeof this._performanceManager.createObserver !== 'function') {
+        return false;
+      }
+
       const entryTypes: string[] = [];
 
       if (this._options.enableNavigation) {
@@ -212,7 +208,7 @@ export class PerformanceIntegration implements Integration {
       }
 
       if (entryTypes.length === 0) {
-        return;
+        return false;
       }
 
       // 创建性能观察者
@@ -246,8 +242,10 @@ export class PerformanceIntegration implements Integration {
       if (globalProcess && globalProcess.env && globalProcess.env.NODE_ENV !== 'production') {
         console.log('[sentry-miniapp] Performance observers setup for:', entryTypes);
       }
+      return true;
     } catch (error) {
       console.warn('[sentry-miniapp] Failed to setup performance observers:', error);
+      return false;
     }
   }
 
@@ -753,6 +751,13 @@ export class PerformanceIntegration implements Integration {
 
       // 检查 Performance API 支持情况
       const hasPerformanceAPI = !!currentSdk.getPerformance;
+
+      scope.setTag('performance.api.available', true);
+      scope.setContext('performance', {
+        api_version: 'miniapp-1.0',
+        sample_rate: this._options.sampleRate,
+        buffer_size: this._options.bufferSize,
+      });
 
       scope.setContext('performance_support', {
         has_performance_api: hasPerformanceAPI,

--- a/test/performance.realcore.test.ts
+++ b/test/performance.realcore.test.ts
@@ -47,6 +47,31 @@ describe('PerformanceIntegration（真 @sentry/core 集成）', () => {
     delete g.wx;
   });
 
+  it('小游戏宿主仅提供 performance.now 时默认集成静默 no-op', () => {
+    g.wx.getPerformance = vi.fn(() => ({ now: vi.fn(() => 1) }));
+    const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const client = init({
+      dsn: 'https://test@o0.ingest.sentry.io/0',
+      transport: () => ({
+        send: () => Promise.resolve({ statusCode: 200 }),
+        flush: () => Promise.resolve(true),
+      }),
+    } as any);
+
+    const performance = client?.getIntegrationByName?.('PerformanceAPI') as any;
+    expect(performance).toBeDefined();
+    expect(performance._observers).toEqual([]);
+    expect(performance._reportTimer).toBeNull();
+    expect(
+      consoleSpy.mock.calls.some((call) =>
+        String(call[0]).includes('Failed to setup performance observers'),
+      ),
+    ).toBe(false);
+
+    consoleSpy.mockRestore();
+  });
+
   it('默认集成接收微信性能条目后会发送 transaction', async () => {
     const beforeSendTransaction = vi.fn((event: any) => event);
 

--- a/test/performance.test.ts
+++ b/test/performance.test.ts
@@ -427,9 +427,25 @@ describe('PerformanceIntegration', () => {
       const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       integration.setupOnce();
 
-      expect(consoleSpy).toHaveBeenCalledWith('[sentry-miniapp] Performance API not available');
+      expect(consoleSpy).not.toHaveBeenCalled();
       expect(mockPerformanceManager.createObserver).not.toHaveBeenCalled();
       expect((integration as any)._reportTimer).toBeNull();
+      expect(mockScope.setTag).not.toHaveBeenCalled();
+      expect(mockScope.setContext).not.toHaveBeenCalled();
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should silently skip hosts that only expose performance.now', () => {
+      (getPerformanceManager as Mock).mockReturnValue({ now: vi.fn(() => 1) });
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      integration.setupOnce();
+
+      expect(consoleSpy).not.toHaveBeenCalled();
+      expect((integration as any)._reportTimer).toBeNull();
+      expect(mockScope.setTag).not.toHaveBeenCalled();
+      expect(mockScope.setContext).not.toHaveBeenCalled();
 
       consoleSpy.mockRestore();
     });
@@ -460,6 +476,7 @@ describe('PerformanceIntegration', () => {
       disabledIntegration.setupOnce();
 
       expect(mockPerformanceManager.createObserver).not.toHaveBeenCalled();
+      expect((disabledIntegration as any)._reportTimer).toBeNull();
       disabledIntegration.cleanup();
     });
 
@@ -489,6 +506,9 @@ describe('PerformanceIntegration', () => {
         '[sentry-miniapp] Failed to setup performance observers:',
         error,
       );
+      expect((integration as any)._reportTimer).toBeNull();
+      expect(mockScope.setTag).not.toHaveBeenCalled();
+      expect(mockScope.setContext).not.toHaveBeenCalled();
 
       consoleSpy.mockRestore();
     });

--- a/website/guide/minigame.md
+++ b/website/guide/minigame.md
@@ -34,6 +34,7 @@ SDK 默认通过 `wx`、`tt` 等平台对象识别平台。多个对象共存时
 | 设备信息与离线缓存 | 支持 | 支持 | 依赖宿主系统信息与 Storage API |
 | 冷启动首帧 | 支持 | 支持 | 上报 `minigame.coldstart` |
 | FPS 与卡顿 | 支持 | 支持 | 依赖全局 `requestAnimationFrame` |
+| 小程序导航 / 渲染 / 资源 PerformanceObserver | 不适用 | 不适用 | 小游戏通常只有 `performance.now()`，默认性能集成自动跳过 |
 | 页面路由、点击面包屑 | 不适用 | 不适用 | 没有 Page 模型，自动跳过 |
 
 ## 冷启动与帧率数据在哪里看

--- a/website/guide/performance-and-tracing.md
+++ b/website/guide/performance-and-tracing.md
@@ -47,7 +47,7 @@ Sentry.init({
 | API 请求 | 作为 `http.client` span 查看请求耗时 |
 | 小游戏冷启动、FPS、jank | 作为小游戏专属 transaction 与 measurement |
 
-宿主没有对应 Performance API 时，相关采集会跳过，不影响异常上报。小游戏性能请看[小游戏接入与性能](/guide/minigame)。
+宿主没有 `createObserver` 时，默认性能集成会静默跳过，不设置已启用标记，也不会启动定时汇总。微信 / 抖音小游戏的 `Performance` 通常只提供 `now()`，其冷启动、FPS 和 jank 由小游戏专属集成采集；详见[小游戏接入与性能](/guide/minigame)。
 
 微信的 `wx.reportPerformance()` 属于小程序后台的自定义测速能力，不是 Sentry 性能监控的一部分；如需使用，请先在微信后台配置指标，再由业务代码主动调用。
 


### PR DESCRIPTION
## 问题

微信 / 抖音小游戏的 `getPerformance()` 通常只提供 `now()`，默认 `PerformanceAPI` 集成此前会无条件调用 `createObserver()`，导致启动告警，并继续写入已启用标记、启动空转汇总定时器。

## 改动

- 将 `PerformanceManager.createObserver` 调整为可选能力
- 缺少 observer 时静默跳过默认性能集成
- 只有 observer 成功建立后才写入 enabled 上下文并启动定时汇总
- observer 建立失败时同样保持禁用状态
- 补充小游戏仅提供 `performance.now()` 的单元测试和真实 `@sentry/core` 回归测试
- 明确官网与英文 README 中小程序 / 小游戏的 Performance 能力边界

小游戏冷启动、FPS、jank 仍由专属集成采集，不受本次调整影响。

## 验证

- `yarn lint`
- `yarn typecheck`
- `yarn test`（47 个测试文件，732 条用例）
- `yarn build`
- `yarn docs:build`

Closes #318