### PR TITLE
test: 验证发布包最小运行时兼容性

### DIFF
--- a/scripts/internal/check-package-consumers.mjs
+++ b/scripts/internal/check-package-consumers.mjs
@@ -66,8 +66,14 @@ function runtimeProbe(moduleSyntax) {
   const platforms = JSON.stringify(platformContracts);
   const load =
     moduleSyntax === 'esm'
-      ? "import * as sdk from 'sentry-miniapp';\nimport assert from 'node:assert/strict';"
-      : "const sdk = require('sentry-miniapp');\nconst assert = require('node:assert/strict');";
+      ? `import assert from 'node:assert/strict';
+const nativeURLSearchParams = globalThis.URLSearchParams;
+assert.equal(Reflect.deleteProperty(globalThis, 'URLSearchParams'), true);
+const sdk = await import('sentry-miniapp');`
+      : `const assert = require('node:assert/strict');
+const nativeURLSearchParams = globalThis.URLSearchParams;
+assert.equal(Reflect.deleteProperty(globalThis, 'URLSearchParams'), true);
+const sdk = require('sentry-miniapp');`;
 
   const runStart = moduleSyntax === 'esm' ? '' : 'async function main() {';
   const runEnd =
@@ -85,6 +91,16 @@ const required = ${required};
 for (const name of required) {
   assert.ok(name in sdk, \`Missing public export: \${name}\`);
 }
+assert.equal(
+  typeof globalThis.URLSearchParams,
+  'function',
+  'Package entrypoint did not install the URLSearchParams polyfill',
+);
+assert.notEqual(
+  globalThis.URLSearchParams,
+  nativeURLSearchParams,
+  'Package runtime probe unexpectedly kept the native URLSearchParams',
+);
 
 const platformName = process.argv[2] || 'wechat';
 const contract = ${platforms}.find(candidate => candidate.platform === platformName);
@@ -142,10 +158,6 @@ async function runUmdProbe(packageRoot, expectedVersion) {
     clearTimeout,
     console,
     setTimeout,
-    TextDecoder,
-    TextEncoder,
-    URL,
-    URLSearchParams,
     wx: {
       request(options) {
         const headers = { ...(options.headers || {}), ...(options.header || {}) };
@@ -170,6 +182,22 @@ async function runUmdProbe(packageRoot, expectedVersion) {
 
   const sdk = sandbox.SentryMiniapp;
   assert.ok(sdk, 'UMD bundle did not expose globalThis.SentryMiniapp');
+  assert.equal(
+    typeof sandbox.URLSearchParams,
+    'function',
+    'UMD bundle did not install the URLSearchParams polyfill',
+  );
+  assert.equal(sandbox.URL, undefined, 'UMD runtime probe unexpectedly received URL');
+  assert.equal(
+    sandbox.TextEncoder,
+    undefined,
+    'UMD runtime probe unexpectedly received TextEncoder',
+  );
+  assert.equal(
+    sandbox.TextDecoder,
+    undefined,
+    'UMD runtime probe unexpectedly received TextDecoder',
+  );
   for (const name of requiredExports) {
     assert.ok(name in sdk, `UMD bundle is missing public export: ${name}`);
   }


### PR DESCRIPTION
## 改动说明

- CJS 与 7 平台 ESM 消费者在加载 SDK 前移除 Node 原生 `URLSearchParams`
- 验证最终 npm 包入口会安装 SDK 自带 polyfill，并能继续初始化和发送 envelope
- UMD 沙箱不再注入 `URL`、`URLSearchParams`、`TextEncoder`、`TextDecoder`，更贴近小程序运行时
- 明确断言 UMD 不依赖这些测试环境 Web API 完成基础上报

## 验证

- `yarn run lint`
- `yarn run typecheck`
- `yarn run test`（48 个文件、738 个用例）
- `yarn run build`
- `yarn prettier --check scripts/internal/check-package-consumers.mjs`