### PR TITLE
chore(release): 准备 1.20.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-miniapp",
-  "version": "1.19.3",
+  "version": "1.20.0",
   "description": "Sentry SDK for Mini Programs (WeChat, Alipay, ByteDance, Baidu, QQ, DingTalk, Kuaishou) & Taro / uni-app | 小程序监控 SDK，支持异常监控、性能监控、错误收集",
   "repository": {
     "type": "git",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
 // 版本号应该与 package.json 中的版本保持同步
-export const SDK_VERSION = '1.19.3';
+export const SDK_VERSION = '1.20.0';
 export const SDK_NAME = 'sentry.javascript.miniapp';


### PR DESCRIPTION
## 发布内容

准备发布 `sentry-miniapp@1.20.0`。

## 主要变化

- 新增公开 `miniappPlatform` 配置和 `MiniappPlatform` 类型，统一小程序宿主标签与 Sentry 顶层 `platform` 的语义；旧 `platform` 配置继续兼容
- 修复独立 `http.client` span 上报和 Sentry 自请求识别边界
- 将 `@sentry/core` 升级至 `10.72.0`，同时保留 Logs 默认关闭、显式开启的现有契约
- 加强 Node 20/22/24、Taro、uni-app、7 个小程序平台及 CJS / ESM / UMD 发布包回归验证

## 版本变更

- `package.json`: `1.19.3` → `1.20.0`
- `src/version.ts`: `1.19.3` → `1.20.0`

## 验证

- `yarn run lint`
- `yarn run typecheck`
- `yarn run test`（49 个文件、756 个用例）
- `yarn run build`（含 publint、CJS / ESM / UMD、7 平台运行时矩阵及 TypeScript 发布包消费者检查）

合并后从 `master` 的合并提交创建 `v1.20.0` tag，由发布 workflow 通过 npm Trusted Publishing 发布，并自动创建 GitHub Release。
