### PR TITLE
chore(release): 准备 1.19.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-miniapp",
-  "version": "1.19.1",
+  "version": "1.19.2",
   "description": "Sentry SDK for Mini Programs (WeChat, Alipay, ByteDance, Baidu, QQ, DingTalk, Kuaishou) & Taro / uni-app | 小程序监控 SDK，支持异常监控、性能监控、错误收集",
   "repository": {
     "type": "git",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
 // 版本号应该与 package.json 中的版本保持同步
-export const SDK_VERSION = '1.19.1';
+export const SDK_VERSION = '1.19.2';
 export const SDK_NAME = 'sentry.javascript.miniapp';


### PR DESCRIPTION
## 发布版本

`1.19.2`

## 主要变更

- 修复 Node 20 无法加载 ESM 入口的问题
- 为 ESM / CommonJS 分别提供正确分类的 TypeScript 声明入口
- 使用真实 npm tarball 验证 CJS、ESM、公开导出、SDK 版本与 NodeNext 类型
- 在 Node 20、22、24 CI 中验证发布包消费兼容性

## 发布前验证

- `yarn run lint`
- `yarn run typecheck`
- `yarn run test`（712 tests）
- `yarn run build`
- `yarn run build:miniapp`
