### PR TITLE
fix: 保证抖音小游戏 onHide 事件同步发起上报

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -7,6 +7,7 @@ import {
   getIsolationScope,
   getCurrentScope,
   makeOfflineTransport,
+  resolvedSyncPromise,
   stackParserFromStackParserOptions,
 } from '@sentry/core';
 import type {
@@ -24,6 +25,7 @@ import { configureConsent, isConsentGranted, notifyConsentDrop } from './consent
 import type { MiniappOptions, ReportDialogOptions, SendFeedbackParams } from './types';
 import { createMiniappTransport, createMiniappOfflineStore } from './transports';
 import type { MiniappTransportOptions } from './transports';
+import { createConsentAwareOfflineTransport } from './transports/consent';
 import { SDK_NAME, SDK_VERSION } from './version';
 import { syncDebugIdsToCoreGlobal } from './debugIds';
 import { miniappStackParser } from './stacktrace';
@@ -100,7 +102,7 @@ export class MiniappClient extends Client<MiniappClientOptions> {
       : undefined;
 
     // 配置隐私合规「同意门禁」。必须在 super() 之前——transport 工厂在 super() 执行期间被 core
-    // 调用建立，其 shouldSend / store 需读到已就绪的 consent 状态。configureConsent 是模块函数、
+    // 调用建立，其同意门禁 / store 需读到已就绪的 consent 状态。configureConsent 是模块函数、
     // 不触碰 this，故在 super 前调用合法。requireConsent=false 时它把门禁置为「恒放行」，行为不变。
     configureConsent({
       required: options.requireConsent === true,
@@ -129,27 +131,30 @@ export class MiniappClient extends Client<MiniappClientOptions> {
               headers: miniappTransportOptions.headers ?? {},
             });
 
-        // 同意门禁：用 core offline transport 的 shouldSend 闸断网络（同意前 envelope 不发、
-        // 转入本地缓冲），setConsent(true) 后由 transport.flush() 补发。即便用户关了
+        // 同意门禁：在调用 core offline transport 前同步闸断网络（同意前 envelope 不发、
+        // 直接转入本地缓冲），setConsent(true) 后由 transport.flush() 补发。即便用户关了
         // enableOfflineCache，requireConsent 仍需缓冲，故强制走 offline 路径；若用户传了自定义
         // transport，也要包住它，避免合规开关被高级用法绕过。
         if (options.requireConsent === true) {
-          return makeOfflineTransport(() => baseTransport)({
+          const store = createMiniappOfflineStore({
             ...transportOptions,
-            createStore: (storeOptions: any) =>
-              createMiniappOfflineStore({
-                ...storeOptions,
-                // 同意前缓存用独立上限 + 冷启动优先（保留最旧）淘汰，区别于弱网那套默认值。
-                offlineCacheLimit: options.consentCacheLimit ?? 100,
-                offlineCacheMaxAge: options.consentCacheMaxAge,
-                maxBytes: options.consentCacheMaxBytes,
-                evictionMode: 'preserve-oldest',
-                onDrop: notifyConsentDrop,
-              }),
-            // 返回 false → core 不发网络、转 shouldStore 入缓存。同意后恒为 true。
-            shouldSend: () => isConsentGranted(),
-            flushAtStartup: true,
-          } as any);
+            // 同意前缓存用独立上限 + 冷启动优先（保留最旧）淘汰，区别于弱网那套默认值。
+            offlineCacheLimit: options.consentCacheLimit ?? 100,
+            ...(options.consentCacheMaxAge !== undefined && {
+              offlineCacheMaxAge: options.consentCacheMaxAge,
+            }),
+            ...(options.consentCacheMaxBytes !== undefined && {
+              maxBytes: options.consentCacheMaxBytes,
+            }),
+            evictionMode: 'preserve-oldest',
+            onDrop: notifyConsentDrop,
+          });
+          return createConsentAwareOfflineTransport(
+            baseTransport,
+            miniappTransportOptions,
+            store,
+            isConsentGranted,
+          );
         }
 
         if (!options.transport && options.enableOfflineCache !== false) {
@@ -183,7 +188,7 @@ export class MiniappClient extends Client<MiniappClientOptions> {
   public eventFromException(exception: unknown, hint?: EventHint): PromiseLike<Event> {
     const event = eventFromUnknownInput(this, this.getOptions().stackParser, exception, hint);
     event.level = 'error';
-    return Promise.resolve(event);
+    return resolvedSyncPromise(event);
   }
 
   public eventFromMessage(
@@ -191,7 +196,7 @@ export class MiniappClient extends Client<MiniappClientOptions> {
     level: SeverityLevel = 'info',
     hint?: EventHint,
   ): PromiseLike<Event> {
-    return Promise.resolve(
+    return resolvedSyncPromise(
       eventFromMessageCore(
         this.getOptions().stackParser,
         message,
@@ -235,15 +240,17 @@ export class MiniappClient extends Client<MiniappClientOptions> {
 
       const currentScope = scope || getCurrentScope();
       const isolationScope = getIsolationScope();
-      return Promise.resolve(
-        super._prepareEvent(event, hint || {}, currentScope, isolationScope),
-      ).then((prepared) => this._fillDefaultContexts(prepared));
+      // 保留 core SyncPromise 的同步完成语义：抖音小游戏 onHide 返回后可能立即冻结 JS，
+      // 若用原生 Promise 包裹，底层 request 会被推迟到下次 onShow，甚至因进程回收而丢失。
+      return super
+        ._prepareEvent(event, hint || {}, currentScope, isolationScope)
+        .then((prepared) => this._fillDefaultContexts(prepared));
     } catch (error) {
       // Fallback if scopes are not properly initialized
       if (this.getOptions().debug) {
         console.warn('[sentry-miniapp] _prepareEvent 兜底（scope 未就绪）:', error);
       }
-      return Promise.resolve(this._fillDefaultContexts(event));
+      return resolvedSyncPromise(this._fillDefaultContexts(event));
     }
   }
 

--- a/src/consent.ts
+++ b/src/consent.ts
@@ -5,9 +5,9 @@
  * `setConsent(true)` 后补发并恢复正常上报。
  *
  * 采用模块级单例（对齐 `crossPlatform.ts` 的缓存 + `resetPlatformCache` 范式）：门禁状态
- * 要同时被 transport 的 `shouldSend` 钩子（在 `MiniappClient` 构造时建立）读取、被公开的
- * `setConsent` API 写入，二者跨文件，需共享同一处状态。这也是它放在 `src/` 顶层而非
- * `integrations/` 的原因——门禁挂在 transport 上、早于集成 setupOnce，集成来不及提供状态。
+ * 要同时被 transport（在 `MiniappClient` 构造时建立）读取、被公开的 `setConsent` API 写入，
+ * 二者跨文件，需共享同一处状态。这也是它放在 `src/` 顶层而非 `integrations/` 的原因——
+ * 门禁挂在 transport 上、早于集成 setupOnce，集成来不及提供状态。
  */
 
 /** `onConsentCacheDrop` 回调的丢弃原因。 */

--- a/src/transports/consent.ts
+++ b/src/transports/consent.ts
@@ -1,0 +1,59 @@
+import { envelopeContainsItemType, makeOfflineTransport, resolvedSyncPromise } from '@sentry/core';
+import type { BaseTransportOptions, Envelope, OfflineStore, Transport } from '@sentry/core';
+
+type ConsentStateReader = () => boolean;
+
+/**
+ * 在 miniapp 生命周期同步段内执行同意判断，同时复用 core 的离线重试能力。
+ *
+ * core offline transport 的 `shouldSend` 会被 `await`，即使返回 boolean 也会产生微任务。
+ * 抖音小游戏在 onHide 返回后可能冻结 JS，因此门禁必须在调用 core transport 前同步完成。
+ */
+export function createConsentAwareOfflineTransport(
+  baseTransport: Transport,
+  options: BaseTransportOptions,
+  store: OfflineStore,
+  hasConsent: ConsentStateReader,
+): Transport {
+  const isClientReport = (envelope: Envelope): boolean =>
+    envelopeContainsItemType(envelope, ['client_report']);
+
+  const consentGuardedTransport: Transport = {
+    send: (envelope) => {
+      if (hasConsent()) {
+        return baseTransport.send(envelope);
+      }
+
+      // 已安排的离线重试可能遇到中途撤回同意。同步放回队首，并用 4xx 阻止 core
+      // 继续安排重试；下次 setConsent(true) 会显式触发 flush。
+      if (!isClientReport(envelope)) {
+        void store.unshift(envelope);
+      }
+      return resolvedSyncPromise({ statusCode: 403 });
+    },
+    flush: (timeout) => baseTransport.flush(timeout),
+  };
+
+  const offlineTransport = makeOfflineTransport(() => consentGuardedTransport)({
+    ...options,
+    createStore: () => store,
+    // requireConsent 初始化时默认未同意，必须等 setConsent(true) 后才能排空历史缓存。
+    flushAtStartup: false,
+  });
+
+  return {
+    send: (envelope) => {
+      if (hasConsent()) {
+        return offlineTransport.send(envelope);
+      }
+      if (isClientReport(envelope)) {
+        return resolvedSyncPromise({});
+      }
+
+      // createMiniappOfflineStore 在返回 Promise 前已同步完成 Storage 写入。
+      return resolvedSyncPromise(store.push(envelope)).then(() => ({}));
+    },
+    flush: (timeout) =>
+      hasConsent() ? offlineTransport.flush(timeout) : baseTransport.flush(timeout),
+  };
+}

--- a/test/consent-transport.test.ts
+++ b/test/consent-transport.test.ts
@@ -1,0 +1,99 @@
+import type { Envelope, OfflineStore, Transport } from '@sentry/core';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { createConsentAwareOfflineTransport } from '../src/transports/consent';
+import { createEventEnvelope } from './support/envelopes';
+
+function createClientReportEnvelope(): Envelope {
+  return [
+    { sent_at: '2022-01-01T00:00:00.000Z' },
+    [[{ type: 'client_report' }, { timestamp: 1640995200, discarded_events: [] }]],
+  ];
+}
+
+describe('createConsentAwareOfflineTransport', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('未同意时同步缓存事件、丢弃 client report，并只 flush 底层请求', () => {
+    const store: OfflineStore = {
+      push: vi.fn(() => Promise.resolve()),
+      unshift: vi.fn(() => Promise.resolve()),
+      shift: vi.fn(() => Promise.resolve(undefined)),
+    };
+    const baseTransport: Transport = {
+      send: vi.fn(() => Promise.resolve({ statusCode: 200 })),
+      flush: vi.fn(() => Promise.resolve(true)),
+    };
+    const transport = createConsentAwareOfflineTransport(
+      baseTransport,
+      { url: 'https://o0.ingest.sentry.io/api/0/envelope/', recordDroppedEvent: vi.fn() },
+      store,
+      () => false,
+    );
+
+    transport.send(createEventEnvelope('blocked-event'));
+    expect(store.push).toHaveBeenCalledTimes(1);
+    expect(baseTransport.send).not.toHaveBeenCalled();
+
+    transport.send(createClientReportEnvelope());
+    expect(store.push).toHaveBeenCalledTimes(1);
+
+    transport.flush(10);
+    expect(baseTransport.flush).toHaveBeenCalledWith(10);
+  });
+
+  it('已同意时同步调用底层 transport', () => {
+    const store: OfflineStore = {
+      push: vi.fn(() => Promise.resolve()),
+      unshift: vi.fn(() => Promise.resolve()),
+      shift: vi.fn(() => Promise.resolve(undefined)),
+    };
+    const baseTransport: Transport = {
+      send: vi.fn(() => Promise.resolve({ statusCode: 200 })),
+      flush: vi.fn(() => Promise.resolve(true)),
+    };
+    const transport = createConsentAwareOfflineTransport(
+      baseTransport,
+      { url: 'https://o0.ingest.sentry.io/api/0/envelope/', recordDroppedEvent: vi.fn() },
+      store,
+      () => true,
+    );
+    const envelope = createEventEnvelope('granted-event');
+
+    transport.send(envelope);
+    expect(baseTransport.send).toHaveBeenCalledWith(envelope);
+
+    transport.flush(20);
+    expect(baseTransport.flush).toHaveBeenCalledWith(20);
+  });
+
+  it('已安排的重试遇到撤回同意时同步放回缓存且不发送网络', async () => {
+    vi.useFakeTimers();
+    const envelope = createEventEnvelope('revoked-before-retry');
+    let granted = true;
+    const store: OfflineStore = {
+      push: vi.fn(() => Promise.resolve()),
+      unshift: vi.fn(() => Promise.resolve()),
+      shift: vi.fn(() => Promise.resolve(envelope)),
+    };
+    const baseTransport: Transport = {
+      send: vi.fn(() => Promise.resolve({ statusCode: 200 })),
+      flush: vi.fn(() => Promise.resolve(true)),
+    };
+    const transport = createConsentAwareOfflineTransport(
+      baseTransport,
+      { url: 'https://o0.ingest.sentry.io/api/0/envelope/', recordDroppedEvent: vi.fn() },
+      store,
+      () => granted,
+    );
+
+    transport.flush();
+    granted = false;
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(store.unshift).toHaveBeenCalledWith(envelope);
+    expect(baseTransport.send).not.toHaveBeenCalled();
+  });
+});

--- a/test/consent.realcore.test.ts
+++ b/test/consent.realcore.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
-import { makeOfflineTransport } from '@sentry/core';
 import { configureConsent, isConsentGranted, resetConsentState, setConsentGranted } from '../src/consent';
 import { resetPlatformCache } from '../src/crossPlatform';
+import { createConsentAwareOfflineTransport } from '../src/transports/consent';
 import { createMiniappOfflineStore } from '../src/transports/offlineStore';
 import { createEventEnvelope } from './support/envelopes';
 
@@ -38,25 +38,28 @@ describe('Consent gate with real makeOfflineTransport', () => {
 
   it('queues before consent, flushes after consent, and blocks again when consent is revoked', async () => {
     const baseSend = vi.fn((_: any) => Promise.resolve({ statusCode: 200 }));
-    const makeBase = () => ({ send: baseSend, flush: () => Promise.resolve(true) });
-
-    const transport = makeOfflineTransport(makeBase as any)({
+    const baseTransport = { send: baseSend, flush: () => Promise.resolve(true) };
+    const options = {
       url: 'https://o0.ingest.sentry.io/api/0/envelope/',
       recordDroppedEvent: () => {},
-      createStore: (options: any) =>
-        createMiniappOfflineStore({
-          ...options,
-          offlineCacheLimit: 100,
-          evictionMode: 'preserve-oldest',
-        }),
-      shouldSend: () => isConsentGranted(),
-      flushAtStartup: false,
-    } as any);
+    };
+    const store = createMiniappOfflineStore({
+      ...options,
+      offlineCacheLimit: 100,
+      evictionMode: 'preserve-oldest',
+    });
+    const transport = createConsentAwareOfflineTransport(
+      baseTransport,
+      options,
+      store,
+      isConsentGranted,
+    );
 
-    await transport.send(createEventEnvelope('before-consent'));
+    const blockedSend = transport.send(createEventEnvelope('before-consent'));
 
     expect(baseSend).not.toHaveBeenCalled();
     expect(mem[OFFLINE_KEY]).toContain('before-consent');
+    await blockedSend;
 
     setConsentGranted(true);
     void transport.flush();
@@ -70,9 +73,10 @@ describe('Consent gate with real makeOfflineTransport', () => {
     baseSend.mockClear();
     setConsentGranted(false);
 
-    await transport.send(createEventEnvelope('blocked-again'));
+    const blockedAgain = transport.send(createEventEnvelope('blocked-again'));
 
     expect(baseSend).not.toHaveBeenCalled();
     expect(mem[OFFLINE_KEY]).toContain('blocked-again');
+    await blockedAgain;
   });
 });

--- a/test/lifecycle-sync.realcore.test.ts
+++ b/test/lifecycle-sync.realcore.test.ts
@@ -1,0 +1,105 @@
+import {
+  captureException,
+  captureMessage,
+  getClient,
+  type Envelope,
+  type Transport,
+} from '@sentry/core';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { resetConsentState } from '../src/consent';
+import { resetPlatformCache } from '../src/crossPlatform';
+import { init, setConsent } from '../src/index';
+
+describe('小游戏生命周期同步发送链路（真 @sentry/core）', () => {
+  const g = globalThis as any;
+  const storage = new Map<string, unknown>();
+  let rawRequest: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    storage.clear();
+    delete g.wx;
+    resetPlatformCache();
+
+    rawRequest = vi.fn((options: Record<string, any>) => {
+      const response = { statusCode: 200, data: { ok: true }, header: {} };
+      options.success?.(response);
+      options.complete?.(response);
+      return { abort: vi.fn() };
+    });
+    g.tt = {
+      request: rawRequest,
+      getSystemInfoSync: vi.fn(() => ({ platform: 'ios' })),
+      getAccountInfoSync: vi.fn(() => ({ miniProgram: { appId: 'douyin-sync-test' } })),
+      getStorageSync: vi.fn((key: string) => storage.get(key)),
+      setStorageSync: vi.fn((key: string, value: unknown) => storage.set(key, value)),
+      removeStorageSync: vi.fn((key: string) => storage.delete(key)),
+    };
+  });
+
+  afterEach(async () => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    const client = getClient();
+    if (client) await client.close(0);
+    resetConsentState();
+    delete g.tt;
+    resetPlatformCache();
+  });
+
+  it('异常、消息和 transaction 在 capture 调用返回前到达 transport', () => {
+    const captured: Envelope[] = [];
+    const transport = (): Transport => ({
+      send: (envelope) => {
+        captured.push(envelope);
+        return Promise.resolve({ statusCode: 200 });
+      },
+      flush: () => Promise.resolve(true),
+    });
+    const client = init({
+      dsn: 'https://test@o0.ingest.sentry.io/0',
+      defaultIntegrations: false,
+      enableOfflineCache: false,
+      enableMinigameLifecycle: false,
+      enableMinigameFrameRate: false,
+      tracesSampleRate: 1,
+      transport,
+    });
+
+    captureException(new Error('sync exception'));
+    expect(captured).toHaveLength(1);
+
+    captureMessage('sync message');
+    expect(captured).toHaveLength(2);
+
+    client!.captureEvent({ type: 'transaction', transaction: 'sync transaction' });
+    expect(captured).toHaveLength(3);
+  });
+
+  it('同意前同步写缓存，同意后在 capture 返回前调用 tt.request', async () => {
+    vi.useFakeTimers();
+    const client = init({
+      dsn: 'https://test@o0.ingest.sentry.io/0',
+      defaultIntegrations: false,
+      enableMinigameLifecycle: false,
+      enableMinigameFrameRate: false,
+      requireConsent: true,
+      consentCacheMaxAge: 60_000,
+      consentCacheMaxBytes: 128 * 1024,
+      tracesSampleRate: 1,
+    });
+
+    client!.captureEvent({ type: 'transaction', transaction: 'before consent' });
+    expect(rawRequest).not.toHaveBeenCalled();
+    expect(String(storage.get('sentry_offline_store'))).toContain('before consent');
+
+    setConsent(true);
+    client!.captureEvent({ type: 'transaction', transaction: 'after consent' });
+    expect(rawRequest).toHaveBeenCalledTimes(1);
+
+    await Promise.resolve();
+    await vi.runAllTimersAsync();
+    expect(rawRequest).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(String(storage.get('sentry_offline_store')))).toEqual([]);
+  });
+});

--- a/test/minigame-framerate.realcore.test.ts
+++ b/test/minigame-framerate.realcore.test.ts
@@ -68,7 +68,7 @@ describe('MinigameFrameRateIntegration（真 @sentry/core 集成）', () => {
     delete g.wx;
   });
 
-  it('开启 tracing 后，分级会话汇总产出真实 transaction（含分档 measurement）', async () => {
+  it('onHide 返回前同步产出真实 transaction（含分档 measurement）', () => {
     init({
       dsn: 'https://test@o0.ingest.sentry.io/0',
       tracesSampleRate: 1.0,
@@ -88,9 +88,7 @@ describe('MinigameFrameRateIntegration（真 @sentry/core 集成）', () => {
     frame(85); // delta 65 → major（33<65≤100）
     frame(285); // delta 200 → severe（>100）
 
-    hideCb!(); // 退后台 → 发会话汇总 transaction
-    // transaction 经异步 prepareEvent 后才进 transport，放掉微任务 + 一个宏任务。
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    hideCb!(); // 退后台后 JS 线程可能立即冻结，transport 必须已收到 transaction。
 
     const summary = collectEnvelopePayloads<Event>(captured, ['transaction']).find(
       (t) => t.transaction === 'minigame.framerate.summary',


### PR DESCRIPTION
## 问题

抖音小游戏在部分真机环境中会在 `tt.onHide` 回调返回后立即冻结 JS 线程。当前事件链被原生 `Promise` 以及 `makeOfflineTransport.shouldSend` 内部的 `await` 打断，导致底层 `tt.request` 无法在本次同步段内发起；若进程随后被回收，事件会静默丢失。

## 改动

- 使用 `@sentry/core` 的 `resolvedSyncPromise`，并直接串联 core `_prepareEvent` 返回的 `SyncPromise`，保留异常、消息和 transaction 的同步完成能力。
- 新增 consent-aware offline transport，在进入 core offline transport 前同步执行隐私同意门禁，避免 `shouldSend` 的 `await` 引入微任务。
- 保留同意前同步写缓存、同意后补发、撤回同意后重新缓存、离线重试和 client report 丢弃语义。
- 将真实小游戏 `onHide` 集成测试改为断言回调返回前 transaction 已到达 transport，并补充抖音宿主、默认请求 transport 与 consent 的真实 core 回归测试。

## 验证

- `yarn lint`
- `yarn typecheck`
- `yarn test:coverage`（51 files / 761 tests）
- `yarn test:shuffle`
- `yarn build`（含 publint、CJS / ESM / UMD / TypeScript 与 7 平台消费检查）

## 边界

本修复保证同步处理链上底层请求在 `onHide` 返回前被调用。请求发出后，宿主若冻结 JS，响应回调、失败缓存与重试仍需等 JS 恢复执行；因此不承诺冻结期间一定完成响应或落盘。

无需更新用户文档：对外 API 和配置方式不变。

Closes #358

关联上游：getsentry/sentry-javascript#24005