### PR TITLE
chore(release): 发布 1.19.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-miniapp",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "description": "Sentry SDK for Mini Programs (WeChat, Alipay, ByteDance, Baidu, QQ, DingTalk, Kuaishou) & Taro / uni-app | 小程序监控 SDK，支持异常监控、性能监控、错误收集",
   "repository": {
     "type": "git",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
 // 版本号应该与 package.json 中的版本保持同步
-export const SDK_VERSION = '1.19.0';
+export const SDK_VERSION = '1.19.1';
 export const SDK_NAME = 'sentry.javascript.miniapp';


### PR DESCRIPTION
## 发布内容

发布 `sentry-miniapp@1.19.1`，包含 #318 的小游戏 Performance 能力兼容修复：

- 微信 / 抖音小游戏仅提供 `performance.now()` 时，默认 Performance Observer 集成静默跳过
- 不再输出启动告警、写入错误的 enabled 标记或启动空转汇总定时器
- 小游戏冷启动、FPS、jank 专属能力保持不变
- `PerformanceManager.createObserver` 对外类型调整为可选

## 发布前验证

- `yarn lint`
- `yarn typecheck`
- `yarn test`（47 个测试文件，732 条用例）
- `yarn build`
- `npm pack --dry-run --json`（82 个文件）

合并后将从合并提交创建 `v1.19.1` tag，触发 npm Trusted Publishing 与 GitHub Release。