### PR TITLE
test: 校验 npm 发布包结构

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
   },
   "homepage": "https://github.com/lizhiyao/sentry-miniapp",
   "scripts": {
-    "build": "vite build && npm run check:build-output",
+    "build": "vite build && npm run check:build-output && npm run check:package",
     "check:build-output": "node scripts/internal/check-build-output.mjs dist/sentry-miniapp.esm.js dist/sentry-miniapp.cjs.js dist/sentry-miniapp.umd.js",
+    "check:package": "publint --level error",
     "build:miniapp": "vite build --mode miniapp && node scripts/internal/check-build-output.mjs examples/wxapp/lib/sentry-miniapp.js && node scripts/internal/check-miniapp-bundle.mjs examples/wxapp/lib/sentry-miniapp.js",
     "build:types": "vite build && tsc --emitDeclarationOnly --outDir dist/types",
     "dev": "vite build --watch",
@@ -71,6 +72,7 @@
     "lint-staged": "^16.4.0",
     "lodash": "4.18.1",
     "prettier": "^3.8.1",
+    "publint": "^0.3.24",
     "typescript": "^5.8.3",
     "vite": "^6.4.1",
     "vite-plugin-dts": "^4.5.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1360,6 +1360,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@publint/pack@npm:^0.1.7":
+  version: 0.1.7
+  resolution: "@publint/pack@npm:0.1.7"
+  dependencies:
+    tinyexec: "npm:^1.3.0"
+  checksum: 10c0/bbb63243bd86991074ea06bcdc84ad574a0ee30d694df70fdba2f5f7bbf82d4257717c243807e985b0f75199ed1fc03e17d9e86bc8944b86da49025b1f38d769
+  languageName: node
+  linkType: hard
+
 "@rollup/pluginutils@npm:^5.1.4":
   version: 5.3.0
   resolution: "@rollup/pluginutils@npm:5.3.0"
@@ -5414,6 +5423,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mri@npm:^1.1.0":
+  version: 1.2.0
+  resolution: "mri@npm:1.2.0"
+  checksum: 10c0/a3d32379c2554cf7351db6237ddc18dc9e54e4214953f3da105b97dc3babe0deb3ffe99cf409b38ea47cc29f9430561ba6b53b24ab8f9ce97a4b50409e4a50e7
+  languageName: node
+  linkType: hard
+
 "ms@npm:^2.1.3":
   version: 2.1.3
   resolution: "ms@npm:2.1.3"
@@ -5646,6 +5662,13 @@ __metadata:
   version: 1.0.1
   resolution: "package-json-from-dist@npm:1.0.1"
   checksum: 10c0/62ba2785eb655fec084a257af34dbe24292ab74516d6aecef97ef72d4897310bc6898f6c85b5cd22770eaa1ce60d55a0230e150fb6a966e3ecd6c511e23d164b
+  languageName: node
+  linkType: hard
+
+"package-manager-detector@npm:^1.8.0":
+  version: 1.8.0
+  resolution: "package-manager-detector@npm:1.8.0"
+  checksum: 10c0/4c8e2c47fdc874465d3b3b11934401db9d73470ccbdabeb092e46cb94abbc491d5befc8c271b5ea1ae9c6a881f44c2997e011873365bde9fd6c3dc001221ff7a
   languageName: node
   linkType: hard
 
@@ -5882,6 +5905,20 @@ __metadata:
   version: 7.2.0
   resolution: "property-information@npm:7.2.0"
   checksum: 10c0/03662c8f9e1544510914c5e594ae72963f67d261027a5fdc06c4134742584fe40dd49b959470d30e757e9fb70b297d8546ab1362a040364144029926ad4e07c4
+  languageName: node
+  linkType: hard
+
+"publint@npm:^0.3.24":
+  version: 0.3.24
+  resolution: "publint@npm:0.3.24"
+  dependencies:
+    "@publint/pack": "npm:^0.1.7"
+    package-manager-detector: "npm:^1.8.0"
+    picocolors: "npm:^1.1.1"
+    sade: "npm:^1.8.1"
+  bin:
+    publint: ./src/cli.js
+  checksum: 10c0/ad938ca375aa196845cd2705c49295662839fb991374c24d9acb85945177ebe73c95c8b82666858826b36a8dad943427a0ef0eb1f8b7eaa8abe4c8bc5f55781c
   languageName: node
   linkType: hard
 
@@ -6299,6 +6336,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sade@npm:^1.8.1":
+  version: 1.8.1
+  resolution: "sade@npm:1.8.1"
+  dependencies:
+    mri: "npm:^1.1.0"
+  checksum: 10c0/da8a3a5d667ad5ce3bf6d4f054bbb9f711103e5df21003c5a5c1a8a77ce12b640ed4017dd423b13c2307ea7e645adee7c2ae3afe8051b9db16a6f6d3da3f90b1
+  languageName: node
+  linkType: hard
+
 "safe-buffer@npm:~5.1.0, safe-buffer@npm:~5.1.1":
   version: 5.1.2
   resolution: "safe-buffer@npm:5.1.2"
@@ -6370,6 +6416,7 @@ __metadata:
     lint-staged: "npm:^16.4.0"
     lodash: "npm:4.18.1"
     prettier: "npm:^3.8.1"
+    publint: "npm:^0.3.24"
     typescript: "npm:^5.8.3"
     vite: "npm:^6.4.1"
     vite-plugin-dts: "npm:^4.5.4"
@@ -6806,6 +6853,13 @@ __metadata:
   version: 1.0.4
   resolution: "tinyexec@npm:1.0.4"
   checksum: 10c0/d4a5bbcf6bdb23527a4b74c4aa566f41432167112fe76f420ec7e3a90a3ecfd3a7d944383e2719fc3987b69400f7b928daf08700d145fb527c2e80ec01e198bd
+  languageName: node
+  linkType: hard
+
+"tinyexec@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "tinyexec@npm:1.3.0"
+  checksum: 10c0/e9b89f97489d2aab2cef408da279e6b32547e738d1275032ccb8fd0028a006d93eb70fc51c6cffd9fc2f5aca6c2a273d8b6f73b52d46ee5116da6b94969ef958
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 摘要

- 引入 `publint`，按真实 `yarn pack` 文件清单校验 npm 包结构与入口配置
- 新增 `check:package` 命令，仅阻止 error 级发布问题，避免已知建议成为 CI 噪声
- 将发布包校验接入 `build`，覆盖本地构建、CI 和 `prepublishOnly` 发布前门禁

## 能发现的问题

- `main`、`module`、`types` 或 `exports` 指向未发布文件
- ESM / CJS 入口格式与条件导出不匹配
- 发布清单缺失必要入口或包含无效包结构

## 验证

- `yarn install --immutable`
- `yarn check:package`
- `yarn build`
- `yarn lint`
- `yarn typecheck`
- `yarn test:coverage`（712 个测试及覆盖率门槛通过）