### PR TITLE
chore(deps): 配置分目录依赖更新

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,47 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '09:00'
+      timezone: Asia/Shanghai
+    open-pull-requests-limit: 5
+    groups:
+      vite-test-toolchain:
+        patterns:
+          - vite
+          - vite-plugin-dts
+          - vitest
+          - '@vitest/*'
+
+  - package-ecosystem: npm
+    directory: /examples/uniapp
+    schedule:
+      interval: weekly
+      day: monday
+      time: '09:15'
+      timezone: Asia/Shanghai
+    open-pull-requests-limit: 3
+    groups:
+      uni-app-toolchain:
+        patterns:
+          - '@dcloudio/*'
+          - vite
+
+  - package-ecosystem: npm
+    directory: /examples/taro
+    schedule:
+      interval: weekly
+      day: monday
+      time: '09:30'
+      timezone: Asia/Shanghai
+    open-pull-requests-limit: 3
+    groups:
+      taro-toolchain:
+        patterns:
+          - '@tarojs/*'
+          - babel-preset-taro
+          - webpack


### PR DESCRIPTION
## 变更

- 为根目录、`examples/uniapp` 和 `examples/taro` 分别启用每周 Dependabot version updates
- 将 Vite、Vitest、coverage provider 与 `vite-plugin-dts` 归为同一工具链组
- 将 DCloud 全套包与 Vite 归为 uni-app 工具链组
- 将 Taro 全套包与 Webpack 归为 Taro 工具链组
- 为三个目录分别限制并发 PR 数，减少依赖更新噪音

## 调研结论

当前 18 个尚未实际修复的 Dependabot 告警都来自示例工程开发依赖：

- DCloud 最新非 alpha 版 `3.0.0-5020420260813003` 仍将 Vite peer dependency 精确锁定为 `5.2.8`
- Taro 最新稳定版 `4.2.1` 仍将 Webpack peer dependency 精确锁定为 `5.91.0`

因此不能只把 Vite 强升到 5.4/6，或把 Webpack 强升到 5.104；那会制造上游未声明支持的依赖组合。这个 PR 选择跟踪并成组升级父框架，而不是使用 `--force` 掩盖 peer 冲突。

这些依赖不进入 `sentry-miniapp` npm 发布包；示例 CI 只执行本地生产构建，不会对外启动 Vite 开发服务器。现有告警的处置将在合并后按上游阻塞和实际可利用性单独记录。

## 验证

- 使用 `js-yaml` 解析配置成功，确认包含三个 manifest 目录
- `yarn lint`
- `yarn test`（51 个文件、761 个用例）

配置格式遵循 GitHub Dependabot v2 的 `directory`、`schedule` 与单 ecosystem `groups` 约定。