### PR TITLE
test: 补充跨端运行时降级场景

### DIFF
--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { getConfiguredDefaultIntegrationsMode, MiniappClient } from '../src/client';
 import { MiniappOptions } from '../src/types';
 import { resetPlatformCache } from '../src/crossPlatform';
-import { SeverityLevel, getCurrentScope, parameterize } from '@sentry/core';
+import { Client, SeverityLevel, getCurrentScope, parameterize } from '@sentry/core';
 import { miniappStackParser } from '../src/stacktrace';
 
 describe('MiniappClient', () => {
@@ -479,6 +479,31 @@ describe('MiniappClient', () => {
       );
     });
 
+    it('core 事件准备失败时保留原事件并补齐默认上下文', async () => {
+      const error = new Error('scope unavailable');
+      const prepare = vi.spyOn(Client.prototype as any, '_prepareEvent').mockImplementation(() => {
+        throw error;
+      });
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const c = new MiniappClient({ debug: true });
+
+      try {
+        const event = await c['_prepareEvent']({ message: 'keep me' }, {});
+
+        expect(event?.message).toBe('keep me');
+        expect(event?.contexts?.['miniapp']).toEqual(
+          expect.objectContaining({ environment: 'miniapp', platform: 'wechat' }),
+        );
+        expect(warn).toHaveBeenCalledWith(
+          '[sentry-miniapp] _prepareEvent 兜底（scope 未就绪）:',
+          error,
+        );
+      } finally {
+        prepare.mockRestore();
+        warn.mockRestore();
+      }
+    });
+
     // F3：SDK 的 device/os/app 应为「缺省填充」，不得覆盖用户显式设置。
     it('fill-only：不覆盖 per-event 显式设置的 os（F3）', async () => {
       (global as any).wx = {
@@ -541,6 +566,33 @@ describe('MiniappClient', () => {
       );
 
       consoleWarnSpy.mockRestore();
+    });
+  });
+
+  describe('captureFeedback', () => {
+    it('通过当前 scope 使用 core feedback 管线', () => {
+      const scope = getCurrentScope();
+      const previousClient = scope.getClient();
+      const beforeSendFeedback = vi.fn();
+      client.on('beforeSendFeedback', beforeSendFeedback);
+      scope.setClient(client);
+
+      try {
+        const eventId = client.captureFeedback({ message: 'miniapp feedback' });
+
+        expect(eventId).toMatch(/^[a-f0-9]{32}$/);
+        expect(beforeSendFeedback).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: 'feedback',
+            contexts: expect.objectContaining({
+              feedback: expect.objectContaining({ message: 'miniapp feedback' }),
+            }),
+          }),
+          {},
+        );
+      } finally {
+        scope.setClient(previousClient);
+      }
     });
   });
 

--- a/test/crossPlatform.test.ts
+++ b/test/crossPlatform.test.ts
@@ -457,6 +457,43 @@ describe('CrossPlatform', () => {
       expect(result?.brand).toBe('Xiaomi');
       expect(sync).toHaveBeenCalled();
     });
+
+    it('无旧 API 兜底时保留分体 API 已返回的部分信息', async () => {
+      (global as any).wx = {
+        getWindowInfo: vi.fn().mockReturnValue({ screenWidth: 390, screenHeight: 844 }),
+        getAppBaseInfo: vi.fn().mockReturnValue({ version: '8.0.0', SDKVersion: '3.0.0' }),
+      };
+
+      const { getSystemInfo } = await import('../src/crossPlatform');
+
+      expect(getSystemInfo()).toEqual({
+        screenWidth: 390,
+        screenHeight: 844,
+        version: '8.0.0',
+        SDKVersion: '3.0.0',
+      });
+    });
+  });
+
+  describe('getPerformanceManager', () => {
+    it('宿主性能 API 抛错时返回 null 而不是影响 SDK 初始化', async () => {
+      const error = new Error('performance unavailable');
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      (global as any).wx = {
+        getPerformance: vi.fn(() => {
+          throw error;
+        }),
+      };
+
+      const { getPerformanceManager } = await import('../src/crossPlatform');
+
+      try {
+        expect(getPerformanceManager()).toBeNull();
+        expect(warn).toHaveBeenCalledWith('Failed to get performance manager:', error);
+      } finally {
+        warn.mockRestore();
+      }
+    });
   });
 
   describe('getAccountInfo', () => {

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -182,6 +182,34 @@ describe('Helpers', () => {
       expect(obj.method).toBe(originalMethod);
     });
 
+    it('restores state held by an own host accessor', () => {
+      const original = vi.fn(() => 'original');
+      const wrapped = vi.fn(() => 'wrapped');
+      let current = original;
+      const host = {} as { method: () => string };
+      Object.defineProperty(host, 'method', {
+        configurable: true,
+        enumerable: true,
+        get: () => current,
+        set: (value) => {
+          current = value;
+        },
+      });
+
+      const result = fill(host, 'method', () => wrapped);
+      expect(host.method).toBe(wrapped);
+
+      result?.restore();
+
+      expect(host.method).toBe(original);
+      expect(Object.getOwnPropertyDescriptor(host, 'method')).toMatchObject({
+        configurable: true,
+        enumerable: true,
+        get: expect.any(Function),
+        set: expect.any(Function),
+      });
+    });
+
     it('should leave a non-configurable accessor unchanged when assignment is ignored', () => {
       const originalMethod = vi.fn(() => 'original');
       const obj = {} as { method: () => string };
@@ -369,6 +397,53 @@ describe('Helpers', () => {
       result?.restore();
       expect(Object.prototype.hasOwnProperty.call(obj, 'method')).toBe(false);
       expect(obj.method).toBe(original);
+    });
+
+    it('restores state owned by an inherited host accessor', () => {
+      const original = vi.fn(() => 'original');
+      const wrapped = vi.fn(() => 'wrapped');
+      let current = original;
+      const prototype = {} as { method: () => string };
+      Object.defineProperty(prototype, 'method', {
+        configurable: true,
+        get: () => current,
+        set: (value) => {
+          current = value;
+        },
+      });
+      const host = Object.create(prototype) as { method: () => string };
+
+      const result = fill(host, 'method', () => wrapped);
+      expect(host.method).toBe(wrapped);
+      expect(Object.prototype.hasOwnProperty.call(host, 'method')).toBe(false);
+
+      result?.restore();
+
+      expect(host.method).toBe(original);
+      expect(Object.prototype.hasOwnProperty.call(host, 'method')).toBe(false);
+    });
+
+    it('falls back to assignment when a host rejects exact descriptor restoration', () => {
+      const original = vi.fn(() => 'original');
+      const wrapped = vi.fn(() => 'wrapped');
+      const target = { method: original };
+      const host = new Proxy(target, {
+        set(targetObject, property, value) {
+          return Reflect.set(targetObject, property, value, targetObject);
+        },
+        defineProperty(targetObject, property, descriptor) {
+          if (property === 'method' && descriptor.value === original) {
+            throw new Error('descriptor restoration denied');
+          }
+          return Reflect.defineProperty(targetObject, property, descriptor);
+        },
+      });
+
+      const result = fill(host, 'method', () => wrapped);
+      expect(host.method).toBe(wrapped);
+
+      expect(() => result?.restore()).not.toThrow();
+      expect(host.method).toBe(original);
     });
 
     it('contains replacement prototype assignment failures', () => {


### PR DESCRIPTION
## 改动说明

新增 7 条直接执行生产代码的测试，覆盖以下用户可触发场景：

- 分体系统信息 API 只返回部分数据且没有旧 API 兜底
- 宿主 `getPerformance()` 抛错时安全降级
- 自有与继承 accessor 包装后正确恢复宿主内部状态
- 宿主拒绝精确恢复 descriptor 时回退到普通赋值
- core 事件准备失败时保留原事件并补齐默认上下文
- `MiniappClient.captureFeedback()` 使用 core feedback 管线

没有为 `globalThis` 不存在、纯字符串匹配抛错等现代运行时不可达分支补形式化测试。

## 覆盖率变化

- 测试：705 → 712
- Statements / Lines：98.65% → 99.01%
- Branches：95.08% → 95.46%
- Functions：99.17% → 99.44%
- `src/client.ts`：语句、函数和行覆盖率达到 100%

## 验证

- [x] `yarn lint`
- [x] `yarn typecheck`
- [x] `yarn test:coverage`
- [x] `git diff --check`