### PR TITLE
test: 补齐跨平台独立追踪契约

### DIFF
--- a/test/platform-contracts.realcore.test.ts
+++ b/test/platform-contracts.realcore.test.ts
@@ -4,6 +4,7 @@ import {
   getClient,
   getIsolationScope,
   installedIntegrations,
+  type SpanJSON,
 } from '@sentry/core';
 
 import { _resetAppLifecycle } from '../src/appLifecycle';
@@ -31,8 +32,11 @@ const PLATFORM_CONTRACTS: PlatformContract[] = [
   { globalName: 'ks', platform: 'kuaishou', requestMethod: 'request', objectStorage: false },
 ];
 
-function collectEvents(capturedRequests: Array<Record<string, any>>): any[] {
-  const events: any[] = [];
+function collectEnvelopePayloads<T>(
+  capturedRequests: Array<Record<string, any>>,
+  itemType: string,
+): T[] {
+  const payloads: T[] = [];
   for (const request of capturedRequests) {
     const body =
       typeof request.data === 'string'
@@ -42,10 +46,14 @@ function collectEvents(capturedRequests: Array<Record<string, any>>): any[] {
     for (let index = 1; index + 1 < lines.length; index += 2) {
       const itemHeader = JSON.parse(lines[index]!);
       const payload = JSON.parse(lines[index + 1]!);
-      if (itemHeader.type === 'event') events.push(payload);
+      if (itemHeader.type === itemType) payloads.push(payload as T);
     }
   }
-  return events;
+  return payloads;
+}
+
+function collectEvents(capturedRequests: Array<Record<string, any>>): any[] {
+  return collectEnvelopePayloads(capturedRequests, 'event');
 }
 
 describe.each(PLATFORM_CONTRACTS)(
@@ -436,6 +444,58 @@ describe.each(PLATFORM_CONTRACTS)(
       );
       expect(event?.contexts?.miniapp?.platform).toBe(platform);
       expect(event?.contexts?.device?.brand).toBe('unknown');
+      await client!.close(2000);
+    });
+
+    it('无 active span 时通过宿主请求 API 上报独立 HTTP span', async () => {
+      const client = init({
+        dsn: 'https://test@o0.ingest.sentry.io/0',
+        platform,
+        tracesSampleRate: 1,
+        tracePropagationTargets: ['api.example.com'],
+        enableOfflineCache: false,
+        enableAutoSessionTracking: false,
+        enableMinigameLifecycle: false,
+        enableMinigameFrameRate: false,
+      });
+
+      const requestTask = host[requestMethod]({
+        url: `https://api.example.com/${platform}/users?token=secret`,
+        method: 'POST',
+        header: { 'X-Business': 'preserved' },
+      });
+      expect(requestTask).toEqual(expect.objectContaining({ abort: expect.any(Function) }));
+      await client!.flush(2000);
+
+      const spans = collectEnvelopePayloads<SpanJSON>(capturedRequests, 'span');
+      expect(spans).toEqual([
+        expect.objectContaining({
+          description: `POST https://api.example.com/${platform}/users`,
+          op: 'http.client',
+          origin: 'auto.http.miniapp',
+          is_segment: true,
+          segment_id: expect.any(String),
+          status: 'ok',
+          data: expect.objectContaining({
+            'http.request.method': 'POST',
+            'http.response.status_code': 200,
+            'url.full': `https://api.example.com/${platform}/users?token=secret`,
+            'server.address': 'api.example.com',
+          }),
+        }),
+      ]);
+
+      const forwardedRequest = originalRequest.mock.calls.find(
+        ([options]) => options.url === `https://api.example.com/${platform}/users?token=secret`,
+      )?.[0];
+      expect(forwardedRequest?.header).toEqual(
+        expect.objectContaining({
+          'X-Business': 'preserved',
+          'sentry-trace': expect.any(String),
+          baggage: expect.stringContaining('sentry-'),
+        }),
+      );
+
       await client!.close(2000);
     });
   },


### PR DESCRIPTION
## 改动内容

- 扩展真实 `@sentry/core` 平台契约测试，覆盖微信、支付宝、字节跳动、钉钉、QQ、百度和快手
- 验证各平台 `request` / `httpRequest` 在无 active span 时都会发送独立 HTTP span envelope
- 验证 span 名去除 query、完整 URL 与状态码属性保留、segment 标记正确
- 验证业务 header 保留，并注入 `sentry-trace` 与 `baggage`
- 抽取通用 envelope payload 解析器，事件与 span 复用同一解析路径

## 验证结果

- `yarn lint`
- `yarn typecheck`
- `yarn test:coverage`：48 个测试文件、738 条用例全部通过
- 覆盖率：statements/lines 99.26%、branches 95.93%、functions 99.44%
- `yarn test:shuffle`：738 条用例全部通过