### PR TITLE
chore(release): 准备 1.19.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-miniapp",
-  "version": "1.19.2",
+  "version": "1.19.3",
   "description": "Sentry SDK for Mini Programs (WeChat, Alipay, ByteDance, Baidu, QQ, DingTalk, Kuaishou) & Taro / uni-app | 小程序监控 SDK，支持异常监控、性能监控、错误收集",
   "repository": {
     "type": "git",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
 // 版本号应该与 package.json 中的版本保持同步
-export const SDK_VERSION = '1.19.2';
+export const SDK_VERSION = '1.19.3';
 export const SDK_NAME = 'sentry.javascript.miniapp';


### PR DESCRIPTION
## 发布内容

准备发布 `sentry-miniapp@1.19.3`。

本版本包含 #331 对 #330 的修复：抖音小游戏等缺少 `PerformanceObserver` 且没有活跃父 span 的运行时，API 请求会作为 standalone `http.client` segment span 上报，不再丢失全部 HTTP 性能数据。

## 变更

- `package.json`: `1.19.2` → `1.19.3`
- `src/version.ts`: `1.19.2` → `1.19.3`

## 验证

- `yarn lint`
- `yarn typecheck`
- `yarn test`（46 个文件，716 个用例）
- `yarn build`（包含 publint 与 CJS / ESM / TypeScript 消费者检查）

合并后从 `master` 的合并提交创建 `v1.19.3` tag，由发布 workflow 通过 npm Trusted Publishing 发布，并自动创建 GitHub Release。
