### PR TITLE
fix: 强化 SDK 自请求识别

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -24,7 +24,7 @@ yarn install
 | 命令 | 说明 |
 |------|------|
 | `yarn dev` | 监听源码并持续构建标准 ESM/CJS/UMD 产物 |
-| `yarn build` | 构建标准 ESM/CJS/UMD 产物与类型声明 |
+| `yarn build` | 构建标准 ESM/CJS/UMD 产物与类型声明，并检查 npm 包入口、七平台消费与自请求递归 |
 | `yarn build:miniapp` | 构建微信示例使用的独立 CommonJS bundle，并执行兼容性与加载检查 |
 | `yarn dev:miniapp` | 监听源码并持续构建微信示例 bundle |
 | `yarn build:types` | 构建类型定义文件（d.ts） |
@@ -81,6 +81,7 @@ sentry-miniapp/
 
 - **单元测试 (`yarn test`，Vitest)**：覆盖核心类、工具函数与集成插件（跨端兼容性、面包屑、去重、transport 等），用 mock 的平台全局对象跑通 init → 事件构建 → transport → `wx.request` 全链路。
 - **真实 core 集成测试 (`test/*.realcore.test.ts`)**：不 mock `@sentry/core`，验证事件、transaction、session 最终进入 envelope 的形态。自定义 transport 与 envelope 解析统一复用 `test/support/`。
+- **发布包消费测试 (`yarn build`)**：把当前 npm tarball 解包到隔离目录，验证 CJS / ESM / UMD 与类型入口；七个平台还会分别在全局 `URL` 缺失和残缺时安装会复制请求参数的外层 wrapper，断言一次业务请求只能产生一次 Sentry envelope，防止 SDK 自请求递归。
 - **测试类型检查 (`yarn typecheck`)**：源码使用 `tsconfig.json`，测试使用 `tsconfig.test.json`；测试保留严格函数签名检查，仅放宽动态 fixture 的索引访问规则。
 
 测试必须执行 `src/` 或仓库脚本中的生产逻辑；不要只调用测试文件里临时创建的 mock、示例重试函数或常量再断言自身行为。时间相关逻辑优先使用 Vitest fake timers，避免真实等待拖慢 CI。

--- a/scripts/internal/check-package-consumers.mjs
+++ b/scripts/internal/check-package-consumers.mjs
@@ -34,6 +34,7 @@ const platformContracts = [
   { globalName: 'swan', platform: 'swan', requestMethod: 'request', statusKey: 'statusCode' },
   { globalName: 'ks', platform: 'kuaishou', requestMethod: 'request', statusKey: 'statusCode' },
 ];
+const selfRequestRuntimeModes = ['missing-url', 'partial-url'];
 
 async function writeConsumer(file, source) {
   await writeFile(file, source, 'utf8');
@@ -67,12 +68,24 @@ function runtimeProbe(moduleSyntax) {
   const load =
     moduleSyntax === 'esm'
       ? `import assert from 'node:assert/strict';
+const runtimeMode = process.argv[3] || 'standard';
 const nativeURLSearchParams = globalThis.URLSearchParams;
 assert.equal(Reflect.deleteProperty(globalThis, 'URLSearchParams'), true);
+if (runtimeMode === 'missing-url') {
+  assert.equal(Reflect.deleteProperty(globalThis, 'URL'), true);
+} else if (runtimeMode === 'partial-url') {
+  globalThis.URL = { createObjectURL() {}, revokeObjectURL() {} };
+}
 const sdk = await import('sentry-miniapp');`
       : `const assert = require('node:assert/strict');
+const runtimeMode = process.argv[3] || 'standard';
 const nativeURLSearchParams = globalThis.URLSearchParams;
 assert.equal(Reflect.deleteProperty(globalThis, 'URLSearchParams'), true);
+if (runtimeMode === 'missing-url') {
+  assert.equal(Reflect.deleteProperty(globalThis, 'URL'), true);
+} else if (runtimeMode === 'partial-url') {
+  globalThis.URL = { createObjectURL() {}, revokeObjectURL() {} };
+}
 const sdk = require('sentry-miniapp');`;
 
   const runStart = moduleSyntax === 'esm' ? '' : 'async function main() {';
@@ -105,10 +118,17 @@ assert.notEqual(
 const platformName = process.argv[2] || 'wechat';
 const contract = ${platforms}.find(candidate => candidate.platform === platformName);
 assert.ok(contract, \`Unknown platform contract: \${platformName}\`);
+assert.ok(
+  runtimeMode === 'standard' || ${JSON.stringify(selfRequestRuntimeModes)}.includes(runtimeMode),
+  \`Unknown runtime mode: \${runtimeMode}\`,
+);
 
 const envelopes = [];
-globalThis[contract.globalName] = {
-  [contract.requestMethod](options) {
+const requestedUrls = [];
+let rawRequestCalls = 0;
+const rawRequest = function(options) {
+    rawRequestCalls += 1;
+    requestedUrls.push(options.url);
     const headers = { ...(options.headers || {}), ...(options.header || {}) };
     const contentType = Object.entries(headers).find(
       ([name]) => name.toLowerCase() === 'content-type',
@@ -124,22 +144,72 @@ globalThis[contract.globalName] = {
     options.success?.(response);
     options.complete?.(response);
     return { abort() {} };
-  },
+};
+const host = {
+  [contract.requestMethod]: rawRequest,
   getSystemInfoSync() {
     return { platform: 'devtools', brand: 'package-smoke' };
   },
 };
+globalThis[contract.globalName] = host;
 
 sdk.init({
   dsn: 'https://test@o0.ingest.sentry.io/0',
+  platform: contract.platform,
+  tracesSampleRate: runtimeMode === 'standard' ? undefined : 1,
   enableOfflineCache: false,
   enableAutoSessionTracking: false,
   enableMinigameLifecycle: false,
   enableMinigameFrameRate: false,
 });
-sdk.captureMessage('package consumer runtime smoke');
+
+if (runtimeMode === 'standard') {
+  sdk.captureMessage('package consumer runtime smoke');
+} else {
+  const sentryWrappedRequest = host[contract.requestMethod];
+  let outerRequestCalls = 0;
+  host[contract.requestMethod] = function(options) {
+    outerRequestCalls += 1;
+    // A broken self-request guard would recurse forever. Bypass instrumentation after a few calls
+    // so the probe fails with a finite request list instead of hanging CI.
+    if (outerRequestCalls > 6) return rawRequest.call(this, options);
+    return sentryWrappedRequest.call(this, {
+      ...options,
+      ...(options.header && { header: { ...options.header } }),
+      ...(options.headers && { headers: { ...options.headers } }),
+    });
+  };
+  host[contract.requestMethod]({
+    url: 'https://api.example.com/package-self-request-smoke',
+    method: 'POST',
+  });
+}
+
 assert.equal(await sdk.flush(2000), true, 'SDK flush failed');
 assert.ok(envelopes.length > 0, 'SDK did not send an envelope through the mini program host');
+if (runtimeMode !== 'standard') {
+  assert.equal(
+    requestedUrls.length,
+    2,
+    \`\${platformName} \${runtimeMode} recursively traced an SDK envelope\`,
+  );
+  assert.equal(
+    requestedUrls[0],
+    'https://api.example.com/package-self-request-smoke',
+    \`\${platformName} \${runtimeMode} did not send the business request first\`,
+  );
+  assert.ok(
+    requestedUrls[1].startsWith('https://o0.ingest.sentry.io/api/0/envelope/'),
+    \`\${platformName} \${runtimeMode} used an unexpected envelope endpoint\`,
+  );
+  const envelopeQuery = requestedUrls[1].split('?')[1] || '';
+  assert.ok(
+    envelopeQuery.split('&').includes('sentry_key=test'),
+    \`\${platformName} \${runtimeMode} envelope URL omitted sentry_key\`,
+  );
+  assert.equal(rawRequestCalls, 2, \`\${platformName} \${runtimeMode} used extra host requests\`);
+  assert.equal(envelopes.length, 1, \`\${platformName} \${runtimeMode} sent extra envelopes\`);
+}
 await sdk.close(0);
 
 process.stdout.write(JSON.stringify({
@@ -147,6 +217,8 @@ process.stdout.write(JSON.stringify({
   version: sdk.SDK_VERSION,
   envelopes: envelopes.length,
   platform: platformName,
+  requests: requestedUrls.length,
+  runtimeMode,
 }));
 ${runEnd}
 `;
@@ -275,12 +347,15 @@ try {
   await writeConsumer(esmConsumer, runtimeProbe('esm'));
 
   const cjsExecution = await runNode(cjsConsumer, tempRoot, {
-    scriptArgs: ['wechat'],
+    scriptArgs: ['wechat', 'missing-url'],
   });
+  const esmScenarios = platformContracts.flatMap((contract) =>
+    selfRequestRuntimeModes.map((runtimeMode) => ({ contract, runtimeMode })),
+  );
   const esmExecutions = await Promise.all(
-    platformContracts.map(({ platform }) =>
+    esmScenarios.map(({ contract, runtimeMode }) =>
       runNode(esmConsumer, tempRoot, {
-        scriptArgs: [platform],
+        scriptArgs: [contract.platform, runtimeMode],
       }),
     ),
   );
@@ -289,13 +364,15 @@ try {
     assert.equal(
       execution.stderr,
       '',
-      `ESM ${platformContracts[index].platform} probe emitted stderr:\n${execution.stderr}`,
+      `ESM ${esmScenarios[index].contract.platform} ${esmScenarios[index].runtimeMode} probe emitted stderr:\n${execution.stderr}`,
     );
   }
 
   const cjsResult = JSON.parse(cjsExecution.stdout);
   const esmResults = esmExecutions.map(({ stdout }) => JSON.parse(stdout));
-  const esmResult = esmResults.find(({ platform }) => platform === 'wechat');
+  const esmResult = esmResults.find(
+    ({ platform, runtimeMode }) => platform === 'wechat' && runtimeMode === 'missing-url',
+  );
   assert.ok(esmResult, 'ESM WeChat probe did not produce a result');
   assert.deepEqual(esmResult.keys, cjsResult.keys, 'ESM and CJS exports differ');
   assert.equal(
@@ -308,13 +385,23 @@ try {
     packageJson.version,
     'ESM SDK_VERSION differs from package version',
   );
-  assert.ok(cjsResult.envelopes > 0, 'CJS runtime probe did not send an envelope');
-  for (const contract of platformContracts) {
-    const result = esmResults.find(({ platform }) => platform === contract.platform);
-    assert.ok(result, `Missing ESM runtime result for ${contract.platform}`);
-    assert.ok(
-      result.envelopes > 0,
-      `ESM ${contract.platform} probe did not send an envelope through ${contract.globalName}.${contract.requestMethod}`,
+  assert.equal(cjsResult.envelopes, 1, 'CJS runtime probe sent unexpected envelopes');
+  assert.equal(cjsResult.requests, 2, 'CJS runtime probe used unexpected host requests');
+  for (const { contract, runtimeMode } of esmScenarios) {
+    const result = esmResults.find(
+      (candidate) =>
+        candidate.platform === contract.platform && candidate.runtimeMode === runtimeMode,
+    );
+    assert.ok(result, `Missing ESM runtime result for ${contract.platform} ${runtimeMode}`);
+    assert.equal(
+      result.envelopes,
+      1,
+      `ESM ${contract.platform} ${runtimeMode} sent unexpected envelopes through ${contract.globalName}.${contract.requestMethod}`,
+    );
+    assert.equal(
+      result.requests,
+      2,
+      `ESM ${contract.platform} ${runtimeMode} used unexpected host requests`,
     );
   }
   const umdKeys = await runUmdProbe(packageRoot, packageJson.version);
@@ -342,7 +429,7 @@ try {
   });
 
   console.log(
-    `Package consumer checks passed for CJS, ESM (${platformContracts.length} platforms), UMD and TypeScript (${cjsResult.keys.length} exports).`,
+    `Package consumer checks passed for CJS, ESM (${platformContracts.length} platforms × ${selfRequestRuntimeModes.length} URL modes), UMD and TypeScript (${cjsResult.keys.length} exports).`,
   );
 } finally {
   await rm(tempRoot, { force: true, recursive: true });

--- a/src/integrations/networkbreadcrumbs.ts
+++ b/src/integrations/networkbreadcrumbs.ts
@@ -173,7 +173,7 @@ export class NetworkBreadcrumbs implements Integration {
         return originalRequest.call(this, options);
       }
 
-      // 内置 transport 的请求由共享 WeakSet 标记，避免依赖小游戏中可能缺失或残缺的 URL。
+      // 内置 transport 会标记 options 及 header 身份，常见浅拷贝 wrapper 也无需依赖全局 URL。
       if (isMarkedSentryRequest(options)) {
         return originalRequest.call(this, options);
       }
@@ -182,7 +182,7 @@ export class NetworkBreadcrumbs implements Integration {
 
       const client = getClient();
       // 使用 core 的 DSN/tunnel 规则识别 SDK 自身 envelope，避免将同域业务请求误排除。
-      if (isSentryRequestUrl(url, client)) {
+      if (isSentryRequestUrl(url, client) || isSentryDsnRequestWithoutURL(url, client)) {
         return originalRequest.call(this, options);
       }
 
@@ -543,6 +543,30 @@ function normalizeUrl(url: unknown): string {
   return String(url);
 }
 
+/**
+ * `@sentry/core` 的自请求识别依赖全局 `URL`。部分小游戏运行时没有完整实现该 API，且外层请求库
+ * 可能通过浅拷贝丢失 transport 的对象身份标记，因此这里用同一组 DSN 约束做无 `URL` 回退。
+ * 同时要求匹配 DSN 主机和 `sentry_key` 查询参数，不能仅按域名过滤业务请求。
+ */
+function isSentryDsnRequestWithoutURL(url: string, client: Client | undefined): boolean {
+  const dsnHost = client?.getDsn()?.host.toLowerCase();
+  if (!dsnHost || !hasSentryKeyQueryParameter(url)) return false;
+
+  const requestHost = extractHost(url).toLowerCase();
+  return requestHost === dsnHost || requestHost.endsWith(`.${dsnHost}`);
+}
+
+function hasSentryKeyQueryParameter(url: string): boolean {
+  const queryStart = url.indexOf('?');
+  if (queryStart === -1) return false;
+
+  const fragmentStart = url.indexOf('#');
+  if (fragmentStart !== -1 && fragmentStart < queryStart) return false;
+
+  const search = url.slice(queryStart, fragmentStart === -1 ? undefined : fragmentStart);
+  return /(^|[?&])sentry_key=/.test(search);
+}
+
 function normalizeMethod(method: unknown): string {
   return typeof method === 'string' && method.trim() !== '' ? method.toUpperCase() : 'GET';
 }
@@ -609,8 +633,16 @@ function normalizeStatusCode(statusCode: unknown): number | undefined {
 
 function extractHost(url: string): string {
   try {
-    const hostMatch = url.match(/^https?:\/\/([^:/\n]+)/i);
-    return hostMatch && hostMatch[1] ? hostMatch[1] : '';
+    const authorityMatch = url.match(/^https?:\/\/([^/?#\n]+)/i);
+    if (!authorityMatch || !authorityMatch[1]) return '';
+
+    const authority = authorityMatch[1].slice(authorityMatch[1].lastIndexOf('@') + 1);
+    if (authority.startsWith('[')) {
+      const closingBracket = authority.indexOf(']');
+      return closingBracket === -1 ? '' : authority.slice(0, closingBracket + 1);
+    }
+
+    return authority.split(':', 1)[0] || '';
   } catch (_e) {
     return '';
   }

--- a/src/transports/requestMarker.ts
+++ b/src/transports/requestMarker.ts
@@ -1,9 +1,29 @@
 const sentryRequestOptions = new WeakSet<object>();
 
 export function markSentryRequest(options: object): void {
-  sentryRequestOptions.add(options);
+  markObject(options);
+
+  const requestOptions = options as Record<string, unknown>;
+  markObject(requestOptions['header']);
+  markObject(requestOptions['headers']);
 }
 
 export function isMarkedSentryRequest(options: unknown): boolean {
-  return typeof options === 'object' && options !== null && sentryRequestOptions.has(options);
+  if (!isObject(options)) return false;
+  if (sentryRequestOptions.has(options)) return true;
+
+  const requestOptions = options as Record<string, unknown>;
+  return isMarkedObject(requestOptions['header']) || isMarkedObject(requestOptions['headers']);
+}
+
+function markObject(value: unknown): void {
+  if (isObject(value)) sentryRequestOptions.add(value);
+}
+
+function isMarkedObject(value: unknown): boolean {
+  return isObject(value) && sentryRequestOptions.has(value);
+}
+
+function isObject(value: unknown): value is object {
+  return typeof value === 'object' && value !== null;
 }

--- a/test/networkbreadcrumbs.realcore.test.ts
+++ b/test/networkbreadcrumbs.realcore.test.ts
@@ -137,6 +137,36 @@ describe('NetworkBreadcrumbs（真 @sentry/core 集成）', () => {
     ]);
   });
 
+  it('外层请求 wrapper 复制参数和请求头且缺少全局 URL 时不会递归上报', async () => {
+    init({
+      dsn: 'https://test@o0.ingest.sentry.io/0',
+      platform: 'bytedance',
+      tracesSampleRate: 1,
+      enableOfflineCache: false,
+      enableAutoSessionTracking: false,
+      enableMinigameLifecycle: false,
+      enableMinigameFrameRate: false,
+    });
+
+    const sentryWrappedRequest = g.tt.request;
+    g.tt.request = (options: Record<string, any>) =>
+      sentryWrappedRequest({
+        ...options,
+        ...(options.header && { header: { ...options.header } }),
+        ...(options.headers && { headers: { ...options.headers } }),
+      });
+    delete g.URL;
+
+    g.tt.request({ url: 'https://api.example.com/v1/login', method: 'POST' });
+    await flush(2000);
+
+    const requestedUrls = requestMock.mock.calls.map(([options]) => options.url);
+    expect(requestedUrls).toEqual([
+      'https://api.example.com/v1/login',
+      expect.stringMatching(/^https:\/\/o0\.ingest\.sentry\.io\/api\/0\/envelope\//),
+    ]);
+  });
+
   it('有 active span 时仍把请求记录为现有 transaction 的子 span', async () => {
     init({
       dsn: 'https://test@o0.ingest.sentry.io/0',

--- a/test/networkbreadcrumbs.test.ts
+++ b/test/networkbreadcrumbs.test.ts
@@ -319,6 +319,36 @@ describe('NetworkBreadcrumbs Integration', () => {
     expect(requestMock).toHaveBeenCalled();
   });
 
+  it('should identify a DSN envelope without relying on the global URL API', () => {
+    const integration = new NetworkBreadcrumbs({ traceNetworkBody: true });
+    setupIntegration(integration);
+
+    crossPlatform.sdk().request({
+      url: 'https://o113510.ingest.sentry.io/api/123/envelope/?sentry_key=key',
+      method: 'POST',
+    });
+
+    expect(mockIsSentryRequestUrl).toHaveReturnedWith(false);
+    expect(addBreadcrumb).not.toHaveBeenCalled();
+    expect(mockStartInactiveSpan).not.toHaveBeenCalled();
+    expect(requestMock).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    'https://sentry.io/api/business',
+    'https://sentry.io.evil.com/api/envelope/?sentry_key=key',
+    'https://evil-sentry.io/api/envelope/?sentry_key=key',
+    'https://sentry.io/api/business#?sentry_key=key',
+  ])('should not treat a business or lookalike URL as an SDK envelope: %s', (url) => {
+    const integration = new NetworkBreadcrumbs({ traceNetworkBody: true });
+    setupIntegration(integration);
+
+    crossPlatform.sdk().request({ url, method: 'POST' });
+
+    expect(addBreadcrumb).toHaveBeenCalledOnce();
+    expect(mockStartInactiveSpan).toHaveBeenCalledOnce();
+  });
+
   it('should ignore self-hosted or tunneled envelopes identified by core', () => {
     mockIsSentryRequestUrl.mockReturnValueOnce(true);
 

--- a/test/requestMarker.test.ts
+++ b/test/requestMarker.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isMarkedSentryRequest,
+  markSentryRequest,
+} from '../src/transports/requestMarker';
+
+describe('transport request marker', () => {
+  it('recognizes the original request options', () => {
+    const options = { url: 'https://sentry.example/api/envelope/' };
+
+    markSentryRequest(options);
+
+    expect(isMarkedSentryRequest(options)).toBe(true);
+  });
+
+  it.each(['header', 'headers'] as const)(
+    'survives a shallow options clone through the %s object identity',
+    (headerName) => {
+      const options = {
+        url: 'https://sentry.example/api/envelope/',
+        [headerName]: { 'Content-Type': 'application/x-sentry-envelope' },
+      };
+      markSentryRequest(options);
+
+      expect(isMarkedSentryRequest({ ...options })).toBe(true);
+    },
+  );
+
+  it('does not classify unrelated or deeply cloned options as marked', () => {
+    const options = {
+      url: 'https://sentry.example/api/envelope/',
+      header: { 'Content-Type': 'application/x-sentry-envelope' },
+    };
+    markSentryRequest(options);
+
+    expect(isMarkedSentryRequest(null)).toBe(false);
+    expect(isMarkedSentryRequest({ ...options, header: { ...options.header } })).toBe(false);
+  });
+});

--- a/test/support/networkbreadcrumbs.ts
+++ b/test/support/networkbreadcrumbs.ts
@@ -39,6 +39,7 @@ export function createNetworkBreadcrumbsTestHarness(
     setupIntegration(integration: NetworkBreadcrumbs): void {
       const client = {
         getOptions: () => ({ dsn: 'https://key@sentry.io/123' }),
+        getDsn: () => ({ host: 'sentry.io' }),
         registerCleanup: vi.fn(),
       } as any;
       dependencies.mockGetClient.mockReturnValue(client);


### PR DESCRIPTION
## CR 结论

对 #348 做真实构建包和请求包装链复查后，发现原修复仍有一个高优先级缺口：`WeakSet` 只能识别同一个参数对象。第三方请求 wrapper 若通过 `{ ...options }` 或重建请求头复制参数，transport 标记会丢失；在全局 `URL` 缺失时，envelope 仍可能被当成业务请求再次追踪。

真实 `dist/sentry-miniapp.cjs` 复现中，一次业务请求会连续产生 Sentry envelope，说明 #348 的原始保护还不够完整。

## 修复

- 同时标记 transport 的 options、`header` 和 `headers` 对象，覆盖常见浅拷贝 wrapper，且不向宿主请求参数写入私有字段
- 保留 `@sentry/core` 的 DSN / tunnel 判断
- 增加不依赖全局 `URL` 的最小 DSN 回退，语义与 core 一致：必须同时匹配 DSN 主机（或其子域）和查询参数 `sentry_key`
- 改进无 `URL` 的 host 提取，正确处理端口、userinfo 和 IPv6 authority
- 明确排除同域业务 URL、相似域名以及 fragment 中伪造的 `sentry_key`，避免扩大过滤范围
- 把自请求回归接入 npm 发布包消费检查：每次 `yarn build` 都会打包并隔离解包，不依赖源码测试环境
- ESM 发布产物覆盖微信、支付宝、字节、钉钉、QQ、百度、快手 × 全局 `URL` 缺失/残缺 14 个场景；CJS 额外覆盖原始微信缺失 `URL` 复现

## 验证

- 真实 npm tarball + 默认 transport + 外层 wrapper 同时复制 options / header / headers：CJS 原始场景和 ESM 14 个跨端组合均稳定为 1 次业务请求 + 1 次 envelope，无递归
- `yarn lint`
- `yarn typecheck`
- `yarn test:coverage`：49 个测试文件、751 个用例通过；全局 statements/lines 99.21%、branches 95.92%、functions 99.45%
- `yarn test:shuffle`：751 个用例通过
- `yarn build`：构建兼容检查、publint、CJS / ESM / UMD、7 平台 × 2 URL 模式发布包消费检查全部通过

这是 #348 的加固修复，继续覆盖 #345 的小游戏自请求递归场景。
