### PR TITLE
fix: 修复独立 HTTP span 上报异常

### DIFF
--- a/src/integrations/networkbreadcrumbs.ts
+++ b/src/integrations/networkbreadcrumbs.ts
@@ -4,7 +4,9 @@ import {
   getClient,
   hasSpansEnabled,
   isSentryRequestUrl,
+  SEMANTIC_ATTRIBUTE_EXCLUSIVE_TIME,
   SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN,
+  SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_NAME,
   SPAN_STATUS_OK,
   SPAN_STATUS_ERROR,
   getTraceData,
@@ -17,6 +19,7 @@ import {
   addFunctionInstrumentationHandler,
   ensureFunctionInstrumentation,
 } from '../instrumentation';
+import { isMarkedSentryRequest } from '../transports/requestMarker';
 
 /**
  * Network Breadcrumbs Integration.
@@ -170,6 +173,11 @@ export class NetworkBreadcrumbs implements Integration {
         return originalRequest.call(this, options);
       }
 
+      // 内置 transport 的请求由共享 WeakSet 标记，避免依赖小游戏中可能缺失或残缺的 URL。
+      if (isMarkedSentryRequest(options)) {
+        return originalRequest.call(this, options);
+      }
+
       const url = normalizeUrl(options.url);
 
       const client = getClient();
@@ -226,6 +234,7 @@ export class NetworkBreadcrumbs implements Integration {
         finishSpanOnce({
           statusCode,
           status: isErrorStatusCode(statusCode) ? 'error' : 'ok',
+          durationMs: duration,
         });
 
         if (traceNetworkBody && res.data && !shouldDenyBodyUrl(url)) {
@@ -267,6 +276,7 @@ export class NetworkBreadcrumbs implements Integration {
         finishSpanOnce({
           status: 'error',
           errorMessage,
+          durationMs: duration,
         });
 
         addBreadcrumb({
@@ -287,6 +297,7 @@ export class NetworkBreadcrumbs implements Integration {
         finishSpanOnce({
           statusCode,
           status: isErrorStatusCode(statusCode) ? 'error' : 'ok',
+          durationMs: Date.now() - startTime,
         });
 
         if (typeof originalComplete === 'function') {
@@ -300,6 +311,7 @@ export class NetworkBreadcrumbs implements Integration {
         finishSpanOnce({
           status: 'error',
           errorMessage: error instanceof Error ? error.message : String(error),
+          durationMs: Date.now() - startTime,
         });
         throw error;
       }
@@ -372,21 +384,29 @@ type RequestSpanFinishOptions = {
   status: 'ok' | 'error';
   statusCode?: unknown;
   errorMessage?: string;
+  durationMs: number;
+};
+
+type RequestSpan = {
+  span: Span;
+  standalone: boolean;
 };
 
 function startRequestSpan(
   method: string,
   url: string,
   enableStandaloneHttpSpans: boolean,
-): Span | null {
+): RequestSpan | null {
   try {
     if (!hasSpansEnabled()) return null;
     const parentSpan = getActiveSpan();
     if (!parentSpan && !enableStandaloneHttpSpans) return null;
 
     const serverAddress = extractHost(url);
-    return startInactiveSpan({
-      name: `${method} ${sanitizeSpanNameUrl(url)}`,
+    const spanName = `${method} ${sanitizeSpanNameUrl(url)}`;
+    const standalone = !parentSpan;
+    const span = startInactiveSpan({
+      name: spanName,
       op: 'http.client',
       kind: 2,
       parentSpan: parentSpan ?? null,
@@ -395,11 +415,13 @@ function startRequestSpan(
       ...(!parentSpan && { experimental: { standalone: true } }),
       attributes: {
         [SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN]: 'auto.http.miniapp',
+        ...(standalone && { [SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_NAME]: spanName }),
         'http.request.method': method,
         'url.full': url,
         'server.address': serverAddress || undefined,
       },
     });
+    return { span, standalone };
   } catch (_e) {
     return null;
   }
@@ -436,8 +458,13 @@ function stripDataUrlContent(url: string): string {
   return `data:${mimeType}`;
 }
 
-function injectTraceHeaders(options: any, span: Span | null, propagateTraceparent: boolean): void {
+function injectTraceHeaders(
+  options: any,
+  requestSpan: RequestSpan | null,
+  propagateTraceparent: boolean,
+): void {
   try {
+    const span = requestSpan?.span;
     const traceData = getTraceData(
       span
         ? propagateTraceparent
@@ -475,10 +502,14 @@ function injectTraceHeaders(options: any, span: Span | null, propagateTraceparen
   }
 }
 
-function finishRequestSpan(span: Span | null, options: RequestSpanFinishOptions): void {
-  if (!span) return;
+function finishRequestSpan(
+  requestSpan: RequestSpan | null,
+  options: RequestSpanFinishOptions,
+): void {
+  if (!requestSpan) return;
 
   try {
+    const { span, standalone } = requestSpan;
     const statusCode = normalizeStatusCode(options.statusCode);
     if (statusCode !== undefined) {
       setHttpStatus(span, statusCode);
@@ -490,6 +521,9 @@ function finishRequestSpan(span: Span | null, options: RequestSpanFinishOptions)
     }
     if (options.errorMessage) {
       span.setAttribute('error.message', options.errorMessage);
+    }
+    if (standalone) {
+      span.setAttribute(SEMANTIC_ATTRIBUTE_EXCLUSIVE_TIME, Math.max(0, options.durationMs));
     }
     span.end();
   } catch (_e) {

--- a/src/transports/requestMarker.ts
+++ b/src/transports/requestMarker.ts
@@ -1,0 +1,9 @@
+const sentryRequestOptions = new WeakSet<object>();
+
+export function markSentryRequest(options: object): void {
+  sentryRequestOptions.add(options);
+}
+
+export function isMarkedSentryRequest(options: unknown): boolean {
+  return typeof options === 'object' && options !== null && sentryRequestOptions.has(options);
+}

--- a/src/transports/xhr.ts
+++ b/src/transports/xhr.ts
@@ -2,6 +2,7 @@ import type { BaseTransportOptions, Transport, TransportMakeRequestResponse } fr
 import { createTransport } from '@sentry/core';
 
 import { sdk } from '../crossPlatform';
+import { markSentryRequest } from './requestMarker';
 
 const SENTRY_ENVELOPE_CONTENT_TYPE = 'application/x-sentry-envelope';
 export const DEFAULT_TRANSPORT_REQUEST_TIMEOUT = 3000;
@@ -127,6 +128,8 @@ export function createMiniappTransport(options: MiniappTransportOptions): Transp
           settle(() => reject(networkError(error)));
         },
       };
+
+      markSentryRequest(requestOptions);
 
       // Use the appropriate request method based on the platform
       try {

--- a/test/networkbreadcrumbs.realcore.test.ts
+++ b/test/networkbreadcrumbs.realcore.test.ts
@@ -17,10 +17,12 @@ describe('NetworkBreadcrumbs（真 @sentry/core 集成）', () => {
   let captured: Envelope[];
   let requestMock: ReturnType<typeof vi.fn>;
   let savedWx: unknown;
+  let savedURL: unknown;
 
   beforeEach(() => {
     captured = [];
     savedWx = g.wx;
+    savedURL = g.URL;
     delete g.wx;
     resetPlatformCache();
 
@@ -45,6 +47,7 @@ describe('NetworkBreadcrumbs（真 @sentry/core 集成）', () => {
     if (client) await client.close(0);
     delete g.tt;
     g.wx = savedWx;
+    g.URL = savedURL;
     resetPlatformCache();
   });
 
@@ -81,10 +84,12 @@ describe('NetworkBreadcrumbs（真 @sentry/core 集成）', () => {
         origin: 'auto.http.miniapp',
         is_segment: true,
         segment_id: expect.any(String),
+        exclusive_time: expect.any(Number),
         status: 'ok',
         data: expect.objectContaining({
           'http.request.method': 'POST',
           'http.response.status_code': 201,
+          'sentry.segment.name': 'POST https://api.example.com/v1/login',
           'url.full': 'https://api.example.com/v1/login?token=secret',
           'server.address': 'api.example.com',
         }),
@@ -99,6 +104,37 @@ describe('NetworkBreadcrumbs（真 @sentry/core 集成）', () => {
         baggage: expect.stringContaining('sentry-'),
       }),
     );
+  });
+
+  it.each([
+    ['缺失', () => delete g.URL],
+    [
+      '残缺',
+      () => {
+        g.URL = { createObjectURL: vi.fn(), revokeObjectURL: vi.fn() };
+        return true;
+      },
+    ],
+  ])('全局 URL %s时内置 transport 请求不会被重复追踪', async (_name, setURL) => {
+    init({
+      dsn: 'https://test@o0.ingest.sentry.io/0',
+      platform: 'bytedance',
+      tracesSampleRate: 1,
+      enableOfflineCache: false,
+      enableAutoSessionTracking: false,
+      enableMinigameLifecycle: false,
+      enableMinigameFrameRate: false,
+    });
+    setURL();
+
+    g.tt.request({ url: 'https://api.example.com/v1/login', method: 'POST' });
+    await flush(2000);
+
+    const requestedUrls = requestMock.mock.calls.map(([options]) => options.url);
+    expect(requestedUrls).toEqual([
+      'https://api.example.com/v1/login',
+      expect.stringMatching(/^https:\/\/o0\.ingest\.sentry\.io\/api\/0\/envelope\//),
+    ]);
   });
 
   it('有 active span 时仍把请求记录为现有 transaction 的子 span', async () => {

--- a/test/networkbreadcrumbs.tracing.test.ts
+++ b/test/networkbreadcrumbs.tracing.test.ts
@@ -59,7 +59,9 @@ vi.mock('@sentry/core', () => {
     isSentryRequestUrl: mockIsSentryRequestUrl,
     getTraceData: mockGetTraceData,
     setHttpStatus: mockSetHttpStatus,
+    SEMANTIC_ATTRIBUTE_EXCLUSIVE_TIME: 'sentry.exclusive_time',
     SEMANTIC_ATTRIBUTE_SENTRY_ORIGIN: 'sentry.origin',
+    SEMANTIC_ATTRIBUTE_SENTRY_SEGMENT_NAME: 'sentry.segment.name',
     SPAN_STATUS_OK: 1,
     SPAN_STATUS_ERROR: 2,
     startInactiveSpan: mockStartInactiveSpan,
@@ -381,6 +383,7 @@ describe('NetworkBreadcrumbs tracing', () => {
 
   it('creates a standalone segment span when no active span exists', () => {
     mockGetActiveSpan.mockReturnValueOnce(undefined);
+    vi.mocked(Date.now).mockReturnValueOnce(1000).mockReturnValueOnce(1125);
     const integration = new NetworkBreadcrumbs({
       tracePropagationTargets: ['api.example.com'],
     });
@@ -396,12 +399,33 @@ describe('NetworkBreadcrumbs tracing', () => {
         experimental: { standalone: true },
         attributes: expect.objectContaining({
           'sentry.origin': 'auto.http.miniapp',
+          'sentry.segment.name': 'GET https://api.example.com/users',
         }),
       }),
     );
+    expect(mockSpanSetAttribute).toHaveBeenCalledWith('sentry.exclusive_time', 125);
     expect(mockGetTraceData).toHaveBeenCalledWith({ span: mockSpan });
     expect(requestMock.mock.calls[0]![0].header).toEqual(
       expect.objectContaining({ 'sentry-trace': 'trace-id-span-id-1' }),
+    );
+  });
+
+  it('does not set standalone-only attributes on child request spans', () => {
+    const integration = new NetworkBreadcrumbs();
+    setupIntegration(integration);
+
+    crossPlatform.sdk().request({ url: 'https://api.example.com/users' });
+
+    expect(mockStartInactiveSpan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        attributes: expect.not.objectContaining({
+          'sentry.segment.name': expect.anything(),
+        }),
+      }),
+    );
+    expect(mockSpanSetAttribute).not.toHaveBeenCalledWith(
+      'sentry.exclusive_time',
+      expect.anything(),
     );
   });
 


### PR DESCRIPTION
## 问题

小游戏运行时可能没有可构造的全局 `URL`，导致 `@sentry/core` 的自请求识别静默失败。内置 transport 发出的 envelope 随后会再次被 `NetworkBreadcrumbs` 追踪，形成无界请求循环。

同时，无父请求使用 standalone span 上报时缺少 `sentry.exclusive_time` 和 `sentry.segment.name`：前者会被部分 Relay 版本以 `invalid_span` 拒收，后者导致看板缺少可用的 segment 名称。

## 修复

- 使用 SDK 内部共享 `WeakSet` 标记内置 transport 请求，在任何 URL 解析前直接跳过网络追踪
- 保留 `@sentry/core` 的 DSN / tunnel 自请求判断，兼容其它发送路径
- 只为 standalone `http.client` span 写入 `sentry.segment.name`
- 在 span 结束前写入毫秒单位的 `sentry.exclusive_time`
- 不引入完整 URL polyfill，不排除整个 DSN 域名，也不向宿主请求参数添加私有字段

## 验证

- 真实 `@sentry/core` + 内置 transport：全局 `URL` 缺失和残缺时，一次业务请求均只产生一次业务请求与一次 envelope 请求
- standalone span envelope 包含 `exclusive_time`、`sentry.segment.name`、状态码与原有追踪字段
- child span 不增加 standalone 专属字段
- `yarn lint`
- `yarn typecheck`
- `yarn test:coverage`（48 个测试文件，741 个用例）
- `yarn build`，包含 `publint` 与 7 平台包消费检查

Closes #345
Closes #346