### PR TITLE
test: 加固网络追踪与平台边界用例

### DIFF
--- a/test/crossPlatform.test.ts
+++ b/test/crossPlatform.test.ts
@@ -110,6 +110,30 @@ describe('CrossPlatform', () => {
       expect(detectPlatform()).toEqual({ sdk: mockTt, name: 'bytedance' });
     });
 
+    it('wx / tt 共存时根据微信 AppID 保持使用 wx 宿主', async () => {
+      const mockWx = {
+        request: vi.fn(),
+        getAccountInfoSync: vi.fn(() => ({ miniProgram: { appId: 'wx1234567890' } })),
+      };
+      (global as any).wx = mockWx;
+      (global as any).tt = { request: vi.fn(), getSystemInfoSync: vi.fn(() => ({})) };
+
+      const { detectPlatform } = await import('../src/crossPlatform');
+      expect(detectPlatform()).toEqual({ sdk: mockWx, name: 'wechat' });
+    });
+
+    it('wx / tt 共存但 AppID 无法识别时保留历史 first-match', async () => {
+      const mockWx = { request: vi.fn() };
+      (global as any).wx = mockWx;
+      (global as any).tt = {
+        request: vi.fn(),
+        getAccountInfoSync: vi.fn(() => ({ miniProgram: { appId: 'unknown-app-id' } })),
+      };
+
+      const { detectPlatform } = await import('../src/crossPlatform');
+      expect(detectPlatform()).toEqual({ sdk: mockWx, name: 'wechat' });
+    });
+
     it.each([
       ['getEnvInfoSync', () => ({ microapp: { appId: 'tt1234567890' } })],
       ['getAccountInfoSync', () => ({ miniProgram: { appId: 'tt1234567890' } })],

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -462,6 +462,67 @@ describe('Helpers', () => {
   });
 
   describe('getErrorDetails', () => {
+    it('should parse a string-form mini program error', () => {
+      const stack = [
+        'MiniProgramError',
+        'Cannot read properties of undefined',
+        'at onLoad (pages/index/index.js:10:5)',
+      ].join('\n');
+
+      expect(getErrorDetails(stack)).toEqual({
+        message: 'Cannot read properties of undefined',
+        stack,
+      });
+    });
+
+    it('should use an embedded host stack when the stack property is empty', () => {
+      const embeddedStack = [
+        'TypeError: player is undefined',
+        'at update (game.js:20:3)',
+      ].join('\n');
+
+      expect(getErrorDetails({ message: embeddedStack, stack: '' })).toEqual({
+        message: 'player is undefined',
+        stack: embeddedStack,
+        type: 'TypeError',
+      });
+    });
+
+    it.each([null, undefined, false, 0])(
+      'should ignore non-error primitive value %j',
+      value => {
+        expect(getErrorDetails(value)).toBeUndefined();
+      },
+    );
+
+    it('should contain host objects whose error properties throw', () => {
+      const value = new Proxy(
+        {},
+        {
+          get() {
+            throw new Error('host error is no longer readable');
+          },
+        },
+      );
+
+      expect(getErrorDetails(value)).toBeUndefined();
+    });
+
+    it('should preserve a standard Error-compatible object type', () => {
+      expect(getErrorDetails({ message: 'out of range', stack: '', name: 'RangeError' })).toEqual({
+        message: 'out of range',
+        stack: '',
+        type: 'RangeError',
+      });
+    });
+
+    it('should not treat an ordinary object constructor as an error type', () => {
+      expect(getErrorDetails({ message: 'host error', stack: '', name: '' })).toEqual({
+        message: 'host error',
+        stack: '',
+      });
+    });
+
     it('should tolerate a throwing name getter and still use the constructor type', () => {
       const value = {
         message: 'host error',

--- a/test/networkbreadcrumbs.realcore.test.ts
+++ b/test/networkbreadcrumbs.realcore.test.ts
@@ -131,4 +131,115 @@ describe('NetworkBreadcrumbs（真 @sentry/core 集成）', () => {
       }),
     ]);
   });
+
+  it('采样率为 0 时请求正常执行但不发送 span', async () => {
+    const beforeSendSpan = vi.fn((span: SpanJSON) => span);
+
+    init({
+      dsn: 'https://test@o0.ingest.sentry.io/0',
+      platform: 'bytedance',
+      tracesSampleRate: 0,
+      enableOfflineCache: false,
+      enableAutoSessionTracking: false,
+      enableMinigameLifecycle: false,
+      enableMinigameFrameRate: false,
+      beforeSendSpan,
+      transport: createCapturingTransport(captured),
+    });
+
+    g.tt.request({ url: 'https://api.example.com/v1/health' });
+    await flush(2000);
+
+    expect(requestMock).toHaveBeenCalledOnce();
+    expect(collectEnvelopePayloads(captured, ['span', 'transaction'])).toEqual([]);
+    expect(beforeSendSpan).not.toHaveBeenCalled();
+  });
+
+  it('关闭独立 HTTP span 后，无 active span 的请求不发送 span envelope', async () => {
+    init({
+      dsn: 'https://test@o0.ingest.sentry.io/0',
+      platform: 'bytedance',
+      tracesSampleRate: 1,
+      enableStandaloneHttpSpans: false,
+      enableOfflineCache: false,
+      enableAutoSessionTracking: false,
+      enableMinigameLifecycle: false,
+      enableMinigameFrameRate: false,
+      transport: createCapturingTransport(captured),
+    });
+
+    g.tt.request({ url: 'https://api.example.com/v1/health' });
+    await flush(2000);
+
+    expect(requestMock).toHaveBeenCalledOnce();
+    expect(collectEnvelopePayloads(captured, ['span', 'transaction'])).toEqual([]);
+  });
+
+  it('请求失败时把错误原因写入独立 span，并标记为失败', async () => {
+    requestMock.mockImplementationOnce((options) => {
+      const error = { errMsg: 'request:fail timeout' };
+      options.fail?.(error);
+      options.complete?.(error);
+      return { abort: vi.fn() };
+    });
+
+    init({
+      dsn: 'https://test@o0.ingest.sentry.io/0',
+      platform: 'bytedance',
+      tracesSampleRate: 1,
+      enableOfflineCache: false,
+      enableAutoSessionTracking: false,
+      enableMinigameLifecycle: false,
+      enableMinigameFrameRate: false,
+      transport: createCapturingTransport(captured),
+    });
+
+    g.tt.request({ url: 'https://api.example.com/v1/timeout' });
+    await flush(2000);
+
+    const spans = collectEnvelopePayloads<SpanJSON>(captured, ['span']);
+    expect(spans).toHaveLength(1);
+    expect(spans[0]).toEqual(
+      expect.objectContaining({
+        op: 'http.client',
+        is_segment: true,
+        data: expect.objectContaining({
+          'error.message': 'request:fail timeout',
+        }),
+      }),
+    );
+    expect(spans[0]?.status).toBe('request:fail timeout');
+  });
+
+  it('HTTP 5xx 响应保留状态码，并把独立 span 标记为失败', async () => {
+    requestMock.mockImplementationOnce((options) => {
+      const response = { statusCode: 503, data: { ok: false }, header: {} };
+      options.success?.(response);
+      options.complete?.(response);
+      return { abort: vi.fn() };
+    });
+
+    init({
+      dsn: 'https://test@o0.ingest.sentry.io/0',
+      platform: 'bytedance',
+      tracesSampleRate: 1,
+      enableOfflineCache: false,
+      enableAutoSessionTracking: false,
+      enableMinigameLifecycle: false,
+      enableMinigameFrameRate: false,
+      transport: createCapturingTransport(captured),
+    });
+
+    g.tt.request({ url: 'https://api.example.com/v1/unavailable' });
+    await flush(2000);
+
+    const spans = collectEnvelopePayloads<SpanJSON>(captured, ['span']);
+    expect(spans).toHaveLength(1);
+    expect(spans[0]?.data).toEqual(
+      expect.objectContaining({
+        'http.response.status_code': 503,
+      }),
+    );
+    expect(spans[0]?.status).toBe('unavailable');
+  });
 });


### PR DESCRIPTION
## 改动内容

- 为独立 HTTP span 补充真实 `@sentry/core` 集成测试，覆盖采样关闭、功能开关、请求超时和 HTTP 503
- 补充 `wx` / `tt` 共存时微信 AppID 与未知 AppID 的平台识别回退
- 补充小程序字符串异常、内嵌堆栈、异常宿主对象和错误类型解析边界

## 验证结果

- `yarn lint`
- `yarn typecheck`
- `yarn test:coverage`：46 个测试文件、731 条用例全部通过
- 覆盖率：statements/lines 99.26%、branches 95.92%、functions 99.44%
- `yarn test:shuffle`：731 条用例全部通过