### PR TITLE
test: 将发布脚本纳入代码检查

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "docs:build": "vitepress build website",
     "docs:preview": "vitepress preview website",
     "sourcemap:doctor": "node scripts/doctor-sourcemap.mjs",
-    "lint": "eslint src test --ext .ts",
+    "lint": "eslint src test scripts --ext .ts,.js,.mjs --max-warnings 0",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
@@ -96,7 +96,7 @@
     "vite@npm:^5.4.14": "npm:6.4.3"
   },
   "lint-staged": {
-    "src/**/*.{ts,js}": [
+    "{src,test,scripts}/**/*.{ts,js,mjs}": [
       "eslint --fix",
       "prettier --write"
     ],

--- a/scripts/doctor-sourcemap.mjs
+++ b/scripts/doctor-sourcemap.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { existsSync, readFileSync, statSync } from 'node:fs';
-import { basename, dirname, join, relative, resolve } from 'node:path';
+import { basename, dirname, relative, resolve } from 'node:path';
 import {
   collectBuildMaps,
   collectFiles,

--- a/scripts/internal/check-miniapp-bundle.mjs
+++ b/scripts/internal/check-miniapp-bundle.mjs
@@ -22,7 +22,7 @@ assert.equal(sourceMap.version, 3, 'source map must use version 3');
 assert.ok(sourceMap.sources?.length > 0, 'source map must contain sources');
 assert.ok(
   code.includes(`sourceMappingURL=${basename(sourceMapPath)}`),
-  'bundle must reference its adjacent source map'
+  'bundle must reference its adjacent source map',
 );
 
 const tempDirectory = await mkdtemp(join(tmpdir(), 'sentry-miniapp-bundle-'));

--- a/scripts/version-updater.js
+++ b/scripts/version-updater.js
@@ -8,8 +8,5 @@ module.exports.readVersion = function (contents) {
 };
 
 module.exports.writeVersion = function (contents, version) {
-  return contents.replace(
-    /SDK_VERSION\s*=\s*'[^']+'/,
-    `SDK_VERSION = '${version}'`,
-  );
+  return contents.replace(/SDK_VERSION\s*=\s*'[^']+'/, `SDK_VERSION = '${version}'`);
 };


### PR DESCRIPTION
## 改动说明

- 将 `scripts/**/*.js|mjs` 纳入仓库 ESLint 门禁
- 将 lint 设置为零 warning，避免发布脚本带着静态检查问题进入 npm 包
- 扩展 lint-staged，使源码、测试和脚本在提交前统一执行 ESLint 与 Prettier
- 清理 Source Map doctor 的未使用导入，并对齐两处既有脚本格式

## 验证

- `yarn run lint`
- `yarn run typecheck`
- `yarn run test`（48 个文件、738 个用例）
- `yarn run build`
- `yarn prettier --check package.json scripts`