### PR TITLE
chore(deps): 升级 @sentry/core 至 10.73.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "vitest": "^3.2.6"
   },
   "dependencies": {
-    "@sentry/core": "10.72.0"
+    "@sentry/core": "10.73.0"
   },
   "resolutions": {
     "js-yaml": "4.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1813,12 +1813,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@sentry/core@npm:10.72.0":
-  version: 10.72.0
-  resolution: "@sentry/core@npm:10.72.0"
+"@sentry/core@npm:10.73.0":
+  version: 10.73.0
+  resolution: "@sentry/core@npm:10.73.0"
   dependencies:
     "@sentry/conventions": "npm:^0.16.0"
-  checksum: 10c0/6b923a7d89c746ac87b9f1037ab08017d3c22ca1c8d295ac19bac580f58d5c354d16bd6c017c4834ded7f7a9c124c3dd876dbf256430ee6eabfed8f808b417b9
+  checksum: 10c0/553469fd82ec11f5697ab4b2881b6f811834a1036e88afe24920940f131d59ad1dfcd008b99656661c49c7c9de51678719b884b0a6cfcb696312fd58bb911495
   languageName: node
   linkType: hard
 
@@ -6404,7 +6404,7 @@ __metadata:
     "@commitlint/cli": "npm:^20.5.0"
     "@commitlint/config-conventional": "npm:^20.5.0"
     "@publint/pack": "npm:^0.1.7"
-    "@sentry/core": "npm:10.72.0"
+    "@sentry/core": "npm:10.73.0"
     "@types/node": "npm:^20.19.11"
     "@typescript-eslint/eslint-plugin": "npm:^8.57.1"
     "@typescript-eslint/parser": "npm:^8.57.1"


### PR DESCRIPTION
## 变更内容

- 将 `@sentry/core` 从 `10.72.0` 升级至当前 latest `10.73.0`
- 同步更新 Yarn 4 锁文件
- SDK 版本与业务代码保持不变

## 兼容性评估

Sentry 官方 10.73.0 Release Notes 的公开变更集中在 Next.js、Node 和 Cloudflare，没有 `@sentry/core` 对外 API 的 breaking change。重点回归了 sentry-miniapp 依赖的 SyncPromise、小游戏 `onHide` 同步上报、consent 门禁、离线 transport 与七端发布包消费路径。

## 验证

- `yarn lint`
- `yarn typecheck`
- `yarn test`（51 个文件、761 项）
- `yarn test:coverage`（全局 statements/lines 99.22%、branches 96.03%、functions 99.46%）
- `yarn test:shuffle`（761 项）
- `yarn build`（含 publint、CJS/ESM/UMD、7 平台 × 2 URL 模式与 TypeScript 46 个导出检查）

Closes #361