### PR TITLE
fix: 统一小程序平台配置语义

### DIFF
--- a/.agents/skills/sentry-miniapp-sdk/SKILL.md
+++ b/.agents/skills/sentry-miniapp-sdk/SKILL.md
@@ -48,7 +48,7 @@ ls yarn.lock pnpm-lock.yaml package-lock.json 2>/dev/null
 
 | Question | Impact |
 |----------|--------|
-| Which mini program platform? | Determines `platform` option and API differences |
+| Which mini program platform? | Determines whether `miniappPlatform` is needed and which host APIs are used |
 | Native or cross-platform framework (Taro/uni-app)? | Determines init pattern and build config |
 | Is `sentry-miniapp` already installed? | Skip install if present, check version |
 | Where is the app entry point? | Determines where to place `Sentry.init()` |
@@ -163,14 +163,14 @@ Sentry.init({
 
 ### Step 3: Configure Platform (if needed)
 
-The SDK auto-detects the platform at runtime. When multiple platform globals are present, it uses platform-specific host names, data paths, and App IDs to disambiguate them. Set `platform` only when those runtime signals are unavailable, conflicting, or the detected event label still does not match the release target.
+The SDK auto-detects the platform at runtime. When multiple platform globals are present, it uses platform-specific host names, data paths, and App IDs to disambiguate them. Set `miniappPlatform` only when those runtime signals are unavailable, conflicting, or the detected event label still does not match the release target.
 
 If you need to override the event's miniapp platform label:
 
 ```javascript
 Sentry.init({
   dsn: '...',
-  platform: 'bytedance', // 'wechat' | 'alipay' | 'bytedance' | 'qq' | 'swan' | 'dingtalk' | 'kuaishou'
+  miniappPlatform: 'bytedance', // 'wechat' | 'alipay' | 'bytedance' | 'qq' | 'swan' | 'dingtalk' | 'kuaishou'
   // Note: Baidu's global object is `swan`, so use 'swan' (there is no 'baidu' value).
 });
 ```

--- a/examples/taro/src/utils/sentry.ts
+++ b/examples/taro/src/utils/sentry.ts
@@ -16,8 +16,6 @@ Sentry.init({
   environment: 'production',
   debug: false,
 
-  // 小程序平台标识
-  platform: 'wechat',
   enableSystemInfo: true,
   enableUserInteractionBreadcrumbs: true,
   enableConsoleBreadcrumbs: true,

--- a/examples/uniapp/src/utils/sentry.js
+++ b/examples/uniapp/src/utils/sentry.js
@@ -22,8 +22,6 @@ Sentry.init({
   environment: 'production',
   debug: false,
 
-  // 小程序平台标识
-  platform: 'wechat',
   enableSystemInfo: true,
   enableUserInteractionBreadcrumbs: true,
   enableConsoleBreadcrumbs: true,

--- a/examples/wxapp/app.js
+++ b/examples/wxapp/app.js
@@ -30,7 +30,6 @@ Sentry.init({
   debug: false,
 
   // 小程序特有配置
-  platform: 'wechat',
   enableSystemInfo: true,
   enableUserInteractionBreadcrumbs: true,
   enableConsoleBreadcrumbs: true,

--- a/scripts/internal/check-package-consumers.mjs
+++ b/scripts/internal/check-package-consumers.mjs
@@ -300,13 +300,16 @@ import {
   logger,
   miniappStackParser,
   type MiniappOptions,
+  type MiniappPlatform,
   type PerformanceIntegrationOptions,
 } from 'sentry-miniapp';
 
 declare const options: MiniappOptions;
+const miniappPlatform: MiniappPlatform = 'wechat';
 const performanceOptions: PerformanceIntegrationOptions = {};
 
 init(options);
+init({ miniappPlatform });
 captureException(new Error('consumer type probe'));
 logger.info('consumer type probe');
 Integrations.performanceIntegration(performanceOptions);

--- a/src/client.ts
+++ b/src/client.ts
@@ -18,7 +18,8 @@ import type {
   SeverityLevel,
 } from '@sentry/core';
 
-import { appName, getAccountInfo, getSystemInfo } from './crossPlatform';
+import { getAccountInfo, getSystemInfo, resolveMiniappPlatform } from './crossPlatform';
+import type { AppName } from './crossPlatform';
 import { configureConsent, isConsentGranted, notifyConsentDrop } from './consent';
 import type { MiniappOptions, ReportDialogOptions, SendFeedbackParams } from './types';
 import { createMiniappTransport, createMiniappOfflineStore } from './transports';
@@ -29,12 +30,12 @@ import { miniappStackParser } from './stacktrace';
 
 export type MiniappClientOptions = Omit<
   MiniappOptions,
-  'integrations' | 'platform' | 'stackParser' | 'transport'
+  'integrations' | 'miniappPlatform' | 'platform' | 'stackParser' | 'transport'
 > &
   ClientOptions<MiniappTransportOptions> & {
     platform: string;
     /** 小程序宿主标识；与 Sentry 顶层 event.platform 分离。 */
-    miniappPlatform?: string | undefined;
+    miniappPlatform?: AppName | undefined;
   };
 
 const clientsWithCustomTransport = new WeakSet<MiniappClient>();
@@ -92,8 +93,11 @@ export class MiniappClient extends Client<MiniappClientOptions> {
   public constructor(options: MiniappOptions | MiniappClientOptions = {}) {
     const usesCustomTransport = typeof options.transport === 'function';
     const defaultIntegrationsMode = resolveDefaultIntegrationsMode(options.defaultIntegrations);
-    const miniappPlatform =
-      ('miniappPlatform' in options && options.miniappPlatform) || options.platform;
+    const hasConfiguredMiniappPlatform =
+      options.miniappPlatform !== undefined || options.platform !== undefined;
+    const miniappPlatform = hasConfiguredMiniappPlatform
+      ? resolveMiniappPlatform(options)
+      : undefined;
 
     // 配置隐私合规「同意门禁」。必须在 super() 之前——transport 工厂在 super() 执行期间被 core
     // 调用建立，其 shouldSend / store 需读到已就绪的 consent 状态。configureConsent 是模块函数、
@@ -260,7 +264,7 @@ export class MiniappClient extends Client<MiniappClientOptions> {
     contexts['miniapp'] = {
       environment: 'miniapp',
       ...contexts['miniapp'],
-      platform: this.getOptions().miniappPlatform || appName(),
+      platform: this.getOptions().miniappPlatform ?? resolveMiniappPlatform({}),
       sdk_version: SDK_VERSION,
     };
 

--- a/src/crossPlatform.ts
+++ b/src/crossPlatform.ts
@@ -60,6 +60,9 @@ export type AppName =
   | 'kuaishou'
   | 'unknown';
 
+/** 可显式配置的小程序宿主平台。`unknown` 仅供自动检测结果使用。 */
+export type MiniappPlatform = Exclude<AppName, 'unknown'>;
+
 /**
  * 系统信息接口
  */
@@ -148,7 +151,7 @@ const isBrowserRuntime = (): boolean => {
  * isMiniappEnvironment() 均基于此。数组顺序只作为宿主信号无法消除多对象歧义时的兼容回退，
  * 新增平台只需改这一处。
  */
-const PLATFORMS: ReadonlyArray<{ global: string; name: AppName }> = [
+const PLATFORMS: ReadonlyArray<{ global: string; name: MiniappPlatform }> = [
   { global: 'wx', name: 'wechat' },
   { global: 'my', name: 'alipay' },
   { global: 'tt', name: 'bytedance' },
@@ -472,7 +475,7 @@ const isMiniappEnvironment = (): boolean => {
 
 // 懒加载 SDK 和 appName，避免在模块导入时就执行平台检测
 export let _sdk: SDK | null = null;
-let _appName: string | null = null;
+let _appName: AppName | null = null;
 
 export const sdk = (): SDK => {
   if (_sdk === null) {
@@ -481,11 +484,38 @@ export const sdk = (): SDK => {
   return _sdk;
 };
 
-export const appName = (): string => {
+export const appName = (): AppName => {
   if (_appName === null) {
     _appName = getAppName();
   }
   return _appName;
+};
+
+const MINIAPP_PLATFORMS = new Set<MiniappPlatform>(PLATFORMS.map((platform) => platform.name));
+
+/**
+ * 解析事件使用的小程序宿主标记。`miniappPlatform` 是公开主选项，旧 `platform`
+ * 仅作兼容别名；非法 JavaScript 入参不会污染 Sentry 顶层平台语义。
+ */
+export const resolveMiniappPlatform = (options: {
+  miniappPlatform?: unknown;
+  platform?: unknown;
+}): AppName => {
+  const optionName = options.miniappPlatform !== undefined ? 'miniappPlatform' : 'platform';
+  const configured = options[optionName];
+
+  if (configured === undefined) {
+    return appName();
+  }
+  if (typeof configured === 'string' && MINIAPP_PLATFORMS.has(configured as MiniappPlatform)) {
+    return configured as MiniappPlatform;
+  }
+
+  console.warn(
+    `[sentry-miniapp] 忽略无效的 ${optionName}=${String(configured)}；` +
+      '请使用 wechat、alipay、bytedance、qq、swan、dingtalk 或 kuaishou，SDK 将改用自动识别结果。',
+  );
+  return appName();
 };
 
 // 小游戏环境检测缓存

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,6 +79,7 @@ export type {
   SendFeedbackParams,
   MinigameFrameRateOptions,
   MinigameJankLevels,
+  MiniappPlatform,
 } from './types';
 export { MiniappClient } from './client';
 export * as Integrations from './integrations/index';

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -15,7 +15,7 @@ import { setConsentGranted, isConsentGranted } from './consent';
 export { getDiagnostics } from './diagnostics';
 
 import { MiniappClient, setConfiguredDefaultIntegrationsMode } from './client';
-import { appName, isMiniappEnvironment, isMinigame } from './crossPlatform';
+import { isMiniappEnvironment, isMinigame, resolveMiniappPlatform } from './crossPlatform';
 import {
   GlobalHandlers,
   TryCatch,
@@ -192,15 +192,15 @@ export function init(options: MiniappOptions = {}): MiniappClient | undefined {
     generatedEventFilters,
   );
 
+  const miniappPlatform = resolveMiniappPlatform(options);
   const opts = {
     ...options,
+    miniappPlatform,
     defaultIntegrations: [],
     integrations,
     stackParser: stackParserFromStackParserOptions(options.stackParser ?? miniappStackParser),
     transport: options.transport,
   };
-  const miniappPlatform = options.platform || appName();
-
   // 平台标记。device / os / app context 由 MiniappClient._prepareEvent 在每个事件上统一写入
   // （唯一权威），此处不再重复设置，避免字段不一致与覆盖歧义（见架构 review P2-b）。
   setContext('miniapp', {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,8 @@
 import type { Options as CoreOptions } from '@sentry/core';
 import type { MiniappTransportOptions } from './transports';
-import type { AppName } from './crossPlatform';
+import type { AppName, MiniappPlatform } from './crossPlatform';
+
+export type { MiniappPlatform } from './crossPlatform';
 
 /**
  * 分级卡顿阈值（毫秒）。各档全 optional，可只启用其中一两档（如只给 major + severe）。
@@ -51,7 +53,13 @@ export interface MiniappOptions extends CoreOptions<MiniappTransportOptions> {
    * 默认按宿主全局对象及平台专属宿主信息自动识别；无法消除多对象歧义时可显式指定。
    * 此选项不切换底层运行时 API。百度小程序使用 `swan`，没有单独的 `baidu`。
    */
-  platform?: 'wechat' | 'alipay' | 'bytedance' | 'qq' | 'swan' | 'dingtalk' | 'kuaishou';
+  miniappPlatform?: MiniappPlatform;
+
+  /**
+   * @deprecated 请改用 `miniappPlatform`。此兼容别名将在未来主版本移除；两者同时传入时
+   * `miniappPlatform` 优先。
+   */
+  platform?: MiniappPlatform;
 
   /** Whether to enable system info collection */
   enableSystemInfo?: boolean;

--- a/test/crossPlatform.test.ts
+++ b/test/crossPlatform.test.ts
@@ -698,6 +698,23 @@ describe('CrossPlatform', () => {
       expect(result1).toBe('wechat');
       expect(result2).toBe('wechat'); // Should return cached value
     });
+
+    it('无效 miniappPlatform 会警告并回退自动识别，不使用旧别名', async () => {
+      (global as any).wx = { request: vi.fn() };
+      const { resolveMiniappPlatform } = await import('../src/crossPlatform');
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      try {
+        expect(
+          resolveMiniappPlatform({ miniappPlatform: 'javascript', platform: 'qq' }),
+        ).toBe('wechat');
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('无效的 miniappPlatform=javascript'),
+        );
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
   });
 
   describe('Storage API wrapping for Alipay/DingTalk', () => {

--- a/test/platform-detection.realcore.test.ts
+++ b/test/platform-detection.realcore.test.ts
@@ -78,7 +78,7 @@ describe('平台识别与显式覆盖（真 @sentry/core 集成）', () => {
     expect(event.contexts?.device?.brand).toBe('ByteDance');
   });
 
-  it('宿主信号不足时允许 platform=bytedance 覆盖小程序宿主标记', async () => {
+  it('宿主信号不足时允许 miniappPlatform=bytedance 覆盖小程序宿主标记', async () => {
     tt.getSystemInfoSync.mockReturnValue({
       brand: 'Unknown Adapter',
       model: 'Unknown Device',
@@ -88,7 +88,7 @@ describe('平台识别与显式覆盖（真 @sentry/core 集成）', () => {
     const wxOnError = g.wx.onError;
     const client = init({
       dsn: 'https://test@o0.ingest.sentry.io/0',
-      platform: 'bytedance',
+      miniappPlatform: 'bytedance',
       enableAutoSessionTracking: false,
       transport: createCapturingTransport(captured),
     });
@@ -107,5 +107,63 @@ describe('平台识别与显式覆盖（真 @sentry/core 集成）', () => {
     assertDefined(event);
     expect(event.platform).toBe('javascript');
     expect(event.contexts?.miniapp?.platform).toBe('bytedance');
+  });
+
+  it('兼容旧 platform 别名，但事件顶层 platform 始终是 javascript', async () => {
+    const client = init({
+      dsn: 'https://test@o0.ingest.sentry.io/0',
+      platform: 'bytedance',
+      enableAutoSessionTracking: false,
+      transport: createCapturingTransport(captured),
+    });
+    expect(client).toBeDefined();
+
+    captureException(new Error('legacy platform alias'));
+    await flush(2000);
+
+    const event = collectEnvelopePayloads<Event>(captured, ['event']).find((item) =>
+      item.exception?.values?.some((value: any) => value.value?.includes('legacy platform alias')),
+    );
+    assertDefined(event);
+    expect(event.platform).toBe('javascript');
+    expect(event.contexts?.miniapp?.platform).toBe('bytedance');
+  });
+
+  it('JavaScript 传入无效 platform 时警告并回退自动识别', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const client = init({
+      dsn: 'https://test@o0.ingest.sentry.io/0',
+      platform: 'javascript',
+      enableAutoSessionTracking: false,
+      transport: createCapturingTransport(captured),
+    } as any);
+    expect(client).toBeDefined();
+
+    captureException(new Error('invalid platform fallback'));
+    await flush(2000);
+
+    const event = collectEnvelopePayloads<Event>(captured, ['event']).find((item) =>
+      item.exception?.values?.some((value: any) =>
+        value.value?.includes('invalid platform fallback'),
+      ),
+    );
+    assertDefined(event);
+    expect(event.platform).toBe('javascript');
+    expect(event.contexts?.miniapp?.platform).toBe('bytedance');
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('无效的 platform=javascript'));
+    warnSpy.mockRestore();
+  });
+
+  it('miniappPlatform 优先于兼容 platform 别名', () => {
+    const client = init({
+      dsn: 'https://test@o0.ingest.sentry.io/0',
+      miniappPlatform: 'qq',
+      platform: 'wechat',
+      enableAutoSessionTracking: false,
+      transport: createCapturingTransport(captured),
+    });
+
+    expect(client?.getOptions().miniappPlatform).toBe('qq');
+    expect(client?.getOptions().platform).toBe('javascript');
   });
 });

--- a/website/guide/configuration.md
+++ b/website/guide/configuration.md
@@ -12,7 +12,8 @@
 | `release` | `string` | — | 版本号；**Source Map 解析的关键**，需与上传时的 release 完全一致 |
 | `environment` | `string` | — | 环境标识，如 `production` / `staging` |
 | `debug` | `boolean` | `false` | 开启 SDK 调试日志 |
-| `platform` | `'wechat'｜'alipay'｜'bytedance'｜'qq'｜'swan'｜'dingtalk'｜'kuaishou'` | 自动识别 | 小程序宿主标记，写入 `contexts.miniapp.platform`。事件顶层 `platform` 固定为 Sentry 标准值 `javascript`，以保持 JavaScript 堆栈解析与聚合语义。SDK 会结合平台对象、宿主名称、数据路径和 AppID 消除歧义；仅在信息缺失或冲突时手动指定。该选项不切换底层运行时 API。百度小程序使用 `swan` |
+| `miniappPlatform` | `'wechat'｜'alipay'｜'bytedance'｜'qq'｜'swan'｜'dingtalk'｜'kuaishou'` | 自动识别 | 小程序宿主标记，写入 `contexts.miniapp.platform`。事件顶层 `platform` 固定为 Sentry 标准值 `javascript`。SDK 会结合平台对象、宿主名称、数据路径和 AppID 消除歧义；仅在信息缺失或冲突时手动指定。该选项不切换底层运行时 API。百度小程序使用 `swan` |
+| `platform` | 同 `miniappPlatform` | — | 已弃用的兼容别名，请改用 `miniappPlatform`；两者同时传入时后者优先 |
 
 ## 采样
 

--- a/website/guide/minigame.md
+++ b/website/guide/minigame.md
@@ -23,7 +23,7 @@ Sentry.captureException(new Error('minigame sentry test'));
 
 ## 平台识别与游戏引擎
 
-SDK 默认通过 `wx`、`tt` 等平台对象识别平台。多个对象共存时，还会结合宿主名称、`ttfile://` 数据路径和 `tt...` AppID 等平台专属信息自动判定抖音环境。如果宿主 API 不可用或未返回有效信息，仍可显式传入 `platform: 'bytedance'` 作为事件标记兜底；详见[跨平台差异与降级](/guide/platform-compatibility#sdk-如何处理平台差异)。
+SDK 默认通过 `wx`、`tt` 等平台对象识别平台。多个对象共存时，还会结合宿主名称、`ttfile://` 数据路径和 `tt...` AppID 等平台专属信息自动判定抖音环境。如果宿主 API 不可用或未返回有效信息，仍可显式传入 `miniappPlatform: 'bytedance'` 作为事件标记兜底；详见[跨平台差异与降级](/guide/platform-compatibility#sdk-如何处理平台差异)。
 
 ## 能捕获什么
 

--- a/website/guide/platform-compatibility.md
+++ b/website/guide/platform-compatibility.md
@@ -18,7 +18,7 @@ SDK 初始化时按当前运行时的全局对象识别平台，业务代码不�
 | 百度智能小程序 | `swan` | `swan` | `swan.request` |
 | 快手小程序 | `ks` | `kuaishou` | `ks.request` |
 
-识别完成后，SDK 的异常捕获、面包屑、transport、离线缓存等上层能力只面对统一接口。通常无需手动设置 `platform`。
+识别完成后，SDK 的异常捕获、面包屑、transport、离线缓存等上层能力只面对统一接口。通常无需手动设置 `miniappPlatform`。
 
 只有一个平台对象时，SDK 直接使用它。运行时同时存在多个平台对象时，SDK 会进一步读取同步宿主信息，以平台专属信号消除歧义：
 
@@ -31,11 +31,11 @@ SDK 初始化时按当前运行时的全局对象识别平台，业务代码不�
 ```js
 Sentry.init({
   dsn: 'YOUR_DSN',
-  platform: 'bytedance',
+  miniappPlatform: 'bytedance',
 });
 ```
 
-显式配置只覆盖 `contexts.miniapp.platform`，不会切换底层宿主对象。事件顶层 `platform` 始终是 `javascript`，与 Sentry 官方 JavaScript SDK 的堆栈解析和 Source Map 语义保持一致；异常监听、网络和 Storage 等能力仍使用自动检测到的平台 API。
+显式配置只覆盖 `contexts.miniapp.platform`，不会切换底层宿主对象。事件顶层 `platform` 始终是 `javascript`，与 Sentry 官方 JavaScript SDK 的堆栈解析和 Source Map 语义保持一致；异常监听、网络和 Storage 等能力仍使用自动检测到的平台 API。旧 `platform` 选项仍可兼容，但已弃用；两者同时传入时 `miniappPlatform` 优先，非法值会给出警告并回退自动识别。
 
 ## 网络请求差异
 


### PR DESCRIPTION
## 背景

`platform` 同时容易被理解为 Sentry 事件顶层平台和小程序宿主平台，而 SDK 内部实际要求顶层始终为 `javascript`。公开类型、初始化路径和文档此前也没有统一表达这一语义。

## 改动

- 新增公开 `miniappPlatform` 选项和 `MiniappPlatform` 类型
- 保留 `platform` 作为已弃用兼容别名，`miniappPlatform` 优先
- 统一 `init` 与 `MiniappClient` 的平台解析逻辑，对非法 JavaScript 入参警告并回退自动识别
- 保持宿主 API 自动检测不受显式事件标签影响，顶层 `event.platform` 固定为 `javascript`
- 更新官网、Agent Skill、示例和发布包类型消费者检查
- 补充首选字段、旧别名、冲突优先级、非法值及真实 envelope 集成测试

## 验证

- `yarn run lint`
- `yarn run typecheck`
- `yarn run test:coverage`（49 个文件、754 个用例通过）
- `yarn run build`（含 publint、CJS / ESM / UMD 及 TypeScript 发布包消费者检查）
- `yarn run docs:build`

Closes #347
