### PR TITLE
test: 提高覆盖率质量门槛

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,8 +69,8 @@ This is critical: when modifying functionality, **always consider the impact on 
   only assert calls to mocks or helper logic defined inside the test itself.
 - Reuse `test/support/` for real `@sentry/core` transports and envelope assertions. Prefer fake
   timers over real delays for time-dependent behavior.
-- Coverage must stay above the enforced global thresholds: 99% statements/lines,
-  95.25% branches, and 99.3% functions. New changes should improve coverage without
+- Coverage must stay above the enforced global thresholds: 99.2% statements/lines,
+  95.75% branches, and 99.3% functions. New changes should improve coverage without
   excluding production code from measurement.
 
 ## License

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -23,10 +23,10 @@ export default defineConfig({
       reportsDirectory: 'coverage',
       reporter: ['text', 'lcov', 'html'],
       thresholds: {
-        statements: 99,
-        branches: 95.25,
+        statements: 99.2,
+        branches: 95.75,
         functions: 99.3,
-        lines: 99,
+        lines: 99.2,
       },
     },
   },


### PR DESCRIPTION
## 改动内容

- 将 statements / lines 覆盖率门槛由 99% 提升至 99.2%
- 将 branches 覆盖率门槛由 95.25% 提升至 95.75%
- 同步更新贡献文档，固化 #333 获得的测试质量提升

## 验证结果

- `yarn test:coverage`：46 个测试文件、731 条用例全部通过
- 当前覆盖率：statements/lines 99.26%、branches 95.92%、functions 99.44%
- `git diff --check`