### PR TITLE
chore(release): 发布 1.20.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,6 @@
 
 一个基于 `@sentry/core` 核心构建的**小程序监控 SDK**，提供**异常监控**、**性能监控**、离线缓存、分布式追踪等能力。支持微信、支付宝、字节跳动、百度、QQ、钉钉、快手等多端小程序，以及微信 / 抖音等**小游戏**，并兼容 Taro / uni-app 等跨端框架。
 
-小程序运行时没有浏览器 `window` / `fetch` / `XMLHttpRequest`，本 SDK 会使用各平台的小程序 API 完成事件上报与自动捕获。如果你的目标是 H5 页面，请使用官方 [`@sentry/browser`](https://github.com/getsentry/sentry-javascript/tree/develop/packages/browser)；如果目标是小程序或小游戏，用本 SDK。
-
 > **📖 接入细节与生产配置**：[sentry-miniapp.pages.dev](https://sentry-miniapp.pages.dev/) —— 快速接入、框架指南、配置项、Source Map、FAQ、示例工程都在文档站。
 
 > **📰 最新文章**：[《我给 Sentry 提了个 PR，后来 sentry-miniapp 进了官方文档》](https://juejin.cn/post/7636106283963760681) — sentry-miniapp 已被收录进 Sentry 官方文档的 community-supported SDK 列表。觉得有用请帮忙点个 ⭐ Star，让更多小程序团队找到它。
@@ -139,23 +137,9 @@ Sentry.setConsent(true);
 | 确认各平台、小程序 / 小游戏能力差异 | [支持范围](https://sentry-miniapp.pages.dev/guide/platforms) |
 | 关心主包体积 | [主包体积优化](https://sentry-miniapp.pages.dev/guide/bundle-size) |
 | 看可运行示例 | [示例工程](https://sentry-miniapp.pages.dev/guide/examples) |
-| 从 1.18 升级到 1.19 | [1.19 升级说明](https://sentry-miniapp.pages.dev/guide/migration-1.19) |
+| 排查没有事件、自动捕获、追踪或隐私同意问题 | [常见问题](https://sentry-miniapp.pages.dev/guide/faq) |
 | 查看版本历史与每次发布内容 | [GitHub Releases](https://github.com/lizhiyao/sentry-miniapp/releases) |
 | 参与开发或贡献 | [开发指南](https://github.com/lizhiyao/sentry-miniapp/blob/master/DEVELOPMENT.md) / [贡献指南](https://github.com/lizhiyao/sentry-miniapp/blob/master/CONTRIBUTING.md) |
-
----
-
-## ❓ 常见问题
-
-- **初始化后 Sentry 里没有事件？** 先用 `captureException` 主动发一个测试事件，再检查 DSN、`request` 合法域名、`Sentry.init` 是否在 `App()` 前执行、`sampleRate` 是否过低，以及是否只调用了 `addBreadcrumb`。面包屑不会单独上报，只会随下一次事件发送。
-- **必须在 `onError` 里手动上报吗？** 不用。`Sentry.init` 会注册平台全局错误监听；前提是它在 `App()` 前执行。若初始化太晚，启动阶段生命周期、Session 和部分面包屑会降级。
-- **网络请求会随错误上报吗？** 会。默认记录 `url`、`method`、状态码、耗时等摘要，并作为面包屑随事件上报；默认不记录请求 / 响应体，需要时再开启 `traceNetworkBody` 并做好脱敏。
-- **会默认向所有 API 发追踪头吗？** 不会。小程序没有可靠的 same-origin，`tracePropagationTargets` 默认为空时不注入；请只白名单自己控制的后端域名。
-- **uni-app / Taro 组件错误为什么还要额外接？** 框架可能先接住组件错误，不一定冒泡到平台全局 `onError`。Vue 用 `app.config.errorHandler` / `Vue.config.errorHandler`，Taro React 建议加 Error Boundary。
-- **隐私协议同意前会发请求吗？** 默认会按 SDK 配置正常上报；如果业务要求同意前禁止出网，请开启 `requireConsent`，并在用户同意后调用 `Sentry.setConsent(true)`。
-- **支持 Session Replay 或 H5 端吗？** 小程序没有 DOM，暂不支持官方 Session Replay；H5 端请用官方 [`@sentry/browser`](https://github.com/getsentry/sentry-javascript/tree/develop/packages/browser)，小程序端继续用 `sentry-miniapp`。
-
-> 每条的完整解答见 **[文档站 · 常见问题](https://sentry-miniapp.pages.dev/guide/faq)**。
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sentry-miniapp",
-  "version": "1.20.2",
+  "version": "1.20.3",
   "description": "Sentry SDK for Mini Programs (WeChat, Alipay, ByteDance, Baidu, QQ, DingTalk, Kuaishou) & Taro / uni-app | 小程序监控 SDK，支持异常监控、性能监控、错误收集",
   "repository": {
     "type": "git",

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
 // 版本号应该与 package.json 中的版本保持同步
-export const SDK_VERSION = '1.20.2';
+export const SDK_VERSION = '1.20.3';
 export const SDK_NAME = 'sentry.javascript.miniapp';


### PR DESCRIPTION
## 变更说明

- 将 npm 包版本与 SDK 运行时版本同步至 `1.20.3`
- 发布 `@sentry/core` 10.73.0 及近期兼容性、构建与依赖维护成果
- 精简 README 开头重复的平台选型说明，H5 与小程序的选择保留在 FAQ

## 验证

- `yarn run lint`
- `yarn run typecheck`
- `yarn run test`（51 个测试文件，759 条用例）
- `yarn run build`
- `yarn run docs:build`