### PR TITLE
chore(release): 发布 1.20.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-miniapp",
-  "version": "1.20.1",
+  "version": "1.20.2",
   "description": "Sentry SDK for Mini Programs (WeChat, Alipay, ByteDance, Baidu, QQ, DingTalk, Kuaishou) & Taro / uni-app | 小程序监控 SDK，支持异常监控、性能监控、错误收集",
   "repository": {
     "type": "git",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
 // 版本号应该与 package.json 中的版本保持同步
-export const SDK_VERSION = '1.20.1';
+export const SDK_VERSION = '1.20.2';
 export const SDK_NAME = 'sentry.javascript.miniapp';


### PR DESCRIPTION
## 发布内容

发布 `sentry-miniapp@1.20.2`，包含 #359 对抖音小游戏 `onHide` 同步发送链路的兼容性修复。

## 版本变更

- `package.json`: `1.20.1` → `1.20.2`
- `src/version.ts`: `SDK_VERSION` 更新为 `1.20.2`

## 验证

- `yarn lint`
- `yarn typecheck`
- `yarn test`（51 files / 761 tests）
- `yarn build`（含 publint 与 CJS / ESM / UMD / TypeScript、7 平台消费检查）
- npm registry 中 `1.20.2` 尚未发布

合并后从 `master` 创建并推送 `v1.20.2` tag，由 Trusted Publishing workflow 发布 npm 包并创建 GitHub Release。