### PR TITLE
chore(deps): 升级 Sentry Core 至 10.72.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "vitest": "^3.2.6"
   },
   "dependencies": {
-    "@sentry/core": "10.70.0"
+    "@sentry/core": "10.72.0"
   },
   "resolutions": {
     "js-yaml": "4.3.1",

--- a/src/client.ts
+++ b/src/client.ts
@@ -116,6 +116,8 @@ export class MiniappClient extends Client<MiniappClientOptions> {
       // 小程序宿主类型单独放在 contexts.miniapp.platform。
       platform: 'javascript',
       miniappPlatform,
+      // @sentry/core 10.71 起默认开启 Logs；保留 sentry-miniapp 的显式 opt-in 契约。
+      enableLogs: options.enableLogs ?? false,
       integrations: Array.isArray(options.integrations) ? options.integrations : [],
       stackParser: stackParserFromStackParserOptions(options.stackParser ?? miniappStackParser),
       transport: (transportOptions: BaseTransportOptions) => {

--- a/test/client.test.ts
+++ b/test/client.test.ts
@@ -597,6 +597,11 @@ describe('MiniappClient', () => {
   });
 
   describe('client configuration and cleanup', () => {
+    it('默认关闭 Logs，并保留用户显式开启配置', () => {
+      expect(new MiniappClient().getOptions().enableLogs).toBe(false);
+      expect(new MiniappClient({ enableLogs: true }).getOptions().enableLogs).toBe(true);
+    });
+
     it('derives the default integration mode for clients outside the constructor cache', () => {
       const fakeClient = {
         getOptions: () => ({ defaultIntegrations: false }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1813,12 +1813,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/core@npm:10.70.0":
-  version: 10.70.0
-  resolution: "@sentry/core@npm:10.70.0"
+"@sentry/core@npm:10.72.0":
+  version: 10.72.0
+  resolution: "@sentry/core@npm:10.72.0"
   dependencies:
     "@sentry/conventions": "npm:^0.16.0"
-  checksum: 10c0/4625428ed269c00375d2436968d7a24e5235a9c83c2968dc237543bba606d42326b5922e2d8d08a76a15e5f8734b940c607b1d911da8906987e1259763d36e21
+  checksum: 10c0/6b923a7d89c746ac87b9f1037ab08017d3c22ca1c8d295ac19bac580f58d5c354d16bd6c017c4834ded7f7a9c124c3dd876dbf256430ee6eabfed8f808b417b9
   languageName: node
   linkType: hard
 
@@ -6404,7 +6404,7 @@ __metadata:
     "@commitlint/cli": "npm:^20.5.0"
     "@commitlint/config-conventional": "npm:^20.5.0"
     "@publint/pack": "npm:^0.1.7"
-    "@sentry/core": "npm:10.70.0"
+    "@sentry/core": "npm:10.72.0"
     "@types/node": "npm:^20.19.11"
     "@typescript-eslint/eslint-plugin": "npm:^8.57.1"
     "@typescript-eslint/parser": "npm:^8.57.1"


### PR DESCRIPTION
## 改动

- 将 `@sentry/core` 从 `10.70.0` 升级到 `10.72.0`
- 同步 Yarn 锁文件
- 显式保留 sentry-miniapp 的 Logs opt-in 契约：默认 `enableLogs: false`，用户传入 `true` 时正常开启
- 增加 client 配置回归测试

## 兼容性评估

Sentry 10.71 将 `enableLogs` 上游默认值改为 `true`，但 sentry-miniapp 当前 README、官网和既有行为均要求显式开启。此次在 client 归一化边界固定默认值，避免依赖小版本升级导致 SDK 静默改变上报行为。

10.72 与本项目直接相关的 core 变更为 child span 超时句柄修复，未发现需要迁移的公开 API 变更。

## 验证

- `yarn run lint`
- `yarn run typecheck`
- `yarn run test:coverage`（49 个文件、756 个用例通过）
- `yarn run test:shuffle`（756 个用例随机顺序通过）
- `yarn run build`（含 publint、CJS / ESM / UMD、7 平台运行时矩阵及 TypeScript 发布包消费者检查）

Closes #344
