### PR TITLE
chore(release): 准备 1.20.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-miniapp",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "description": "Sentry SDK for Mini Programs (WeChat, Alipay, ByteDance, Baidu, QQ, DingTalk, Kuaishou) & Taro / uni-app | 小程序监控 SDK，支持异常监控、性能监控、错误收集",
   "repository": {
     "type": "git",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
 // 版本号应该与 package.json 中的版本保持同步
-export const SDK_VERSION = '1.20.0';
+export const SDK_VERSION = '1.20.1';
 export const SDK_NAME = 'sentry.javascript.miniapp';


### PR DESCRIPTION
## 发布内容

准备发布 `sentry-miniapp@1.20.1`。

## 修复内容

- 恢复微信开发者工具和 `miniprogram-ci@2.1.35` 可识别的 `.cjs.js` CJS 入口
- 增加微信旧版 npm 打包入口规则的发布包回归检查
- 解决 1.19.2 至 1.20.0 可能只提示 warning、跳过 SDK 打包并残留旧产物的问题

## 版本变更

- `package.json`: `1.20.0` → `1.20.1`
- `src/version.ts`: `1.20.0` → `1.20.1`

## 验证

- `yarn lint`
- `yarn typecheck`
- `yarn test`（49 个文件、756 个用例）
- `yarn build`（包含 publint、微信入口契约、CJS / ESM / UMD / TypeScript 发布包消费者检查）
- `miniprogram-ci@2.1.35` 对本地 tarball 的真实打包验证通过

合并后从 `master` 的合并提交创建 `v1.20.1` tag，由发布 workflow 通过 npm Trusted Publishing 发布，并自动创建 GitHub Release。