### PR TITLE
chore(release): 更新 Node 20 兼容的发版工具

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,7 +36,7 @@ updates:
           - patch
     ignore:
       # These major versions require Node 22, while the project still supports Node 20.
-      - dependency-name: '@babel/core'
+      - dependency-name: '@babel/*'
         update-types:
           - version-update:semver-major
       - dependency-name: '@commitlint/*'

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "@typescript-eslint/eslint-plugin": "^8.70.0",
     "@typescript-eslint/parser": "^8.70.0",
     "@vitest/coverage-v8": "^4.1.11",
-    "commit-and-tag-version": "^12.7.1",
+    "commit-and-tag-version": "^12.7.3",
     "eslint": "^10.10.0",
     "globals": "^17.12.0",
     "husky": "^9.1.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2608,9 +2608,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commit-and-tag-version@npm:^12.7.1":
-  version: 12.7.1
-  resolution: "commit-and-tag-version@npm:12.7.1"
+"commit-and-tag-version@npm:^12.7.3":
+  version: 12.7.3
+  resolution: "commit-and-tag-version@npm:12.7.3"
   dependencies:
     chalk: "npm:^2.4.2"
     conventional-changelog: "npm:4.0.0"
@@ -2629,7 +2629,7 @@ __metadata:
     yargs: "npm:^17.7.2"
   bin:
     commit-and-tag-version: bin/cli.js
-  checksum: 10c0/a14518bb0836cba1deb2806b1e22f42c9b45b9fa45bec2586354b63b65ecd6bacf4d4a66899f9c0d7a56004ad5bca135b58bdb45f5a58550fe9cedf84edbf9d3
+  checksum: 10c0/4599a269c6044db94846cfe44e3f59831c3ecae8e34b17055ac6630b7def072dcd84d5b7ff15cd0a0cd4a88ea75109d88583e3fb23a2f7c76f5372e9c382d241
   languageName: node
   linkType: hard
 
@@ -5592,7 +5592,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": "npm:^8.70.0"
     "@typescript-eslint/parser": "npm:^8.70.0"
     "@vitest/coverage-v8": "npm:^4.1.11"
-    commit-and-tag-version: "npm:^12.7.1"
+    commit-and-tag-version: "npm:^12.7.3"
     eslint: "npm:^10.10.0"
     globals: "npm:^17.12.0"
     husky: "npm:^9.1.7"


### PR DESCRIPTION
## 改动说明

- 将 `commit-and-tag-version` 从 12.7.1 升级至仍兼容 Node 20 的 12.7.3
- 将 Babel major 忽略规则从 `@babel/core` 扩展到 `@babel/*`

## 原因

`@babel/plugin-transform-regenerator` 8.0.2 要求 Node 22.18 且 peer 依赖 `@babel/core ^8`，不能在仍支持 Node 20 的项目中单独升级。`commit-and-tag-version` 13.x 同样要求 Node 22，已继续暂缓；12.7.3 是当前主版本内可安全采用的补丁。

## 验证

- `yarn release --dry-run` 正确模拟 1.20.2 → 1.20.3、版本文件、commit 与 tag，未写入真实改动
- `yarn lint`
- `yarn typecheck`
- `yarn test`（51 个测试文件、759 个用例）
- `yarn build`
- `yarn install --immutable`
- Dependabot YAML 结构验证

仅发版工具与维护策略变更，不影响 SDK 运行时，无需发布新版本。