### PR TITLE
fix: 修复 npm 包 ESM 与类型入口

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,5 +72,8 @@ jobs:
     - name: Install dependencies
       run: yarn install --immutable
 
+    - name: Build and Validate Published Package
+      run: yarn run build
+
     - name: Run Tests in Random Order
       run: yarn run test:shuffle

--- a/package.json
+++ b/package.json
@@ -4,15 +4,17 @@
   "description": "Sentry SDK for Mini Programs (WeChat, Alipay, ByteDance, Baidu, QQ, DingTalk, Kuaishou) & Taro / uni-app | 小程序监控 SDK，支持异常监控、性能监控、错误收集",
   "repository": {
     "type": "git",
-    "url": "git://github.com/lizhiyao/sentry-miniapp.git"
+    "url": "git+https://github.com/lizhiyao/sentry-miniapp.git"
   },
   "homepage": "https://github.com/lizhiyao/sentry-miniapp",
   "scripts": {
-    "build": "vite build && npm run check:build-output && npm run check:package",
-    "check:build-output": "node scripts/internal/check-build-output.mjs dist/sentry-miniapp.esm.js dist/sentry-miniapp.cjs.js dist/sentry-miniapp.umd.js",
+    "build": "vite build && npm run build:type-entrypoints && npm run check:build-output && npm run check:package && npm run check:package-consumers",
+    "build:type-entrypoints": "node scripts/internal/create-type-entrypoints.mjs",
+    "check:build-output": "node scripts/internal/check-build-output.mjs dist/sentry-miniapp.mjs dist/sentry-miniapp.cjs dist/sentry-miniapp.umd.js",
     "check:package": "publint --level error",
+    "check:package-consumers": "node scripts/internal/check-package-consumers.mjs",
     "build:miniapp": "vite build --mode miniapp && node scripts/internal/check-build-output.mjs examples/wxapp/lib/sentry-miniapp.js && node scripts/internal/check-miniapp-bundle.mjs examples/wxapp/lib/sentry-miniapp.js",
-    "build:types": "vite build && tsc --emitDeclarationOnly --outDir dist/types",
+    "build:types": "vite build && tsc --emitDeclarationOnly --outDir dist/types && npm run build:type-entrypoints",
     "dev": "vite build --watch",
     "dev:miniapp": "vite build --mode miniapp --watch",
     "docs:dev": "vitepress dev website",
@@ -30,12 +32,14 @@
   },
   "author": "dancerlzy@gmail.com",
   "license": "MIT",
+  "sideEffects": true,
+  "type": "commonjs",
   "packageManager": "yarn@4.16.0",
   "engines": {
     "node": ">=20"
   },
-  "main": "dist/sentry-miniapp.cjs.js",
-  "module": "dist/sentry-miniapp.esm.js",
+  "main": "dist/sentry-miniapp.cjs",
+  "module": "dist/sentry-miniapp.mjs",
   "types": "dist/types/index.d.ts",
   "bin": {
     "sentry-miniapp-sourcemap-doctor": "scripts/doctor-sourcemap.mjs",
@@ -43,10 +47,14 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/types/index.d.ts",
-      "import": "./dist/sentry-miniapp.esm.js",
-      "require": "./dist/sentry-miniapp.cjs.js",
-      "default": "./dist/sentry-miniapp.umd.js"
+      "import": {
+        "types": "./dist/types/index.d.mts",
+        "default": "./dist/sentry-miniapp.mjs"
+      },
+      "require": {
+        "types": "./dist/types/index.d.cts",
+        "default": "./dist/sentry-miniapp.cjs"
+      }
     }
   },
   "files": [
@@ -60,6 +68,7 @@
     "@babel/plugin-transform-regenerator": "^7.29.8",
     "@commitlint/cli": "^20.5.0",
     "@commitlint/config-conventional": "^20.5.0",
+    "@publint/pack": "^0.1.7",
     "@types/node": "^20.19.11",
     "@typescript-eslint/eslint-plugin": "^8.57.1",
     "@typescript-eslint/parser": "^8.57.1",

--- a/scripts/internal/check-package-consumers.mjs
+++ b/scripts/internal/check-package-consumers.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { access, cp, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+import { pack, unpack } from '@publint/pack';
+
+const execFileAsync = promisify(execFile);
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const requiredExports = [
+  'Integrations',
+  'SDK_VERSION',
+  'Transports',
+  'addBreadcrumb',
+  'captureException',
+  'captureMessage',
+  'init',
+  'logger',
+  'miniappStackParser',
+  'setUser',
+  'startSpan',
+];
+
+async function writeConsumer(file, source) {
+  await writeFile(file, source, 'utf8');
+}
+
+async function runNode(file, cwd, { nodeArgs = [], scriptArgs = [] } = {}) {
+  return execFileAsync(process.execPath, [...nodeArgs, file, ...scriptArgs], {
+    cwd,
+    encoding: 'utf8',
+  });
+}
+
+async function unpackPackage(tarball, packageRoot) {
+  const { files, rootDir } = await unpack(await readFile(tarball));
+  const rootPrefix = `${rootDir}/`;
+
+  for (const file of files) {
+    assert(file.name.startsWith(rootPrefix), `Unexpected tarball entry: ${file.name}`);
+    const relativeName = file.name.slice(rootPrefix.length);
+    if (!relativeName) continue;
+
+    const destination = join(packageRoot, relativeName);
+    await mkdir(dirname(destination), { recursive: true });
+    await writeFile(destination, file.data);
+  }
+}
+
+function runtimeProbe(moduleSyntax) {
+  const required = JSON.stringify(requiredExports);
+  const load =
+    moduleSyntax === 'esm'
+      ? "import * as sdk from 'sentry-miniapp';\nimport assert from 'node:assert/strict';"
+      : "const sdk = require('sentry-miniapp');\nconst assert = require('node:assert/strict');";
+
+  return `${load}
+const required = ${required};
+for (const name of required) {
+  assert.ok(name in sdk, \`Missing public export: \${name}\`);
+}
+process.stdout.write(JSON.stringify({
+  keys: Object.keys(sdk).sort(),
+  version: sdk.SDK_VERSION,
+}));
+`;
+}
+
+const typeProbe = `
+import {
+  Integrations,
+  Transports,
+  captureException,
+  init,
+  logger,
+  miniappStackParser,
+  type MiniappOptions,
+  type PerformanceIntegrationOptions,
+} from 'sentry-miniapp';
+
+declare const options: MiniappOptions;
+const performanceOptions: PerformanceIntegrationOptions = {};
+
+init(options);
+captureException(new Error('consumer type probe'));
+logger.info('consumer type probe');
+Integrations.performanceIntegration(performanceOptions);
+Transports.createMiniappTransport;
+miniappStackParser;
+`;
+
+const tempRoot = await mkdtemp(join(tmpdir(), 'sentry-miniapp-package-consumers-'));
+
+try {
+  const tarball = await pack(repoRoot, {
+    destination: tempRoot,
+    packageManager: 'yarn',
+  });
+  const nodeModules = join(tempRoot, 'node_modules');
+  const packageRoot = join(nodeModules, 'sentry-miniapp');
+
+  await mkdir(packageRoot, { recursive: true });
+  await unpackPackage(tarball, packageRoot);
+  await cp(join(repoRoot, 'node_modules/@sentry'), join(nodeModules, '@sentry'), {
+    dereference: true,
+    recursive: true,
+  });
+
+  const packageJson = JSON.parse(await readFile(join(packageRoot, 'package.json'), 'utf8'));
+  await Promise.all([
+    access(join(packageRoot, packageJson.exports['.'].import.types)),
+    access(join(packageRoot, packageJson.exports['.'].require.types)),
+  ]);
+  await writeConsumer(
+    join(tempRoot, 'package.json'),
+    JSON.stringify({ name: 'sentry-miniapp-consumer-smoke', private: true, type: 'module' }),
+  );
+
+  const cjsConsumer = join(tempRoot, 'consumer.cjs');
+  const esmConsumer = join(tempRoot, 'consumer.mjs');
+  await writeConsumer(cjsConsumer, runtimeProbe('cjs'));
+  await writeConsumer(esmConsumer, runtimeProbe('esm'));
+
+  const cjsExecution = await runNode(cjsConsumer, tempRoot);
+  const esmExecution = await runNode(esmConsumer, tempRoot);
+  assert.equal(cjsExecution.stderr, '', `CJS import emitted stderr:\n${cjsExecution.stderr}`);
+  assert.equal(esmExecution.stderr, '', `ESM import emitted stderr:\n${esmExecution.stderr}`);
+
+  const cjsResult = JSON.parse(cjsExecution.stdout);
+  const esmResult = JSON.parse(esmExecution.stdout);
+  assert.deepEqual(esmResult.keys, cjsResult.keys, 'ESM and CJS exports differ');
+  assert.equal(
+    cjsResult.version,
+    packageJson.version,
+    'CJS SDK_VERSION differs from package version',
+  );
+  assert.equal(
+    esmResult.version,
+    packageJson.version,
+    'ESM SDK_VERSION differs from package version',
+  );
+
+  await writeConsumer(join(tempRoot, 'consumer.mts'), typeProbe);
+  await writeConsumer(join(tempRoot, 'consumer.cts'), typeProbe);
+  await writeConsumer(
+    join(tempRoot, 'tsconfig.json'),
+    JSON.stringify({
+      compilerOptions: {
+        module: 'NodeNext',
+        moduleResolution: 'NodeNext',
+        noEmit: true,
+        skipLibCheck: false,
+        strict: true,
+        target: 'ES2020',
+      },
+      include: ['consumer.mts', 'consumer.cts'],
+    }),
+  );
+
+  await runNode(join(repoRoot, 'node_modules/typescript/bin/tsc'), tempRoot, {
+    scriptArgs: ['--project', join(tempRoot, 'tsconfig.json')],
+  });
+
+  console.log(
+    `Package consumer checks passed for CJS, ESM and TypeScript (${cjsResult.keys.length} exports).`,
+  );
+} finally {
+  await rm(tempRoot, { force: true, recursive: true });
+}

--- a/scripts/internal/create-type-entrypoints.mjs
+++ b/scripts/internal/create-type-entrypoints.mjs
@@ -1,0 +1,16 @@
+#!/usr/bin/env node
+
+import { access, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+const typesDirectory = resolve('dist/types');
+const declarationEntry = resolve(typesDirectory, 'index.d.ts');
+const declarationFacade = "export * from './index.js';\n";
+
+await access(declarationEntry);
+await Promise.all([
+  writeFile(resolve(typesDirectory, 'index.d.mts'), declarationFacade, 'utf8'),
+  writeFile(resolve(typesDirectory, 'index.d.cts'), declarationFacade, 'utf8'),
+]);
+
+console.log('Created ESM and CJS declaration entrypoints.');

--- a/vite.config.js
+++ b/vite.config.js
@@ -119,12 +119,12 @@ export default defineConfig(({ mode }) => {
         output: [
           {
             format: 'es',
-            entryFileNames: 'sentry-miniapp.esm.js',
+            entryFileNames: 'sentry-miniapp.mjs',
             exports: 'named'
           },
           {
             format: 'cjs',
-            entryFileNames: 'sentry-miniapp.cjs.js',
+            entryFileNames: 'sentry-miniapp.cjs',
             exports: 'auto'
           },
           {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6403,6 +6403,7 @@ __metadata:
     "@babel/plugin-transform-regenerator": "npm:^7.29.8"
     "@commitlint/cli": "npm:^20.5.0"
     "@commitlint/config-conventional": "npm:^20.5.0"
+    "@publint/pack": "npm:^0.1.7"
     "@sentry/core": "npm:10.70.0"
     "@types/node": "npm:^20.19.11"
     "@typescript-eslint/eslint-plugin": "npm:^8.57.1"


### PR DESCRIPTION
## 背景

现有构建只校验产物结构与静态元数据，没有验证发布 tarball 被真实项目通过 CommonJS、ESM 和 TypeScript 消费时是否可用。

在补充消费者测试时，实际发现 Node 20 无法加载原来的 `.esm.js` 入口；进一步检查还发现 ESM 运行入口对应的声明文件会被 TypeScript 识别为 CommonJS。

## 改动

- 将运行入口规范为 `.mjs` 和 `.cjs`，明确包根目录为 CommonJS
- 为 `import` / `require` 分别提供 `.d.mts` / `.d.cts` 类型入口
- 从真实 `yarn pack` tarball 创建临时消费项目，验证 CJS、ESM、公开导出、版本和 NodeNext 类型
- 在 Node 20、22、24 CI 中构建并验证发布包
- 保留 `sideEffects: true`，避免打包器错误移除 SDK 的 polyfill 初始化

## 验证

- `yarn run lint`
- `yarn run typecheck`
- `yarn run test:coverage`（712 tests）
- `yarn run build`
- `yarn run build:types`
- `yarn run build:miniapp`
- Node 20.15 执行 `check:package-consumers`
- `Are the Types Wrong`：Node CJS、Node ESM 与 bundler 均通过
