### PR TITLE
test: 增加跨端框架示例构建验证

### DIFF
--- a/.github/workflows/framework-examples.yml
+++ b/.github/workflows/framework-examples.yml
@@ -1,0 +1,59 @@
+name: Framework Examples
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/framework-examples.yml'
+      - 'examples/taro/**'
+      - 'examples/uniapp/**'
+  schedule:
+    - cron: '0 3 * * 1'
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  build:
+    name: Build ${{ matrix.name }} example
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Taro
+            directory: examples/taro
+            script: build:weapp
+          - name: uni-app
+            directory: examples/uniapp
+            script: build:mp-weixin
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install SDK dependencies
+        run: yarn install --immutable
+
+      - name: Build and pack current SDK
+        run: |
+          yarn run build
+          yarn pack --out "$RUNNER_TEMP/sentry-miniapp.tgz"
+
+      - name: Install example dependencies with current SDK
+        working-directory: ${{ matrix.directory }}
+        run: npm install --no-save --no-package-lock --no-audit --no-fund "$RUNNER_TEMP/sentry-miniapp.tgz"
+
+      - name: Build example
+        working-directory: ${{ matrix.directory }}
+        run: npm run ${{ matrix.script }}

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -85,6 +85,8 @@ sentry-miniapp/
 
 测试必须执行 `src/` 或仓库脚本中的生产逻辑；不要只调用测试文件里临时创建的 mock、示例重试函数或常量再断言自身行为。时间相关逻辑优先使用 Vitest fake timers，避免真实等待拖慢 CI。
 
+Taro / uni-app 示例依赖较重，不加入每个 PR 的必跑任务。`.github/workflows/framework-examples.yml` 会在相关示例或 workflow 发生变化的 PR、每周定时任务及手动触发时构建当前 SDK tarball，覆盖示例声明的发布版依赖后执行真实微信小程序构建，用于发现框架工具链和 SDK 入口的兼容性漂移。
+
 在提交 Pull Request 前，请务必确保所有测试通过，且没有 Lint 错误：
 
 ```bash

--- a/examples/taro/README.md
+++ b/examples/taro/README.md
@@ -64,7 +64,7 @@ Taro 真机错误栈是微信合并后的 `appservice.app.js`，**分页 Source 
 
 ## 用本地源码而非已发布版
 
-示例默认依赖已发布的 `sentry-miniapp`（`package.json` 中 `"sentry-miniapp": "^1.11.0"`）。
+示例默认按 `package.json` 的 semver 范围安装已发布的 `sentry-miniapp`。
 若想验证仓库当前源码，先在仓库根执行 `yarn build`，再把本目录依赖改为：
 
 ```jsonc
@@ -75,4 +75,4 @@ Taro 真机错误栈是微信合并后的 `appservice.app.js`，**分页 Source 
 
 ## 说明
 
-本示例工程作为参考工程独立维护，不接入仓库 CI；`node_modules/`、`dist/`、锁文件等已在 `.gitignore` 中忽略，`fresh npm install` 即可运行。
+本示例不加入每个 PR 的必跑 CI，避免重复下载完整 Taro 工具链；仓库的 `Framework Examples` workflow 会在相关示例发生变化、每周定时任务及手动触发时，用**当前仓库 tarball**执行 fresh install 和真实构建。`node_modules/`、`dist/`、锁文件等已在 `.gitignore` 中忽略。

--- a/examples/taro/package.json
+++ b/examples/taro/package.json
@@ -50,6 +50,6 @@
     "sass": "^1.75.0",
     "tsconfig-paths-webpack-plugin": "^4.1.0",
     "typescript": "^5.4.5",
-    "webpack": "5.104.1"
+    "webpack": "5.91.0"
   }
 }

--- a/examples/uniapp/README.md
+++ b/examples/uniapp/README.md
@@ -39,7 +39,7 @@ npm run build:mp-weixin
 
 ## 用本地源码而非已发布版
 
-示例默认依赖已发布的 `sentry-miniapp`（`package.json` 中 `"sentry-miniapp": "^1.9.0"`）。
+示例默认按 `package.json` 的 semver 范围安装已发布的 `sentry-miniapp`。
 若想验证仓库当前源码，先在仓库根执行 `yarn build`，再把本目录依赖改为：
 
 ```jsonc
@@ -50,4 +50,4 @@ npm run build:mp-weixin
 
 ## 说明
 
-本示例工程不接入仓库的 CI 与 `sync:examples`，作为参考工程独立维护；`node_modules/`、`dist/`、`unpackage/` 已在 `.gitignore` 中忽略。
+本示例不加入每个 PR 的必跑 CI，避免重复下载完整 uni-app 工具链；仓库的 `Framework Examples` workflow 会在相关示例发生变化、每周定时任务及手动触发时，用**当前仓库 tarball**执行 fresh install 和真实构建。`node_modules/`、`dist/`、`unpackage/` 已在 `.gitignore` 中忽略。

--- a/examples/uniapp/package.json
+++ b/examples/uniapp/package.json
@@ -20,6 +20,6 @@
     "@dcloudio/uni-stacktracey": "3.0.0-5000720260410001",
     "@dcloudio/vite-plugin-uni": "3.0.0-5000720260410001",
     "sass": "^1.77.0",
-    "vite": "6.4.3"
+    "vite": "5.2.8"
   }
 }


### PR DESCRIPTION
## 改动说明

- 新增 `Framework Examples` workflow，在相关 PR、每周定时任务及手动触发时分别构建 Taro 与 uni-app 示例
- CI 先构建并打包当前仓库 SDK，再以 tarball 覆盖示例依赖，避免只验证 npm 已发布版本
- 将 Taro 的 webpack 对齐为 `@tarojs/taro-loader@4.2.0` 要求的 `5.91.0`
- 将 uni-app 的 Vite 对齐为 `@dcloudio/vite-plugin-uni` 要求的 `5.2.8`
- 更新开发文档和示例说明，明确验证范围与触发策略

## 验证

- `yarn lint`
- `yarn typecheck`
- `yarn test`（48 个测试文件，738 个用例）
- `yarn build`
- GitHub Actions：Taro 示例 fresh install 与真实微信小程序构建通过
- GitHub Actions：uni-app 示例 fresh install 与真实微信小程序构建通过
- Node 20/22/24、CodeQL 与 Cloudflare Pages 全部通过