### PR TITLE
test: 将测试代码纳入严格类型检查

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,6 +23,7 @@ Brief description of changes.
 - [ ] Code follows the existing code style (ESLint + Prettier)
 - [ ] Tests added/updated for the changes
 - [ ] `yarn lint` passes
+- [ ] `yarn typecheck` passes
 - [ ] `yarn test:coverage` passes
 - [ ] Cross-platform compatibility considered
 - [ ] Documentation updated (if applicable)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ cp -r .agents/skills/sentry-miniapp-sdk ~/.agents/skills/sentry-miniapp-sdk
 
 - `yarn install` - 安装依赖
 - `yarn run lint` - 代码检查
+- `yarn run typecheck` - 严格检查源码与测试代码的 TypeScript 类型
 - `yarn run test` - 运行单元测试（Vitest）
 - `yarn run test:coverage` - 运行单元测试并检查覆盖率门槛
 - `yarn run test:shuffle` - 随机化用例顺序，检查测试隔离性

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ git checkout -b fix/my-fix
 3. Ensure all checks pass:
 
 ```bash
-yarn lint && yarn test
+yarn lint && yarn typecheck && yarn test
 ```
 
 4. Commit using [Conventional Commits](https://www.conventionalcommits.org/) format:
@@ -69,6 +69,8 @@ This is critical: when modifying functionality, **always consider the impact on 
   only assert calls to mocks or helper logic defined inside the test itself.
 - Reuse `test/support/` for real `@sentry/core` transports and envelope assertions. Prefer fake
   timers over real delays for time-dependent behavior.
+- `yarn typecheck` checks both production code and tests. Keep mocks compatible with the real
+  function signatures instead of bypassing test type errors with broad casts.
 - Coverage must stay above the enforced global thresholds: 99.2% statements/lines,
   95.75% branches, and 99.3% functions. New changes should improve coverage without
   excluding production code from measurement.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -32,6 +32,7 @@ yarn install
 | `yarn test:coverage` | 运行单元测试并检查覆盖率门槛 |
 | `yarn test:shuffle` | 随机化用例顺序，排查测试状态污染与顺序依赖 |
 | `yarn lint` | 运行 ESLint 检查 |
+| `yarn typecheck` | 严格检查源码与测试代码的 TypeScript 类型 |
 
 ---
 
@@ -80,6 +81,7 @@ sentry-miniapp/
 
 - **单元测试 (`yarn test`，Vitest)**：覆盖核心类、工具函数与集成插件（跨端兼容性、面包屑、去重、transport 等），用 mock 的平台全局对象跑通 init → 事件构建 → transport → `wx.request` 全链路。
 - **真实 core 集成测试 (`test/*.realcore.test.ts`)**：不 mock `@sentry/core`，验证事件、transaction、session 最终进入 envelope 的形态。自定义 transport 与 envelope 解析统一复用 `test/support/`。
+- **测试类型检查 (`yarn typecheck`)**：源码使用 `tsconfig.json`，测试使用 `tsconfig.test.json`；测试保留严格函数签名检查，仅放宽动态 fixture 的索引访问规则。
 
 测试必须执行 `src/` 或仓库脚本中的生产逻辑；不要只调用测试文件里临时创建的 mock、示例重试函数或常量再断言自身行为。时间相关逻辑优先使用 Vitest fake timers，避免真实等待拖慢 CI。
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "docs:preview": "vitepress preview website",
     "sourcemap:doctor": "node scripts/doctor-sourcemap.mjs",
     "lint": "eslint src test scripts --ext .ts,.js,.mjs --max-warnings 0",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && npm run typecheck:test",
+    "typecheck:test": "tsc --noEmit --project tsconfig.test.json",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:shuffle": "vitest run --sequence.shuffle",
@@ -96,9 +97,12 @@
     "vite@npm:^5.4.14": "npm:6.4.3"
   },
   "lint-staged": {
-    "{src,test,scripts}/**/*.{ts,js,mjs}": [
+    "{src,scripts}/**/*.{ts,js,mjs}": [
       "eslint --fix",
       "prettier --write"
+    ],
+    "test/**/*.ts": [
+      "eslint --fix"
     ],
     "yarn.lock": [
       "node -e \"const fs = require('fs'); const content = fs.readFileSync('yarn.lock', 'utf8'); if (/registry\\.(?!npmjs\\.org)[a-zA-Z0-9-]+\\.(cn|net|com|org)/i.test(content)) { console.error('Error: yarn.lock contains non-official registry URLs. Please clean it.'); process.exit(1); }\""

--- a/test/globalhandlers.realcore.test.ts
+++ b/test/globalhandlers.realcore.test.ts
@@ -10,7 +10,11 @@ import {
 import { resetPlatformCache } from '../src/crossPlatform';
 import { _resetAppLifecycle } from '../src/appLifecycle';
 import { init } from '../src/index';
-import { collectEnvelopePayloads, createCapturingTransport } from './support/envelopes';
+import {
+  assertDefined,
+  collectEnvelopePayloads,
+  createCapturingTransport,
+} from './support/envelopes';
 
 /**
  * GlobalHandlers 的真 @sentry/core 端到端验证：
@@ -72,8 +76,9 @@ describe('GlobalHandlers（真 @sentry/core 集成）', () => {
 
     const events = collectEnvelopePayloads<Event>(captured, ['event']);
     const errEvent = events.find((e) => e.exception?.values?.length);
-    expect(errEvent).toBeDefined();
-    const val = errEvent.exception.values[0];
+    assertDefined(errEvent);
+    const val = errEvent.exception?.values?.[0];
+    assertDefined(val);
     expect(val.value).toContain('boom from platform');
     expect(val.mechanism).toEqual({ type: 'onerror', handled: false });
   });
@@ -99,6 +104,7 @@ describe('GlobalHandlers（真 @sentry/core 集成）', () => {
 
     const events = collectEnvelopePayloads<Event>(captured, ['event']);
     const value = events[0]?.exception?.values?.[0];
+    assertDefined(value);
     expect(value.mechanism).toEqual({ type: 'onerror', handled: false });
     expect(value.stacktrace?.frames).toEqual(
       expect.arrayContaining([
@@ -133,6 +139,7 @@ describe('GlobalHandlers（真 @sentry/core 集成）', () => {
 
     const events = collectEnvelopePayloads<Event>(captured, ['event']);
     const value = events[0]?.exception?.values?.[0];
+    assertDefined(value);
     expect(value.type).toBe('TypeError');
     expect(value.value).toBe('s.Ins.OnEventGameInit is not a function');
     expect(value.mechanism).toEqual({ type: 'onerror', handled: false });

--- a/test/globalhandlers.test.ts
+++ b/test/globalhandlers.test.ts
@@ -132,7 +132,13 @@ describe('GlobalHandlers', () => {
   describe('event-level onError deduplication', () => {
     const event = (mechanism: string, type?: string, value?: string): Event => ({
       exception: {
-        values: [{ mechanism: { type: mechanism, handled: false }, type, value }],
+        values: [
+          {
+            mechanism: { type: mechanism, handled: false },
+            ...(type === undefined ? {} : { type }),
+            ...(value === undefined ? {} : { value }),
+          },
+        ],
       },
     });
 

--- a/test/httpcontext.realcore.test.ts
+++ b/test/httpcontext.realcore.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { captureException, flush, getClient, withScope, type Envelope, type Event } from '@sentry/core';
 import { resetPlatformCache } from '../src/crossPlatform';
 import { init } from '../src/index';
-import { collectEnvelopePayloads, createCapturingTransport } from './support/envelopes';
+import {
+  assertDefined,
+  collectEnvelopePayloads,
+  createCapturingTransport,
+} from './support/envelopes';
 
 describe('HttpContext（真 @sentry/core 集成）', () => {
   const g = global as any;
@@ -57,7 +61,8 @@ describe('HttpContext（真 @sentry/core 集成）', () => {
       item.exception?.values?.[0]?.value?.includes('HttpContext current event'),
     );
 
-    expect(event).toBeDefined();
+    assertDefined(event);
+    assertDefined(event.contexts);
     expect(event.contexts.runtime).toEqual({
       name: 'miniapp',
       version: '2.0.0',
@@ -94,6 +99,8 @@ describe('HttpContext（真 @sentry/core 集成）', () => {
       item.exception?.values?.[0]?.value?.includes('HttpContext custom app'),
     );
 
+    assertDefined(event);
+    assertDefined(event.contexts);
     expect(event.contexts.app).toEqual(
       expect.objectContaining({
         app_identifier: 'custom-app-id',

--- a/test/linkederrors.test.ts
+++ b/test/linkederrors.test.ts
@@ -51,8 +51,10 @@ describe('LinkedErrors fallbacks', () => {
   it('prepends a linked cause chain while preserving root-to-parent order', () => {
     mockGetCurrentScope.mockReturnValue({ getClient: () => ({}) });
     const root = new NativeError('root');
-    const middle = new NativeError('middle', { cause: root });
-    const outer = new NativeError('outer', { cause: middle });
+    const middle = new NativeError('middle') as Error & { cause?: Error };
+    const outer = new NativeError('outer') as Error & { cause?: Error };
+    middle.cause = root;
+    outer.cause = middle;
     const event: Event = {
       exception: { values: [{ type: 'Error', value: 'outer' }] },
     };

--- a/test/minigame-framerate.realcore.test.ts
+++ b/test/minigame-framerate.realcore.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import * as crossPlatform from '../src/crossPlatform';
 import { init } from '../src/index';
 import { getClient, captureException, flush, type Envelope, type Event } from '@sentry/core';
-import { collectEnvelopePayloads, createCapturingTransport } from './support/envelopes';
+import {
+  assertDefined,
+  collectEnvelopePayloads,
+  createCapturingTransport,
+} from './support/envelopes';
 
 /**
  * 与 minigame-framerate.test.ts 不同：此文件**不 mock** `@sentry/core`，而是用真实
@@ -91,7 +95,8 @@ describe('MinigameFrameRateIntegration（真 @sentry/core 集成）', () => {
     const summary = collectEnvelopePayloads<Event>(captured, ['transaction']).find(
       (t) => t.transaction === 'minigame.framerate.summary',
     );
-    expect(summary).toBeDefined();
+    assertDefined(summary);
+    assertDefined(summary.contexts?.trace);
     expect(summary.contexts.trace.op).toBe('ui.framerate');
 
     const m = summary.measurements || {};

--- a/test/minigame-framerate.test.ts
+++ b/test/minigame-framerate.test.ts
@@ -76,7 +76,7 @@ describe('MinigameFrameRateIntegration', () => {
 
     frame(16);
     hideCb?.();
-    showCb?.({});
+    showCb?.();
     integration.cleanup();
 
     expect(mockAddBreadcrumb).not.toHaveBeenCalled();

--- a/test/minigame.test.ts
+++ b/test/minigame.test.ts
@@ -216,7 +216,7 @@ describe('MinigameIntegration', () => {
   it('onShow 缺少参数时仍记录安全的生命周期面包屑', () => {
     new MinigameIntegration().setupOnce();
 
-    expect(() => showCb!()).not.toThrow();
+    expect(() => (showCb as (() => void) | null)?.()).not.toThrow();
     expect(mockAddBreadcrumb).toHaveBeenLastCalledWith(
       expect.objectContaining({
         category: 'minigame.lifecycle',

--- a/test/networkbreadcrumbs.realcore.test.ts
+++ b/test/networkbreadcrumbs.realcore.test.ts
@@ -4,8 +4,9 @@ import {
   getClient,
   startSpan,
   type Envelope,
-  type Event,
+  type EventHint,
   type SpanJSON,
+  type TransactionEvent,
 } from '@sentry/core';
 import { init } from '../src/index';
 import { resetPlatformCache } from '../src/crossPlatform';
@@ -49,7 +50,7 @@ describe('NetworkBreadcrumbs（真 @sentry/core 集成）', () => {
 
   it('无 PerformanceObserver 和 active span 时上报独立 http.client segment span', async () => {
     const beforeSendSpan = vi.fn((span: SpanJSON) => span);
-    const beforeSendTransaction = vi.fn((event: Event) => event);
+    const beforeSendTransaction = vi.fn((event: TransactionEvent, _hint: EventHint) => event);
 
     init({
       dsn: 'https://test@o0.ingest.sentry.io/0',

--- a/test/networkbreadcrumbs.test.ts
+++ b/test/networkbreadcrumbs.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 
+type ActiveSpanStub = { spanContext: () => { spanId: string } };
+type TraceDataStub = { 'sentry-trace'?: string; baggage?: string };
+
 const {
   mockSpanSetAttribute,
   mockSpanSetStatus,
@@ -28,10 +31,12 @@ const {
     mockSpanEnd,
     mockSpan,
     mockStartInactiveSpan: vi.fn(() => mockSpan),
-    mockGetActiveSpan: vi.fn(() => ({ spanContext: () => ({ spanId: 'parent' }) })),
+    mockGetActiveSpan: vi.fn<() => ActiveSpanStub | undefined>(() => ({
+      spanContext: () => ({ spanId: 'parent' }),
+    })),
     mockHasSpansEnabled: vi.fn(() => true),
     mockIsSentryRequestUrl: vi.fn(() => false),
-    mockGetTraceData: vi.fn(() => ({
+    mockGetTraceData: vi.fn<() => TraceDataStub>(() => ({
       'sentry-trace': 'trace-id-span-id-1',
       baggage: 'sentry-trace_id=trace-id,sentry-public_key=public-key,sentry-sampled=true',
     })),

--- a/test/networkbreadcrumbs.tracing.test.ts
+++ b/test/networkbreadcrumbs.tracing.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
 
+type ActiveSpanStub = { spanContext: () => { spanId: string } };
+type TraceDataStub = { 'sentry-trace'?: string; baggage?: string };
+
 const {
   mockSpanSetAttribute,
   mockSpanSetStatus,
@@ -28,10 +31,12 @@ const {
     mockSpanEnd,
     mockSpan,
     mockStartInactiveSpan: vi.fn(() => mockSpan),
-    mockGetActiveSpan: vi.fn(() => ({ spanContext: () => ({ spanId: 'parent' }) })),
+    mockGetActiveSpan: vi.fn<() => ActiveSpanStub | undefined>(() => ({
+      spanContext: () => ({ spanId: 'parent' }),
+    })),
     mockHasSpansEnabled: vi.fn(() => true),
     mockIsSentryRequestUrl: vi.fn(() => false),
-    mockGetTraceData: vi.fn(() => ({
+    mockGetTraceData: vi.fn<() => TraceDataStub>(() => ({
       'sentry-trace': 'trace-id-span-id-1',
       baggage: 'sentry-trace_id=trace-id,sentry-public_key=public-key,sentry-sampled=true',
     })),

--- a/test/nonwx.realcore.test.ts
+++ b/test/nonwx.realcore.test.ts
@@ -10,7 +10,11 @@ import {
 import { resetPlatformCache } from '../src/crossPlatform';
 import { _resetAppLifecycle } from '../src/appLifecycle';
 import { init } from '../src/index';
-import { collectEnvelopePayloads, createCapturingTransport } from './support/envelopes';
+import {
+  assertDefined,
+  collectEnvelopePayloads,
+  createCapturingTransport,
+} from './support/envelopes';
 
 /**
  * 非 wx 平台（支付宝 `my`）的真 @sentry/core 端到端验证。
@@ -72,7 +76,7 @@ describe('支付宝 my 平台（真 @sentry/core 集成）', () => {
     const ev = events.find((e) =>
       e.exception?.values?.some((v: any) => v.value?.includes('alipay boom')),
     );
-    expect(ev).toBeDefined();
+    assertDefined(ev);
     // 平台标记由 appName() 写入，应识别为 alipay（而非默认 wechat / unknown）
     expect(ev.contexts?.miniapp?.platform).toBe('alipay');
     // 设备信息取自 my.getSystemInfoSync

--- a/test/performance.realcore.test.ts
+++ b/test/performance.realcore.test.ts
@@ -1,7 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { flush, getClient, type Envelope, type Event } from '@sentry/core';
 import { init } from '../src/index';
-import { collectEnvelopePayloads, createCapturingTransport } from './support/envelopes';
+import {
+  assertDefined,
+  collectEnvelopePayloads,
+  createCapturingTransport,
+} from './support/envelopes';
 
 /**
  * 用真实 @sentry/core 验证默认性能集成的完整链路，避免工厂多返回一层函数时
@@ -101,7 +105,9 @@ describe('PerformanceIntegration（真 @sentry/core 集成）', () => {
     const transaction = transactions.find(
       (event) => event.transaction === 'Navigation: appLaunch',
     );
-    expect(transaction).toBeDefined();
+    assertDefined(transaction);
+    assertDefined(transaction.start_timestamp);
+    assertDefined(transaction.timestamp);
     expect(transaction.start_timestamp).toBeGreaterThan(1_000_000_000);
     expect(transaction.timestamp).toBeGreaterThanOrEqual(transaction.start_timestamp);
     expect(transaction.spans).toEqual(

--- a/test/platform-contracts.realcore.test.ts
+++ b/test/platform-contracts.realcore.test.ts
@@ -13,10 +13,18 @@ import { init } from '../src/index';
 
 type PlatformGlobal = 'wx' | 'my' | 'tt' | 'dd' | 'qq' | 'swan' | 'ks';
 type RequestMethod = 'request' | 'httpRequest';
+type MiniappPlatform =
+  | 'wechat'
+  | 'alipay'
+  | 'bytedance'
+  | 'dingtalk'
+  | 'qq'
+  | 'swan'
+  | 'kuaishou';
 
 interface PlatformContract {
   globalName: PlatformGlobal;
-  platform: string;
+  platform: MiniappPlatform;
   requestMethod: RequestMethod;
   objectStorage: boolean;
 }

--- a/test/platform-detection.realcore.test.ts
+++ b/test/platform-detection.realcore.test.ts
@@ -10,7 +10,11 @@ import {
 import { _resetAppLifecycle } from '../src/appLifecycle';
 import { resetPlatformCache } from '../src/crossPlatform';
 import { init } from '../src/index';
-import { collectEnvelopePayloads, createCapturingTransport } from './support/envelopes';
+import {
+  assertDefined,
+  collectEnvelopePayloads,
+  createCapturingTransport,
+} from './support/envelopes';
 
 describe('平台识别与显式覆盖（真 @sentry/core 集成）', () => {
   const g = global as any;
@@ -68,7 +72,7 @@ describe('平台识别与显式覆盖（真 @sentry/core 集成）', () => {
         value.value?.includes('bytedance auto detection'),
       ),
     );
-    expect(event).toBeDefined();
+    assertDefined(event);
     expect(event.platform).toBe('javascript');
     expect(event.contexts?.miniapp?.platform).toBe('bytedance');
     expect(event.contexts?.device?.brand).toBe('ByteDance');
@@ -100,7 +104,7 @@ describe('平台识别与显式覆盖（真 @sentry/core 集成）', () => {
         value.value?.includes('bytedance explicit fallback'),
       ),
     );
-    expect(event).toBeDefined();
+    assertDefined(event);
     expect(event.platform).toBe('javascript');
     expect(event.contexts?.miniapp?.platform).toBe('bytedance');
   });

--- a/test/support/envelopes.ts
+++ b/test/support/envelopes.ts
@@ -1,5 +1,14 @@
 import type { Envelope, EnvelopeItemType, Event, Transport } from '@sentry/core';
 
+export function assertDefined<T>(
+  value: T,
+  message = 'Expected test value to be defined',
+): asserts value is NonNullable<T> {
+  if (value === undefined || value === null) {
+    throw new Error(message);
+  }
+}
+
 export function createEventEnvelope(eventId: string): Envelope {
   const event: Event = { event_id: eventId };
 

--- a/test/support/performance.ts
+++ b/test/support/performance.ts
@@ -1,6 +1,21 @@
 import { vi, type Mock, type Mocked } from 'vitest';
 import type { PerformanceIntegration } from '../../src/integrations/performance';
-import type { PerformanceManager, PerformanceObserver } from '../../src/crossPlatform';
+import type {
+  PerformanceManager,
+  PerformanceObserver,
+  PerformanceObserverCallback,
+} from '../../src/crossPlatform';
+
+type MockPerformanceManager = {
+  getEntries: Mock<PerformanceManager['getEntries']>;
+  getEntriesByType: Mock<PerformanceManager['getEntriesByType']>;
+  getEntriesByName: Mock<PerformanceManager['getEntriesByName']>;
+  mark: Mock<PerformanceManager['mark']>;
+  measure: Mock<PerformanceManager['measure']>;
+  clearMarks: Mock<PerformanceManager['clearMarks']>;
+  clearMeasures: Mock<PerformanceManager['clearMeasures']>;
+  createObserver: Mock<(callback: PerformanceObserverCallback) => PerformanceObserver>;
+};
 
 interface PerformanceTestDependencies {
   PerformanceIntegration: new () => PerformanceIntegration;
@@ -15,7 +30,7 @@ interface PerformanceTestDependencies {
 
 export interface PerformanceTestHarness {
   integration: PerformanceIntegration;
-  mockPerformanceManager: Mocked<PerformanceManager>;
+  mockPerformanceManager: MockPerformanceManager;
   mockObserver: Mocked<PerformanceObserver>;
   mockScope: {
     setTag: Mock;
@@ -37,15 +52,17 @@ export function createPerformanceTestHarness(
     observe: vi.fn(),
     disconnect: vi.fn(),
   };
-  const mockPerformanceManager: Mocked<PerformanceManager> = {
-    getEntries: vi.fn(() => []),
-    getEntriesByType: vi.fn(() => []),
-    getEntriesByName: vi.fn(() => []),
-    mark: vi.fn(),
-    measure: vi.fn(),
-    clearMarks: vi.fn(),
-    clearMeasures: vi.fn(),
-    createObserver: vi.fn(() => mockObserver),
+  const mockPerformanceManager: MockPerformanceManager = {
+    getEntries: vi.fn<PerformanceManager['getEntries']>(() => []),
+    getEntriesByType: vi.fn<PerformanceManager['getEntriesByType']>(() => []),
+    getEntriesByName: vi.fn<PerformanceManager['getEntriesByName']>(() => []),
+    mark: vi.fn<PerformanceManager['mark']>(),
+    measure: vi.fn<PerformanceManager['measure']>(),
+    clearMarks: vi.fn<PerformanceManager['clearMarks']>(),
+    clearMeasures: vi.fn<PerformanceManager['clearMeasures']>(),
+    createObserver: vi.fn<(callback: PerformanceObserverCallback) => PerformanceObserver>(
+      () => mockObserver,
+    ),
   };
   const mockScope = {
     setTag: vi.fn(),

--- a/test/transport.test.ts
+++ b/test/transport.test.ts
@@ -288,7 +288,7 @@ describe('Transport', () => {
         recordDroppedEvent: () => {},
       });
       const envelope: Envelope = [
-        { event_id: 'normalized-failure' },
+        { event_id: 'normalized-failure', sent_at: '2022-01-01T00:00:00.000Z' },
         [[{ type: 'event' }, { event_id: 'normalized-failure' }]],
       ];
 
@@ -310,7 +310,7 @@ describe('Transport', () => {
         recordDroppedEvent: () => {},
       });
       const envelope: Envelope = [
-        { event_id: 'sync-failure' },
+        { event_id: 'sync-failure', sent_at: '2022-01-01T00:00:00.000Z' },
         [[{ type: 'event' }, { event_id: 'sync-failure' }]],
       ];
 
@@ -328,7 +328,7 @@ describe('Transport', () => {
         recordDroppedEvent: () => {},
       });
       const envelope: Envelope = [
-        { event_id: 'missing-request' },
+        { event_id: 'missing-request', sent_at: '2022-01-01T00:00:00.000Z' },
         [[{ type: 'event' }, { event_id: 'missing-request' }]],
       ];
 
@@ -355,7 +355,7 @@ describe('Transport', () => {
           requestTimeout: 10,
         });
         const envelope: Envelope = [
-          { event_id: 'abort-failure' },
+          { event_id: 'abort-failure', sent_at: '2022-01-01T00:00:00.000Z' },
           [[{ type: 'event' }, { event_id: 'abort-failure' }]],
         ];
 

--- a/test/trycatch.realcore.test.ts
+++ b/test/trycatch.realcore.test.ts
@@ -10,7 +10,11 @@ import {
 import { resetPlatformCache } from '../src/crossPlatform';
 import { _resetAppLifecycle } from '../src/appLifecycle';
 import { init, wrap as sdkWrap } from '../src/index';
-import { collectEnvelopePayloads, createCapturingTransport } from './support/envelopes';
+import {
+  assertDefined,
+  collectEnvelopePayloads,
+  createCapturingTransport,
+} from './support/envelopes';
 
 describe('TryCatch（真 @sentry/core 集成）', () => {
   const g = global as any;
@@ -79,12 +83,13 @@ describe('TryCatch（真 @sentry/core 集成）', () => {
     const errEvent = events.find((e) =>
       e.exception?.values?.some((v: any) => v.value?.includes('timer boom')),
     );
-    expect(errEvent).toBeDefined();
+    assertDefined(errEvent);
 
     // wrap() 通过 scope event processor 给事件打上 instrument mechanism，并塞入 extra.arguments。
     // mechanism 必须落在标准位置 exception.values[].mechanism（Sentry 后端读这里），
     // 而非容器级 exception.mechanism——后者后端读不到，等于没标记。
-    const val = errEvent.exception.values.find((v: any) => v.value?.includes('timer boom'));
+    const val = errEvent.exception?.values?.find((v: any) => v.value?.includes('timer boom'));
+    assertDefined(val);
     expect(val.mechanism?.type).toBe('instrument');
     expect(val.mechanism?.handled).toBe(false);
     expect((errEvent.exception as any).mechanism).toBeUndefined(); // 不再误挂容器级
@@ -144,8 +149,11 @@ describe('TryCatch（真 @sentry/core 集成）', () => {
       event.exception?.values?.some((value: any) => value.value === message),
     );
     expect(events).toHaveLength(1);
-    expect(events[0].exception.values[0].type).toBe('TypeError');
-    expect(events[0].exception.values[0].mechanism).toMatchObject({
+    const event = events[0];
+    const value = event?.exception?.values?.[0];
+    assertDefined(value);
+    expect(value.type).toBe('TypeError');
+    expect(value.mechanism).toMatchObject({
       type: 'instrument',
       handled: false,
     });
@@ -170,7 +178,9 @@ describe('TryCatch（真 @sentry/core 集成）', () => {
       event.exception?.values?.some((value: any) => value.value === 'public wrap boom'),
     );
     expect(events).toHaveLength(1);
-    expect(events[0].exception.values[0].mechanism).toMatchObject({
+    const value = events[0]?.exception?.values?.[0];
+    assertDefined(value);
+    expect(value.mechanism).toMatchObject({
       type: 'instrument',
       handled: false,
       data: { function: 'wrap' },
@@ -208,13 +218,14 @@ describe('TryCatch（真 @sentry/core 集成）', () => {
     const errEvent = events.find((e) =>
       e.exception?.values?.some((v: any) => v.value?.includes('outer timer boom')),
     );
-    expect(errEvent).toBeDefined();
+    assertDefined(errEvent);
 
-    const values = errEvent.exception.values;
+    const values = errEvent.exception?.values;
+    assertDefined(values);
     const root = values.find((v: any) => v.value?.includes('root cause'));
     const outer = values.find((v: any) => v.value?.includes('outer timer boom'));
-    expect(root).toBeDefined();
-    expect(outer).toBeDefined();
+    assertDefined(root);
+    assertDefined(outer);
     expect(outer.mechanism?.type).toBe('generic');
     expect(outer.mechanism?.handled).toBe(true);
     expect(root.mechanism?.type).toBe('instrument');
@@ -251,9 +262,11 @@ describe('TryCatch（真 @sentry/core 集成）', () => {
     const ev = collectEnvelopePayloads<Event>(captured, ['event']).find((e) =>
       e.exception?.values?.some((v: any) => v.value?.includes('unrelated later error')),
     );
-    expect(ev).toBeDefined();
+    assertDefined(ev);
+    const value = ev.exception?.values?.[0];
+    assertDefined(value);
     // 不被上一次 wrap 的 mechanism / arguments 污染
-    expect(ev.exception.values[0].mechanism).toEqual({
+    expect(value.mechanism).toEqual({
       handled: true,
       type: 'generic',
     });

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "noPropertyAccessFromIndexSignature": false,
+    "noUncheckedIndexedAccess": false,
+    "rootDir": ".",
+    "types": ["node", "vitest/globals"]
+  },
+  "include": ["src/**/*", "test/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## 改动说明

- 新增 `tsconfig.test.json`，让测试代码继承生产 TypeScript 严格规则
- `yarn typecheck` 现在同时检查 `src/` 与 `test/`
- 测试配置仅放宽动态 fixture 的属性与数组索引访问规则，保留 `strict`、`noImplicitAny`、`exactOptionalPropertyTypes` 等契约检查
- 修正 performance 共享 mock、网络追踪 mock、Envelope fixture 与真实 core 事件断言的类型
- 新增 `assertDefined` 测试辅助函数，用运行时断言完成安全类型收窄
- 修正 lint-staged：测试执行 ESLint，但不触发全文件 Prettier 重排
- 同步贡献指南、开发文档、PR 模板与 AGENTS 命令说明

## 验证

- `yarn run lint`
- `yarn run typecheck`
- `yarn run test:coverage`（48 个文件、738 个用例；99.26% statements/lines、95.93% branches、99.44% functions）
- `yarn run test:shuffle`
- `yarn run build`