### PR TITLE
fix: 恢复微信构建工具兼容的 CJS 入口

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "build": "vite build && npm run build:type-entrypoints && npm run check:build-output && npm run check:package && npm run check:package-consumers",
     "build:type-entrypoints": "node scripts/internal/create-type-entrypoints.mjs",
-    "check:build-output": "node scripts/internal/check-build-output.mjs dist/sentry-miniapp.mjs dist/sentry-miniapp.cjs dist/sentry-miniapp.umd.js",
+    "check:build-output": "node scripts/internal/check-build-output.mjs dist/sentry-miniapp.mjs dist/sentry-miniapp.cjs.js dist/sentry-miniapp.umd.js",
     "check:package": "publint --level error",
     "check:package-consumers": "node scripts/internal/check-package-consumers.mjs",
     "build:miniapp": "vite build --mode miniapp && node scripts/internal/check-build-output.mjs examples/wxapp/lib/sentry-miniapp.js && node scripts/internal/check-miniapp-bundle.mjs examples/wxapp/lib/sentry-miniapp.js",
@@ -39,7 +39,7 @@
   "engines": {
     "node": ">=20"
   },
-  "main": "dist/sentry-miniapp.cjs",
+  "main": "dist/sentry-miniapp.cjs.js",
   "module": "dist/sentry-miniapp.mjs",
   "types": "dist/types/index.d.ts",
   "bin": {
@@ -54,7 +54,7 @@
       },
       "require": {
         "types": "./dist/types/index.d.cts",
-        "default": "./dist/sentry-miniapp.cjs"
+        "default": "./dist/sentry-miniapp.cjs.js"
       }
     }
   },

--- a/scripts/internal/check-package-consumers.mjs
+++ b/scripts/internal/check-package-consumers.mjs
@@ -335,7 +335,11 @@ try {
   });
 
   const packageJson = JSON.parse(await readFile(join(packageRoot, 'package.json'), 'utf8'));
+  const wechatMain = packageJson.main || 'index.js';
+  const wechatEntry = /\.(?:js|json)$/.test(wechatMain) ? wechatMain : `${wechatMain}.js`;
   await Promise.all([
+    // miniprogram-ci 2.x appends .js when main does not already end in .js or .json.
+    access(join(packageRoot, wechatEntry)),
     access(join(packageRoot, packageJson.exports['.'].import.types)),
     access(join(packageRoot, packageJson.exports['.'].require.types)),
   ]);

--- a/vite.config.js
+++ b/vite.config.js
@@ -124,7 +124,7 @@ export default defineConfig(({ mode }) => {
           },
           {
             format: 'cjs',
-            entryFileNames: 'sentry-miniapp.cjs',
+            entryFileNames: 'sentry-miniapp.cjs.js',
             exports: 'auto'
           },
           {


### PR DESCRIPTION
## 问题

从 1.19.2 开始，npm 包的 `main` 从 `dist/sentry-miniapp.cjs.js` 改为 `dist/sentry-miniapp.cjs`。`miniprogram-ci@2.1.35` 只把 `.js` / `.json` 视为完整入口后缀，因此会继续补 `.js`，最终查找不存在的 `sentry-miniapp.cjs.js`，仅输出 warning 并跳过 SDK 打包。

## 修改

- 恢复生成 `dist/sentry-miniapp.cjs.js`
- 同步更新 `main`、`exports.require` 和构建兼容检查
- 在发布包消费者检查中模拟 `miniprogram-ci 2.x` 的入口解析规则，防止再次回归

没有增加 `miniprogram_dist` 重复 bundle：当前自包含 CJS bundle 已通过 `miniprogram-ci@2.1.35` 的旧 Acorn 解析，恢复兼容入口即可解决问题，也不会额外增大 npm 包。

## 验证

- `yarn lint`
- `yarn typecheck`
- `yarn test`：49 个测试文件、756 个测试通过
- `yarn build`：包含 publint、CJS / ESM / UMD / TypeScript 发布包消费者检查
- 使用本地 tarball 和 `miniprogram-ci@2.1.35` 执行 `packNpmManually`：`warnList` 为空，产物可正常 `require`，`SDK_VERSION` 为 `1.20.0`

Closes #353