### PR TITLE
chore(deps): 精简示例依赖更新

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,28 +20,31 @@ updates:
   - package-ecosystem: npm
     directory: /examples/uniapp
     schedule:
-      interval: weekly
-      day: monday
+      interval: monthly
       time: '09:15'
       timezone: Asia/Shanghai
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 1
+    # Examples are compatibility fixtures; follow the framework, then update its
+    # pinned build tool manually according to the new peer dependency contract.
+    allow:
+      - dependency-name: '@dcloudio/*'
     groups:
-      uni-app-toolchain:
+      uni-app-framework:
         patterns:
           - '@dcloudio/*'
-          - vite
 
   - package-ecosystem: npm
     directory: /examples/taro
     schedule:
-      interval: weekly
-      day: monday
+      interval: monthly
       time: '09:30'
       timezone: Asia/Shanghai
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 1
+    allow:
+      - dependency-name: '@tarojs/*'
+      - dependency-name: babel-preset-taro
     groups:
-      taro-toolchain:
+      taro-framework:
         patterns:
           - '@tarojs/*'
           - babel-preset-taro
-          - webpack


### PR DESCRIPTION
## 改动说明

- 根项目依赖继续按周检查
- uni-app 与 Taro 示例改为每月检查，且各自最多保留 1 个版本更新 PR
- 示例仅跟随对应框架依赖，Vite / Webpack 由框架 peerDependencies 决定，不再单独追新
- 补充注释，明确示例工程是兼容性验证夹具

## 设计考虑

示例工程的职责是验证 SDK 与主流框架组合是否可用，不应承担构建工具独立升级。这样可以减少无效依赖 PR，同时避免 Dependabot 把 Vite / Webpack 升到框架尚未声明支持的版本。

## 验证

- Dependabot YAML 解析通过
- `yarn lint`
- `yarn test`（51 个文件，761 个测试）